### PR TITLE
ZCS-912 Universal UI: Attach briefcase item modal from compose view

### DIFF
--- a/WebRoot/css/common.css
+++ b/WebRoot/css/common.css
@@ -589,6 +589,7 @@ LI.RowDouble, LI.Row {list-style: none;}
 /* .Row-matched TD			 	{ 	@ListItemText-matched@				} */
 
 .Row-focused TD 				{	@ListItemText-focused@			}
+.Row-selected.Row-focused TD 				{	@ListItemText-selected@			}
 
 .Row-selected-right TD			{	@ListItemText-actioned@			}
 

--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -4176,6 +4176,7 @@ HTML>BODY .appt-selected .appt_allday_body
 
 .ZmAttachDialog-inline {
 	height:20px;
+	margin-top:12px;
 }
 
 .ZmAttachDialog-removeLink {
@@ -5236,9 +5237,27 @@ If you feel compelled to have a background color, please do so on a per skin lev
 }
 
 .ZmAttachDialog-container .ZmBriefcaseItemSmall {
-	border-style:solid; 
-	border-width:1px 0px;
-	border-color:@lighten(AppC,60)@
+	@AttachBriefcaseItem@
+}
+
+.ZmAttachDialog-container .ZmBriefcaseItemSmall.Row-selected {
+	@AttachBriefcaseItemSelected@
+}
+
+.ZmAttachDialog-container .ZmBriefcaseItemSmall td:nth-child(2),
+.ZmAttachDialog-container .ZmBriefcaseItemSmall td:nth-child(3) {
+	@AttachBriefcaseItemChild@
+}
+
+.ZmAttachDialog-container .ZmBriefcaseItemSmall td:first-child {
+	@AttachBriefcaseItemFirstChild@
+}
+
+.ZmAttachDialog-container .ZmBriefcaseItemIcon .svg-icon {
+	@AttachBriefcaseItemIcon@
+}
+.ZmAttachDialog-container .ZmBriefcaseItemSmall td {
+	@TreeItemHeight@;
 }
 
 .ZmBriefcaseItemSelected .ZmThumbnailItem {
@@ -6452,67 +6471,6 @@ a.ZmLinkDisabled {
     color: @AppC@;
 }
 
-/* File type icon styles */
-.svg-icon.ImgUnknownDoc,
-.svg-icon.ImgGenericDoc,
-.svg-icon.ImgMSProjectDoc,
-.svg-icon.ImgMSVisioDoc {
-	@FileTypeUnknown@
-}
-
-.svg-icon.ImgExeDoc {
-	@FileTypeExe@
-}
-
-.svg-icon.ImgImageDoc {
-	@FileTypeImage@
-}
-
-.svg-icon.ImgPDFDoc {
-	@FileTypePdf@
-}
-
-.svg-icon.ImgEPSDoc {
-	@FileTypeEps@
-}
-
-.svg-icon.ImgMSExcelDoc {
-	@FileTypeExl@
-}
-.svg-icon.ImgMSPowerpointDoc {
-	@FileTypePPT@
-}
-
-.svg-icon.ImgMSWordDoc,
-.svg-icon.ImgDoc {
-	@FileTypeDoc@
-}
-
-.svg-icon.ImgZipDoc {
-	@FileTypeZip@
-}
-
-.svg-icon.ImgAudioDoc,
-.svg-icon.ImgVideoDoc {
-	@FileTypeMedia@
-}
-
-.svg-icon.ImgMessageDoc {
-	@FileTypeMail@
-}
-
-.svg-icon.ImgHtmlDoc {
-	@FileTypeHtml@
-}
-
-.svg-icon.ImgContactDoc {
-	@FileTypeVCard@
-}
-
-.svg-icon.ImgEventDoc {
-	@FileTypeCal@
-}
-
 /* Reading pane mail attachment styles */
 .ZmMailAttachmentsTable {
 	@MailAttachmentsTable@
@@ -6529,7 +6487,7 @@ a.ZmLinkDisabled {
 }
 
 .ZmMailAttachmentIcon,
-.ZmMailAttachmentIcon .svg-icon {
+.ZmMailAttachmentIcon svg.svg-icon {
 	@MailAttachmentIcon@
 }
 

--- a/WebRoot/js/zimbraMail/briefcase/view/ZmBriefcaseIconView.js
+++ b/WebRoot/js/zimbraMail/briefcase/view/ZmBriefcaseIconView.js
@@ -89,14 +89,14 @@ function(item, params) {
 	}
 	
 	htmlArr[idx++] = "<table><tr>";
-    if (appCtxt.get(ZmSetting.SHOW_SELECTION_CHECKBOX)) {
-        htmlArr[idx++] = "<td>";
-        idx = this._getImageHtml(htmlArr, idx, "CheckboxUnchecked", this._getFieldId(item, ZmItem.F_SELECTION));
-        htmlArr[idx++] = "</td>";
-    }
-    htmlArr[idx++] = "<td><div class='Img";
-	htmlArr[idx++] = icon;
-	htmlArr[idx++] = "'></div></td><td nowrap>";
+	if (appCtxt.get(ZmSetting.SHOW_SELECTION_CHECKBOX)) {
+		htmlArr[idx++] = "<td>";
+		idx = this._getImageHtml(htmlArr, idx, "CheckboxUnchecked", this._getFieldId(item, ZmItem.F_SELECTION));
+	htmlArr[idx++] = "</td>";
+	}
+	htmlArr[idx++] = "<td>";
+	htmlArr[idx++] = AjxImg.getImageHtml({imageName: icon, classes: ["ZmBriefcaseItemIcon"]});
+	htmlArr[idx++] = "</td><td nowrap>";
 	htmlArr[idx++] = AjxStringUtil.htmlEncode(item.name);
 	htmlArr[idx++] = "</td><tr></table>";
 	
@@ -112,8 +112,8 @@ function(item, params) {
 ZmBriefcaseIconView.prototype.set =
 function(list, sortField, doNotIncludeFolders){
 
-    doNotIncludeFolders = true;
+	doNotIncludeFolders = true;
 
-    ZmBriefcaseBaseView.prototype.set.call(this, list, sortField, doNotIncludeFolders);
+	ZmBriefcaseBaseView.prototype.set.call(this, list, sortField, doNotIncludeFolders);
 
 };

--- a/WebRoot/js/zimbraMail/briefcase/view/dialog/ZmBriefcaseTabView.js
+++ b/WebRoot/js/zimbraMail/briefcase/view/dialog/ZmBriefcaseTabView.js
@@ -60,7 +60,7 @@ ZmBriefcaseTabView.prototype.toString = function(){
  */
 ZmBriefcaseTabView.prototype.showMe =
 function() {
-    this.setSize(500, 295);
+    this.setSize(600, 295);
     this.showFolder(this._folderId || ZmOrganizer.ID_BRIEFCASE);
 };
 

--- a/WebRoot/skins/_base/base4/skin.css
+++ b/WebRoot/skins/_base/base4/skin.css
@@ -786,6 +786,67 @@ svg.ImgColumnDownArrow{
     fill: @IconMiniCalendarTitlebar@;
 }
 
+/* File type icon styles */
+.svg-icon.ImgUnknownDoc,
+.svg-icon.ImgGenericDoc,
+.svg-icon.ImgMSProjectDoc,
+.svg-icon.ImgMSVisioDoc {
+    @FileTypeUnknown@
+}
+
+.svg-icon.ImgExeDoc {
+    @FileTypeExe@
+}
+
+.svg-icon.ImgImageDoc {
+    @FileTypeImage@
+}
+
+.svg-icon.ImgPDFDoc {
+    @FileTypePdf@
+}
+
+.svg-icon.ImgEPSDoc {
+    @FileTypeEps@
+}
+
+.svg-icon.ImgMSExcelDoc {
+    @FileTypeExl@
+}
+.svg-icon.ImgMSPowerpointDoc {
+    @FileTypePPT@
+}
+
+.svg-icon.ImgMSWordDoc,
+.svg-icon.ImgDoc {
+    @FileTypeDoc@
+}
+
+.svg-icon.ImgZipDoc {
+    @FileTypeZip@
+}
+
+.svg-icon.ImgAudioDoc,
+.svg-icon.ImgVideoDoc {
+    @FileTypeMedia@
+}
+
+.svg-icon.ImgMessageDoc {
+    @FileTypeMail@
+}
+
+.svg-icon.ImgHtmlDoc {
+    @FileTypeHtml@
+}
+
+.svg-icon.ImgContactDoc {
+    @FileTypeVCard@
+}
+
+.svg-icon.ImgEventDoc {
+    @FileTypeCal@
+}
+
 /* Chat icons*/
 
 svg.Img_ImSmallAvailable {

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1219,6 +1219,12 @@ ComposeViewHtmlEditor       = padding:@ComposeViewOutsidePadding@; background-co
 ComposeViewPlainTextEditor  = @FontSize-big@ @FontFamily-fixed@ @FullWidth@ @AppBorder@ overflow:auto; padding:8px;
 ComposeViewHeaderEmptyRight = padding-right: 18px;
 
+AttachBriefcaseItem         = border-style:solid; border-width:0 0 1px 0; border-color:transparent;
+AttachBriefcaseItemSelected = border-bottom-color:@PanelBorderColor@;
+AttachBriefcaseItemChild    = padding: 0 0 0 @MailViewInnerSpacing@;
+AttachBriefcaseItemFirstChild = padding:0 0 0 @SkinWrapperPadding@;
+AttachBriefcaseItemIcon     = height:28px; width:28px;
+
 ###################
 #   CONTACTS-APP SPECIFIC STUFF
 ###################
@@ -1779,7 +1785,7 @@ CheckboxTableRightText      = text-align:left; margin-left:@CheckBoxTableCellSpa
 MailAttachmentsTable        = @FullWidth@
 MailAttachmentItem          = @FullWidth@ @AppBg@ margin-bottom:2px; @roundCorners(3px)@ overflow:hidden;
 MailAttachmentItemActive    = background-color: @darken(AppC,13)@;
-MailAttachmentIcon          = @BigIconSize@
+MailAttachmentIcon          = @BigIconSize@; @roundCorners(0px)@;
 MailAttachmentMetaInfo      = padding:0 @MailViewGutterSpace@; line-height:2;
 MailAttachmentFileName      = margin-right: 5px;
 MailAttachmentFileText      = @Text@
@@ -1794,7 +1800,7 @@ MailAttachmentsAllText      = color: @black@
 #   MIME/File type icon style
 #######################################################################
 
-FileIconCommonStyle = fill:@white@; 
+FileIconCommonStyle = fill:@white@; @roundCorners(2px)@
 FileTypeUnknown     = @FileIconCommonStyle@ background-color:#aaaaaa
 FileTypeDoc         = @FileIconCommonStyle@ background-color:#4990e2
 FileTypePPT         = @FileIconCommonStyle@ background-color:#ff7600


### PR DESCRIPTION
Changeset:

1. Moving svg coloring styles from zm.css to skin.css to keep all similar styles at one place.
2. ZmBriefcaseTabView.js: Updating the dialog with from 500 to 600.
3. ZmBriefcaseIconView: Getting icon using AjxImg utility.
4. zm.css & skin.css : Adding styles for briefcase row item as per UX mockups.