### PR TITLE
Bugfix/zcs 839

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalBaseView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalBaseView.js
@@ -590,6 +590,7 @@ function(ev) {
 	if (this._getItemData(div, "type") == ZmCalBaseView.TYPE_APPT) {
 		if (ev.button == DwtMouseEvent.LEFT || ev.button == DwtMouseEvent.RIGHT) {
 			this._itemClicked(div, ev);
+            this._controller.setCurrentListView(this);
 		}
 	}
 	return this._mouseDownAction(ev, div);


### PR DESCRIPTION
All context menu options stopped working after deleting trashed appointment and trying to take action from user calendar's appointment

Fix Desc:-
Updating and correcting the view to the current calendar view, which was previously coming  as apptlistview.
Doing this references the correct appointment, which was clicked.