### PR TITLE
ZCS-129 Can't Disable External Imap and pop3 Access through cos and per user basis

### DIFF
--- a/WebRoot/js/zimbraMail/prefs/view/ZmPreferencesPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmPreferencesPage.js
@@ -1312,7 +1312,7 @@ ZmPreferencesPage.prototype._isEnabled = function(prefId1 /* ..., prefIdN */) {
 
 		var setup = ZmPref.SETUP[prefId],
 			prefPrecondition = setup && setup.precondition;
-		if (appCtxt.checkPrecondition(prefPrecondition, prefPrecondition && setup.preconditionAny)) {
+		if (appCtxt.checkPrecondition(prefPrecondition  || prefId, prefPrecondition && setup.preconditionAny)) {
 			return true;
 		}
 	}

--- a/WebRoot/templates/prefs/Pages.template
+++ b/WebRoot/templates/prefs/Pages.template
@@ -502,14 +502,12 @@ and the container element is replaced with that control.
 				</tr>
 				<$ } $>
 
-				<$ if (data.isEnabled(ZmSetting.USE_SEND_MSG_SHORTCUT)) { $>
-					<tr>
+				<tr>
 						<td>&nbsp;</td>
 						<td class='ZOptionsField'>
 							<div id='${id}_USE_SEND_MSG_SHORTCUT' tabindex=0 />
 						</td>
-					</tr>
-				<$ } $>
+				</tr>
 
 				<tr>
 					<td>&nbsp;</td>


### PR DESCRIPTION
ZCS-129 Can't Disable External Imap and pop3 Access through cos and per user basis

Issue: Add external account button visible in preference section even if the related attribute is set to FALSE in ldap.

Root Cause:  ZmPreferencesPage::_isEnabled() is not passing the prefId to checkPrecondition function thus returning true always and the attribute value getting ignored.

Fix: Passing the prefId if precondition is not present which in turn checks the setting value in the ldap and returns false if it is set so.

Changeset:
 * ZmPreferencesPage.js: Passing prefId if prefPrecondition is not available while calling ZmAppCtxt::checkPrecondition(). (Reverting bug:97899)
 * Pages.template: Showing mail/compose/use keyboard shortcut ctrl+enter to send message all the time. Previously it used to be shown based on its value which is a problem. (bug: 97899).