### PR TITLE
ZCS-901: Universal UI: Modernize the style of the actions menu tag dropdown

### DIFF
--- a/WebRoot/js/zimbraMail/share/view/ZmTagMenu.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmTagMenu.js
@@ -183,8 +183,27 @@ function(tagList, addRemove) {
 		var tagName = addRemove.add[i];
 		this._addNewTag(this, tagName, tagList, true, null, this._addHash);
 	}
+	
+	var removeList = addRemove.remove;
+	if (removeList.length > 0) {
+		for (i = 0; i < removeList.length; i++) {
+			var tagName = removeList[i];
+			var tagHtmlId = 'Remove_tag_' + i;
+			this._addNewTag(this, tagName, tagList, false, null, this._removeHash, tagHtmlId);
+		}
+		//remove all tags
+		new DwtMenuItem({parent:this, style:DwtMenuItem.SEPARATOR_STYLE});
+		var mi = new DwtMenuItem({parent:this, id:"REMOVE_ALL_TAGS", className: "ZAddNewMenuItem"});
+		mi.setText(ZmMsg.allTags);
+		mi.setImage("Close");
+		mi.setShortcut(appCtxt.getShortcutHint(this._keyMap, ZmKeyMap.UNTAG));
+		mi.setData(ZmTagMenu.KEY_TAG_EVENT, ZmEvent.E_REMOVE_ALL);
+		mi.setData(Dwt.KEY_OBJECT, removeList);
+		mi.addSelectionListener(new AjxListener(this, this._menuItemSelectionListener), 0);
+	}
 
