### PR TITLE
Fixed bug for new emails arriving and being placed in the wrong order…

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
@@ -1707,7 +1707,13 @@ function(item, index, skipNotify, itemIndex) {
                 this._addRow(headerDiv, index);
             }
 			index = parseInt(index) || 0;  //check for NaN index
-            this._addRow(div, index+1); //account for header
+			// Set a row offset to 1 for sorting dateDsc to skip first header
+			var offset = 1;
+			// If sorting is dateAsc then offset by all headers when adding a row
+			if (this._sortByString == "dateAsc") {
+				offset = this._group._sectionHeaders.length;
+			}
+			this._addRow(div, index+offset); //account for header
 
 		}
 	}

--- a/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
@@ -1710,10 +1710,10 @@ function(item, index, skipNotify, itemIndex) {
 			// Set a row offset to 1 for sorting dateDsc to skip first header
 			var offset = 1;
 			// If sorting is dateAsc then offset by all headers when adding a row
-			if (this._sortByString == "dateAsc") {
-				offset = this._group._sectionHeaders.length;
+			if (this._sortByString === ZmSearch.DATE_ASC) {
+				offset = this._group.getAllSectionHeaders().length;
 			}
-			this._addRow(div, index+offset); //account for header
+			this._addRow(div, index + offset); //account for header
 
 		}
 	}


### PR DESCRIPTION
This corrects a bug when new emails arrive and the sorting is Group By Asc.  The addRow index does not account for all the headers and emails come in out of order until refreshed.  This checks for this sort method and adds the proper offset.

Fixes bug: https://bugzilla.zimbra.com/show_bug.cgi?id=107507