### PR TITLE
ZCS-999: Send returnCertInfo Flag to Server in GetContactRequest API

### DIFF
--- a/WebRoot/js/zimbraMail/abook/model/ZmContact.js
+++ b/WebRoot/js/zimbraMail/abook/model/ZmContact.js
@@ -728,6 +728,7 @@ function(callback, errorCallback, batchCmd, deref) {
 	if (deref) {
 		jsonObj.GetContactsRequest.derefGroupMember = "1";
 	}
+	jsonObj.GetContactsRequest.returnCertInfo = "1"; //Fix for: ZCS-999 and ZCS-991
 	var request = jsonObj.GetContactsRequest;
 	request.cn = [{id:this.id}];
 
@@ -738,6 +739,7 @@ function(callback, errorCallback, batchCmd, deref) {
 		if (deref) {
 			jsonObj.GetContactsRequest.derefGroupMember = "1";
 		}
+		jsonObj.GetContactsRequest.returnCertInfo = "1"; //Fix for: ZCS-999 and ZCS-991
 		jsonObj.GetContactsRequest.cn = {id:this.id};
 		batchCmd.addRequestParams(jsonObj, respCallback, errorCallback);
 	} else {

--- a/WebRoot/js/zimbraMail/abook/view/ZmContactPicker.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmContactPicker.js
@@ -715,7 +715,7 @@ ZmContactPicker.prototype.loadSharedGroupContacts =
     request = batchRequest.GetContactsRequest;
 
     for (j = 0,k =0; j < len1; j++) {
-        request.push({ cn: {id: sharedContactGroupArray[j]}, _jsns: 'urn:zimbraMail', derefGroupMember: '1', requestId: k++ });
+        request.push({ cn: {id: sharedContactGroupArray[j]}, _jsns: 'urn:zimbraMail', derefGroupMember: '1', returnCertInfo: '1', requestId: k++ }); //See ZCS-999 and ZCS-991 for returnCertInfo param
     }
         var respCallback = new AjxCallback(this, this.handleSharedContactResponse,[aList]);
        response =  appCtxt.getAppController().sendRequest({

--- a/WebRoot/js/zimbraMail/offline/ZmOffline.js
+++ b/WebRoot/js/zimbraMail/offline/ZmOffline.js
@@ -650,7 +650,7 @@ function(params) {
 			batchRequest.GetMsgRequest = getMsgRequest;
 		}
 		if (contactIdsLength > 0 && getMsgRequest.length < ZmOffline.MAX_REQUEST_IN_BATCH_REQUEST) {
-			batchRequest.GetContactsRequest = {_jsns:"urn:zimbraMail", derefGroupMember:1, cn:{id:contactIds.join()}};
+			batchRequest.GetContactsRequest = {_jsns:"urn:zimbraMail", derefGroupMember:1, returnCertInfo: 1, cn:{id:contactIds.join()}}; //See ZCS-999 and ZCS-991 for returnCertInfo param
 			contactIds.splice(0, contactIdsLength);
 		}
 		appCtxt.getRequestMgr().sendRequest(newParams);


### PR DESCRIPTION
Changes:
* Updated all GetContactsRequest API to include flag `returnCertInfo = 1`
* Following files are updated:
  * ZmContacts.js
  * ZmContactPicker.js
  * ZmOffline.js

https://jira.corp.synacor.com/browse/ZCS-999
https://jira.corp.synacor.com/browse/ZCS-991