-	if (addRemove.add.length) {
+	//add separator at end of tags if no selected tags.
+	if(removeList.length == 0 ) {
 		new DwtMenuItem({parent:this, style:DwtMenuItem.SEPARATOR_STYLE});
 	}
 
@@ -193,61 +212,20 @@ function(tagList, addRemove) {
 	var addid = map ? (map + "_newtag"):this._htmlElId + "|NEWTAG";
 	var removeid = map ? (map + "_removetag"):this._htmlElId + "|REMOVETAG";
 
-	var miNew = this._menuItems[ZmTagMenu.MENU_ITEM_ADD_ID] = new DwtMenuItem({parent:this, id: addid});
+	var miNew = this._menuItems[ZmTagMenu.MENU_ITEM_ADD_ID] = new DwtMenuItem({parent:this, id: addid, className: "ZAddNewMenuItem"});
 	miNew.setText(AjxStringUtil.htmlEncode(ZmMsg.newTag));
 	miNew.setImage("Plus");
 	miNew.setShortcut(appCtxt.getShortcutHint(this._keyMap, ZmKeyMap.NEW_TAG));
 	miNew.setData(ZmTagMenu.KEY_TAG_EVENT, ZmEvent.E_CREATE);
 	miNew.addSelectionListener(new AjxListener(this, this._menuItemSelectionListener), 0);
 	miNew.setEnabled(!appCtxt.isWebClientOffline());
-
-	// add static "Remove Tag" menu item
-	var miRemove = this._menuItems[ZmTagMenu.MENU_ITEM_REM_ID] = new DwtMenuItem({parent:this, id: removeid});
-	miRemove.setEnabled(false);
-	miRemove.setText(AjxStringUtil.htmlEncode(ZmMsg.removeTag));
-	miRemove.setImage("Close");
-
-	var removeList = addRemove.remove;
-	if (removeList.length > 0) {
-		miRemove.setEnabled(true);
-		var removeMenu = null;
-		if (removeList.length > 1) {
-			for (i = 0; i < removeList.length; i++) {
-				if (!removeMenu) {
-					removeMenu = new DwtMenu({parent:miRemove, className:this._className});
-					miRemove.setMenu(removeMenu);
-                    removeMenu.setHtmlElementId('REMOVE_TAG_MENU_' + this.getHTMLElId());
-				}
-				var tagName = removeList[i];
-                var tagHtmlId = 'Remove_tag_' + i;
-				this._addNewTag(removeMenu, tagName, tagList, false, null, this._removeHash, tagHtmlId);
-			}
-			// if multiple removable tags, offer "Remove All"
-			new DwtMenuItem({parent:removeMenu, style:DwtMenuItem.SEPARATOR_STYLE});
-			var mi = new DwtMenuItem({parent:removeMenu, id:"REMOVE_ALL_TAGS"});
-			mi.setText(ZmMsg.allTags);
-			mi.setImage("TagStack");
-			mi.setShortcut(appCtxt.getShortcutHint(this._keyMap, ZmKeyMap.UNTAG));
-			mi.setData(ZmTagMenu.KEY_TAG_EVENT, ZmEvent.E_REMOVE_ALL);
-			mi.setData(Dwt.KEY_OBJECT, removeList);
-			mi.addSelectionListener(new AjxListener(this, this._menuItemSelectionListener), 0);
-		}
-		else {
-			var tag = tagList.getByNameOrRemote(removeList[0]);
-			miRemove.setData(ZmTagMenu.KEY_TAG_EVENT, ZmEvent.E_TAGS);
-			miRemove.setData(ZmTagMenu.KEY_TAG_ADDED, false);
-			miRemove.setData(Dwt.KEY_OBJECT, tag);
-			miRemove.addSelectionListener(new AjxListener(this, this._menuItemSelectionListener), 0);
-		}		
-
-	}
 };
 
 ZmTagMenu.tagNameLength = 20;
 ZmTagMenu.prototype._addNewTag =
 function(menu, newTagName, tagList, add, index, tagHash, tagHtmlId) {
 	var newTag = tagList.getByNameOrRemote(newTagName);
-	var mi = new DwtMenuItem({parent:menu, index:index, id:tagHtmlId});
+	var mi = new DwtMenuItem({parent:menu, index:index, id:tagHtmlId, style:DwtMenuItem.CHECK_STYLE});
     var tagName = AjxStringUtil.clipByLength(newTag.getName(false),ZmTagMenu.tagNameLength);
 	var nameText = newTag.notLocal ? AjxMessageFormat.format(ZmMsg.tagNotLocal, tagName) : tagName;
     mi.setText(nameText);
@@ -256,6 +234,10 @@ function(menu, newTagName, tagList, add, index, tagHash, tagHtmlId) {
 	mi.setData(ZmTagMenu.KEY_TAG_ADDED, add);
 	mi.setData(Dwt.KEY_OBJECT, newTag);
 	mi.addSelectionListener(new AjxListener(this, this._menuItemSelectionListener), 0);
+
+	// add checkmark if tag is added already.
+	!add && mi.setChecked(true, true);
+	
 //	mi.setShortcut(appCtxt.getShortcutHint(null, ZmKeyMap.TAG));
 	tagHash[newTag.id] = mi;
 };

--- a/WebRoot/messages/ZmMsg.properties
+++ b/WebRoot/messages/ZmMsg.properties
@@ -203,7 +203,7 @@ allowMultipleLocations = Allow multiple locations
 allPageSelected = {0} {1} selected. To <a href="javascript:;" onclick="{3}">select all search results</a>, \
   use the shortcut {2}.
 allSearchSelected = All items selected, including those not yet loaded.
-allTags = All Tags
+allTags = Remove all Tags
 almostSupportedBrowserTip =\
 	Please note that because you are running an unsupported browser, your user experience may be affected, \
 	and all functionality may not be available.<p>\
@@ -2824,7 +2824,6 @@ removeDupesToSelf = When I receive a message originally sent by me:
 removeDupesToSelfLabel = Messages from me:
 removePhoto = Remove Photo
 removeRow = Remove row
-removeTag = Remove Tag
 rename = Rename
 renameFolder = Rename Folder
 renameSearch = Rename Search


### PR DESCRIPTION
ZCS-901: Universal UI: Modernize the style of the actions menu tag dropdown

Changeset:

1. ZmMsg.properties:
	* Removing obsolete property removeTag.
	* Updating allTags property value.
2. ZmTagMenu.js:
	* Simplifying the tags menu: All tags in single list and showing added tags with a checkmark.
	* Removing code for remove tag menu.
	* Removing menu item remove tag ( when only 1 tag added).