### PR TITLE
Changed style for focus state of an element from outline to box-shadow

### DIFF
--- a/WebRoot/css/dwt.css
+++ b/WebRoot/css/dwt.css
@@ -582,7 +582,7 @@ TD.DwtListView-ColumnActive {
 
 UL.DwtListView-Rows {
 	list-style:none;
-	padding: @OutlineWidth@;
+	padding: 0px;
 	margin:0px;
 }
 
@@ -1848,7 +1848,7 @@ INPUT.xform_field {
 .ZAddNewMenuItem:focus,
 .ZFocused.DwtCheckbox INPUT:focus,
 .ZFocused.DwtRadioButton INPUT:focus {
-	outline: none;
+	@NoFocusOutline@
 }
 
 

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1292,7 +1292,7 @@ SelOutsetBottomBorderColor  = @darken(SelC, 40)@
 SelOutsetLeftBorderColor    = @darken(SelC, 20)@
 
 SelOutsetBorderColor        = border-color:@SelOutsetTopBorderColor@ @SelOutsetRightBorderColor@ @SelOutsetBottomBorderColor@ @SelOutsetLeftBorderColor@;
-SelOutsetBorder             = @SelOutsetBorderColor@ outline: none;
+SelOutsetBorder             = @SelOutsetBorderColor@ @NoFocusOutline@
 SelInsetBorder              = border-color:@darken(SelC,50)@ @darken(SelC,20)@ @darken(SelC,20)@ @darken(SelC,50)@; @BorderBase@
 SelOutline                  = outline-color:@darken(SelC,20)@; outline-width: 1px; outline-style: solid;
 
@@ -1330,19 +1330,14 @@ SmallInsetBorder            = padding:1px; border:1px solid; border-color:@darke
 
 
 ################
-#   OUTLINES
+#   FOCUS OUTLINES
 #
-#   Primary use is to indicate focus. Outlines do not take up space, so there's no need for a transparent version. They go around the entire element, including the margin.
+#   Focus outline is being shown as `box-shadow` instead of `outline`, so that it doesn't change box model. Alos we set outline:0 to reset default browser behaviour
 #
 ################
 
-#OutlineMargin               = margin:0px;
-OutlineStyle                = outline-style:solid;
-OutlineWidth                = 1px
-OutlineSize                 = outline-width:@OutlineWidth@;
-OutlineColor                = outline-color: @SelOutsetLeftBorderColor@;
-FocusOutline                = @OutlineStyle@ @OutlineSize@ @OutlineColor@
-
+FocusOutline                = outline:0; @cssShadow@: inset 0px 0px 0px 1px @SelC@;
+NoFocusOutline              = outline:0; @cssShadow@: none;
 
 
 ################


### PR DESCRIPTION
Reason: Due to outline, we have to keep 1px breathing space around some of the elements, as outline adds-up in box-model sizing. In this case, element do not has focus, 1px breathing space around area continues to shows up.  

This may-not be final style for focus state of an elements, but just a better approach so that we don't end up adding 1px space around form some elements.