### PR TITLE
ZCS-1032 Universal UI: Mini Calendar prev/next month buttons changing Years not the months.

### DIFF
--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -915,7 +915,7 @@ MiniCalDOWText              = color: @hexToRGBA(TxtC, 40)@;; text-align:center;
 MiniCalButtonSize           = height: 2rem; width: 2rem;
 MiniCalButton               = @ActiveCursor@ @MiniCalButtonSize@
 MiniCalButton-normal        = color: @hexToRGBA(TxtC, 80)@;
-MiniCalButton-hover         = border: 1px solid @AltC@ !important;
+MiniCalButton-hover         = 
 MiniCalButton-active        = @MiniCalButton-hover@
 MiniCalButton-today         = background-color: @AltC@; color: @AppC@;
 


### PR DESCRIPTION
ZCS-1032 Universal UI: Mini Calendar prev/next month buttons changing Years not the months.

Issue: Button width for calendar header changing on hover, causing the buttons to move on hover in the UI.
Fix: Extra border was getting applied in hover state , affecting the bounding box .

Change set:
1. Skin.properties: Removing extra border applied on hover for buttons on mini cal to have a same styling on hover and non hover states.