### PR TITLE
Fix issue of address bubble and tag bubble in mail view reading pane.

### DIFF
--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1082,7 +1082,7 @@ AddreddBubbleLeftChild = @roundCorners(AddressBubbleBorderRadius 0px 0px Address
 AddreddBubbleRightChild = @roundCorners(0px AddressBubbleBorderRadius AddressBubbleBorderRadius 0px)@;
 AddressBubbleOp = background: @PrimaryBrandingColor@; fill: @AppC@;
 AddressBubbleOpActive = background: @darken(PrimaryBrandingColor,25)@;
-TagBubble = @FontSize-normal@ @ActiveCursor@ padding:6px;
+TagBubble = @FontSize-normal@ @ActiveCursor@ padding:6px; height:auto; line-height:1;
 AddressBubbleHolder = max-height:98px; overflow:auto;
 
 ###################
@@ -1160,7 +1160,7 @@ Conv2MsgHeaderImageRadius           = @MediumRoundCorners@
 Conv2MsgHeaderCollapsedImageRadius  = @MediumRoundCorners@
 ConvExpandIcon              = display:none;
 ConvExpanded                = margin-bottom: @MailViewInnerSpacing@;
-MailAddressBubble           = display: block; border: none; background: transparent; padding: 0 0 5px 0; margin: 0; @Text@
+MailAddressBubble           = display: block; border: none; background: transparent; padding: 0 0 5px 0; margin: 0; @Text@; height: auto; line-height: 1;
 MailAddressBubbleChild      = padding: 0px;
 MailViewInfoBar             = background: @AppC@; padding: 20px 0;
 


### PR DESCRIPTION
Fix issue of address bubble and tag bubble in mail view reading pane.

Before:
<img width="789" alt="screen shot 2017-04-21 at 11 04 10 am" src="https://cloud.githubusercontent.com/assets/5223493/25264572/8e5f370a-2685-11e7-98d6-a8a2ca0b27c4.png">

After fix:
<img width="796" alt="screen shot 2017-04-21 at 11 25 59 am" src="https://cloud.githubusercontent.com/assets/5223493/25264578/95f1b808-2685-11e7-9fda-1ddd323110d8.png">

