### PR TITLE
Address bubble regression fix for mail search sidebar

### DIFF
--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1726,7 +1726,7 @@ SearchToolbarFilterText         = @FontSize-slightly-big@;
 SearchToolbarButton             = padding:0 @SkinWrapperPadding@;
 SearchToolbarButtonText         = @FontSize-slightly-big@; text-align: left; padding: 0;
 SearchOpWrapper                 = @FontSize-slightly-big@; padding: 4px @SkinWrapperPadding@; text-align: justify; 
-SearchOp                        = @ActiveCursor@ background: @AddressBubbleBgActive@; display:inline-block; @FontSize-slightly-big@ @roundCorners(3px)@ text-transform: uppercase; margin:6px 4px 0 0; padding: 6px 10px;
+SearchOp                        = @ActiveCursor@ background: @AddressBubbleActive@; display:inline-block; @FontSize-slightly-big@ @roundCorners(3px)@ text-transform: uppercase; margin:6px 4px 0 0; padding: 6px 10px;
 
 ######################################################################
 # Dwt Checkbox Widget style


### PR DESCRIPTION
Updated skin.property variable name from `AddressBubbleBgActive ` to `AddressBubbleActive `, as `AddressBubbleBgActive ` variable is no longer exists.