### PR TITLE
ZCS-913- Universal UI: Standard modal style changes

### DIFF
--- a/WebRoot/css/dwt.css
+++ b/WebRoot/css/dwt.css
@@ -647,11 +647,12 @@ UL.DwtListView-Rows {
 /* Container (TD) for the body of the dialog, including buttons.
 	Class "Dwt[Dark|Light]InnerBorder" is also applied to this elements */
 .DwtDialogBody 	{
-  cursor:default;
-
+  	@DialogBody@
 }
 
-
+.DwtDialogBody * {
+	@DialogBodyText@
+}
 
 /* ??? SHOTGUNS */
 .DwtDialog .Label {
@@ -667,14 +668,12 @@ UL.DwtListView-Rows {
 	/* @Label-wrap@ */
 }
 
-.DwtDialogButtonBar {}
-
-.DwtDialogButtonBar>TABLE>TBODY>TR>TD {
-	padding:5px; 
+.DwtDialogButtonBar {
+	@WindowButtonBar@
 }
-.DwtDialogButtonBar .ZButton {
-	margin-left:3px;
-	@DialogButtonHeight@
+
+.DwtDialogButtonBar .ZButton > .ZButtonTable {
+	@DialogButton@
 }
 
 
@@ -776,22 +775,18 @@ UL.DwtListView-Rows {
 
 /* Outer container for the message dialog */
 .DwtMsgDialog {
-	width:400px;
-	max-height:400px;
-	overflow:auto;
+	@DialogMessageBody@
 }
 
 /* For the error dialog when displaying a request */
 .DwtMsgDialog-wide {
-	width:600px;
-	max-height:400px;
-	overflow:auto;
+	@DialogMessageBodyWide@
 }
 
 /* Text area for the message dialog, including icon */
 .DwtMsgArea {
 	width:100%;
-	@BoxPadding@
+	@DialogBodyText@;
 }
 
 /* Outer container for the confirmation dialog */

--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -6285,3 +6285,33 @@ a.ZmLinkDisabled {
 	@ListItemBottomRowRightIconSize@
 	display: block;
 }
+
+/* Dialog button style */ 
+.ZDialogButton {
+    margin-right: 8px; 
+}
+
+.ZDialogButton.ZPrimaryButton {
+    margin: 0;
+}
+
+.ZDialogButton .ZButtonTable .ZWidgetTitle {
+    color: @AltC@;
+    letter-spacing: 1px;
+}
+
+/* Primary button style */ 
+.ZPrimaryButton .ZButtonTable {
+    background: @AltC@;
+}
+
+.ZPrimaryButton.ZHover    .ZButtonTable,
+.ZPrimaryButton.ZFocused  .ZButtonTable,
+.ZPrimaryButton.ZActive   .ZButtonTable,
+.ZPrimaryButton.ZSelected .ZButtonTable {
+    background: @darken(AltC,30)@;
+}
+
+.ZPrimaryButton .ZButtonTable .ZWidgetTitle {
+    color: @AppC@;
+}

--- a/WebRoot/js/zimbraMail/abook/view/ZmContactPicker.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmContactPicker.js
@@ -457,7 +457,6 @@ function() {
 			- this._getSectionHeight("_handle")  //the header
 			- this._getSectionHeight("_searchTable")
 			- this._getSectionHeight("_paging")
-			- this._getSectionHeight("_buttonsSep")
 			- this._getSectionHeight("_buttons")
 			- 30; //still need some magic to account for some margins etc.
 

--- a/WebRoot/js/zimbraMail/calendar/view/ZmReminderDialog.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmReminderDialog.js
@@ -176,10 +176,7 @@ function(list) {
 	this._createButtons(this.ALL_APPTS, this.ALL_APPTS, dismissListener, openListener, snoozeListener, snoozeSelectButtonListener, snoozeSelectMenuListener);
 
 	this._updateIndividualSnoozeActionsVisibility();
-
-	//hide the separator from the dialog buttons since we do not use dialog buttons for this dialog.
-	document.getElementById(this._htmlElId + "_buttonsSep").style.display = "none";
-
+	
 };
 
 ZmReminderDialog.prototype._createButtons =

--- a/WebRoot/js/zimbraMail/mail/controller/ZmComposeController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmComposeController.js
@@ -358,7 +358,7 @@ function() {
 		ps.registerCallback(DwtDialog.CANCEL_BUTTON, this._popShieldDismissCallback, this);
 	} else if (this._canSaveDraft()) {
 		ps.reset();
-		ps.setMessage(ZmMsg.askSaveDraft, DwtMessageDialog.WARNING_STYLE);
+		ps.setTitle(ZmMsg.askSaveDraft);
 		ps.registerCallback(DwtDialog.YES_BUTTON, this._popShieldYesCallback, this);
 		ps.registerCallback(DwtDialog.NO_BUTTON, this._popShieldNoCallback, this);
 		ps.registerCallback(DwtDialog.CANCEL_BUTTON, this._popShieldDismissCallback, this);
@@ -462,7 +462,7 @@ function(params) {
 
 	var ps = this._popShield = appCtxt.getYesNoCancelMsgDialog();
 	ps.reset();
-	ps.setMessage(ZmMsg.askSaveDraft, DwtMessageDialog.WARNING_STYLE);
+	ps.setTitle(ZmMsg.askSaveDraft);
 	ps.registerCallback(DwtDialog.YES_BUTTON, this._popShieldYesCallback, this, params);
 	ps.registerCallback(DwtDialog.NO_BUTTON, this._popShieldNoCallback, this, params);
 	ps.registerCallback(DwtDialog.CANCEL_BUTTON, this._popShieldDismissCallback, this);

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -294,6 +294,7 @@ FontSize-normal             = font-size:1rem;
 FontSize-slightly-big       = font-size:1.1rem;
 FontSize-big                = font-size:1.18rem;
 FontSize-bigger             = font-size:1.36rem; font-weight:bold;
+FontSize-slightly-bigger    = font-size:1.7rem;
 FontSize-biggest            = font-size: 2rem;
 FontSize-small              = font-size:0.9rem;
 FontSize-smaller            = font-size:0.82rem;
@@ -409,7 +410,7 @@ MatchedBg                   = background-color:@MatchedColor@;
 RightClickBg                = background-color:@RightClickColor@;
 SelectedRow                 = background-color:@SelC@ !important;
 
-WindowTitleText             = font-size:12px; font-weight:bold; padding:5px 10px 7px;
+WindowTitleText             = @FontSize-slightly-bigger@
 WindowTitleText-normal      = @Text@
 WindowTitleText-light       = @Text@
 
@@ -534,10 +535,10 @@ ButtonShadowActive              = @cssShadow@:0px 0px 4px rgba(50, 50, 50, 0.65)
 ButtonBorderColor               = transparent
 ButtonBorderDarkColor           = transparent
 
-ButtonBorder                    = @ButtonRounding@ border:1px solid @ButtonBorderColor@; height:100%;
+ButtonBorder                    = @ButtonRounding@ border:1px solid @ButtonBorderColor@; height:100%; @transition@:background-color 200ms ease-in-out;
 ButtonBorder-normal             = 
 ButtonBorder-disabled           = 
-ButtonBorder-hover              = @AppBg@
+ButtonBorder-hover              = background: rgba(0,0,0,0.1);
 ButtonBorder-active             = @ButtonBorder-hover@
 ButtonBorder-focused            = @ButtonBorder-hover@
 ButtonBorder-selected           = @ButtonBorder-hover@
@@ -551,8 +552,6 @@ ButtonText-active               = @Text-active@
 ButtonText-focused              = @Text-focused@
 ButtonText-selected             = @Text-selected@
 ButtonText-default              = @Text-default@
-
-DialogButtonHeight              = height:24px; height:2.2rem;
 
 ButtonLeftIcon                  = margin: 0;
 ButtonRightIcon                 = margin: 0;
@@ -963,7 +962,7 @@ ToastButton                 = border-left:1px solid #555;
 ################
 #    VEIL
 ################
-VeilColor                   = background-color:white;
+VeilColor                   = background-color: @black@;
 
 
 ################
@@ -1243,10 +1242,18 @@ FieldBorder                 = @InputBorder@  @BorderBase@
 AppTabBottomBorder          = border-bottom-width:0px;
 TabBottomBorder             = border-bottom-width:1px; border-bottom-style:solid; @bColor@:black;
 
-WindowOuterBorder           = background-color:@darken(AppC,17)@;   @PopupShadow@           @roundCorners(4px)@         @MediumOutsetBorder@
-LightWindowOuterBorder      = background-color:@darken(AppC,5)@;    @PopupShadow@           @roundCorners(4px)@         @MediumOutsetBorder@
-WindowInnerBorder           = background-color:@lighten(AppC,25)@;  padding:8px 8px 4px;    @roundCorners(0px 0px 4px 4px)@     border-top:1px solid @darken(AppC,40)@;
-LightWindowInnerBorder      = background-color:@lighten(AppC,50)@;  padding:8px 8px 4px;    @roundCorners(0px 0px 4px 4px)@     border-top:1px solid @darken(AppC,40)@;
+WindowOuterBorder           = @PanelBg@   @PopupShadow@   @roundCorners(3px)@; padding: @SkinWrapperPadding@;
+LightWindowOuterBorder      = @WindowOuterBorder@
+WindowInnerBorder           = padding-top: @SkinWrapperPadding@;
+LightWindowInnerBorder      = @WindowInnerBorder@
+WindowButtonBar             = padding-top: @SkinWrapperPadding@;
+
+DialogBodyText              = @FontSize-slightly-big@
+DialogBody                  = @DialogBodyText@; cursor:default;
+DialogMessageBody           = @DialogBodyText@; width:450px; max-height:400px; overflow:auto;
+DialogMessageBodyWide       = @DialogBodyText@; width:650px; max-height:400px; overflow:auto;
+
+DialogButton                = @FontSize-big@; color: @AltC@; height: auto; padding: 8px 16px; @roundCorners(3px)@; text-transform: uppercase; border:none;
 
 PopupWindowBorder           = @MediumRoundCorners@  @PanelBg@  @PopupShadow@
 
@@ -1494,7 +1501,7 @@ trRadius                    = -webkit-border-top-right-radius
 blRadius                    = -webkit-border-bottom-left-radius
 brRadius                    = -webkit-border-bottom-right-radius
 
-PopupShadow                 = @cssShadow@: 0 4px 6px 0 rgba(0, 0, 0, 0.5);
+PopupShadow                 = @cssShadow@: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
 transition                  = -webkit-transition
 #ENDIF
 

--- a/WebRoot/templates/dwt/Widgets.template
+++ b/WebRoot/templates/dwt/Widgets.template
@@ -41,13 +41,10 @@
 	<div class='DwtDialog WindowOuterContainer'>
 		<table role="presentation">
 			<tr id='${dragId}'>
-				<td class='minWidth'>${icon}</td>
 				<td id='${id}_title' class='DwtDialogTitle'>${title}</td>
-				<td class='minWidth'><div class='${closeIcon2}'></div></td>
-				<td class='minWidth'><div class='${closeIcon1}'></div></td>
 			</tr>
 			<tr>
-				<td class='WindowInnerContainer' colspan='4'>
+				<td class='WindowInnerContainer'>
 					<div id='${id}_content' class='DwtDialogBody'></div>
 					<$ if (data.controlsTemplateId) { $>
 						<$= AjxTemplate.expand(data.controlsTemplateId, data) $>
@@ -59,7 +56,6 @@
 </template>
 
 <template id='dwt.Widgets#DwtDialogControls'>
-	<div class='horizSep' id="${id}_buttonsSep"></div>
 	<div id='${id}_buttons' class='DwtDialogButtonBar'>
 		<$ if (AjxEnv.isNav) { $>
 			<input type='button' id='${id}_focus' style='height:0px;width:0px;display:none;'>
@@ -71,15 +67,11 @@
 	<div class='DwtDialog LightWindowOuterContainer'>
 		<table role="presentation" style='cursor:move;'>
 			<tr id='${dragId}'>
-				<td class='minWidth'>${icon}</td>
 				<td id='${id}_title' class='DwtDialogTitle'>${title}</td>
-				<td class='minWidth'><div class='${closeIcon2}'></div></td>
-				<td class='minWidth'><div class='${closeIcon1}'></div></td>
 			</tr>
 			<tr>
-				<td class='LightWindowInnerContainer full_size' colspan='4'>
+				<td class='LightWindowInnerContainer full_size'>
 					<div id='${id}_content' class='DwtDialogBody'></div>
-					<div class='horizSep'></div>
 					<div id='${id}_buttons' class='DwtDialogButtonBar'>
 						<$ if (AjxEnv.isNav) { $>
 						<input type='button' id='${id}_focus' style='height:0px;width:0px;display:none;'>

--- a/WebRoot/templates/zimbra/Widgets.template
+++ b/WebRoot/templates/zimbra/Widgets.template
@@ -13,11 +13,6 @@
 		</tr>
 		<$ if (data.showDetails) { $>
 		<tr>
-			<td>
-				<hr/>
-			</td>
-		</tr>
-		<tr>
 			<td style='height:100%;vertical-align:top;'>
 				${detail}
 			</td>


### PR DESCRIPTION
Changes:
* ZmReminderDialog.js:
  * Removed reference to separator elements as per changes in template files.
* ZmContactPicker.js:
  * Removed reference to separator elements as per changes in template files.
* ZmComposeController.js:
  * Updated dialog for `Save as Draft` as per mockup
* Updated templates file `dwt/Widgets.template` and `zimbra/Widgets.template` as per requirement
* Updated required css for `dwt.css`, `zm.css` and `skin.css`
* Updated required properties in `skin.properties`

https://jira.corp.synacor.com/browse/ZCS-913