### PR TITLE
ZCS-1304

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 build/
+.project
+/.history
+/.idea

--- a/WebRoot/js/zimbraMail/mail/view/ZmMailMsgView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailMsgView.js
@@ -1831,6 +1831,7 @@ ZmMailMsgView.prototype._renderMessageBody1 = function(params, part) {
         // calendar part in ICS format
         else if (ct === ZmMimeTable.TEXT_CAL) {
             content = ZmMailMsg.getTextFromCalendarPart(bp);
+            content = AjxStringUtil.htmlEncode(content);
         }
 
         // HTML

--- a/WebRoot/js/zimbraMail/share/model/ZmInvite.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmInvite.js
@@ -989,7 +989,7 @@ function(isHtml) {
 		buf[i++] = "<p>\n<table border='0'>\n";
 	}
 
-	var orgName = this.getOrganizerName();
+	var orgName = AjxStringUtil.htmlEncode(this.getOrganizerName());
 	if (orgName) {
 		params = [ZmMsg.organizerLabel, orgName, ""];
 		buf[i++] = formatter.format(params);
@@ -1003,7 +1003,7 @@ function(isHtml) {
 		buf[i++] = "\n";
 	}
 
-	var locationSummary = this.getLocation();
+	var locationSummary = AjxStringUtil.htmlEncode(this.getLocation());
 	if (locationSummary) {
 		params = [ZmMsg.locationLabel, locationSummary, ""];
 		buf[i++] = formatter.format(params);


### PR DESCRIPTION
Cross-Site Scripting vulnerability in Zimbra exploitable by sending a specially crafted email

Desc -
HTML-encode for the description and location field.
Also, adding content to gitignore file.

Changeset -

ZmMailMsgView.js
ZmInvite.js

Testing notes  -
Ran the below test cases successfully against the fix.

Case 1:
1. Send a mail with subject 'My message' from user1 to user2.
2. Inject the attached mime_XSS1 (script is present in location field) to user2
3. Login as user2 and select the conversation.
script present in location field should not be executed.

Case 2:
1. Change the view from conversation to message
2. Load Inbox and select the injected message in case 1.
script present in location field should not be executed.

case 3.
1. Send a mail with subject 'My message3' from user1 to user2.
2. Inject the attached mime_XSS3 (script is present in description field) to user2
3. Login as user2 and select the conversation.
script present in description field should not be executed.

Case 4:
1. Change the view from conversation to message
2. Load Inbox and select the injected message case 3.
script present in description field should not be executed.

Case 5:
Repeat case 1 and case 2 using mime mime_XSS4 with subject 'My message4' to verify XSS on organizer field

Case 6:
Repeat case 1 and case 2 using mime mime_XSS5 with a subject 'My message5' to verify XSS on attendee field.