### PR TITLE
Fixing Background color for input fields.

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -5441,6 +5441,10 @@ If you feel compelled to have a background color, please do so on a per skin lev
 	padding-bottom:4px;
 }
 
+.ZmEditContactView .contactHeaderCellRow INPUT[type="text"] {
+	@ContactEditHeaderInput@
+}
+
 .ZmEditContactView .inlineInput,
 .ZmEditContactView .rowValue.inlineInput {
 	@ContactEditInlineInput@

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -462,7 +462,7 @@ InputBorder                 = border-width: 0 0 1px 0; border-style:solid; borde
 InputHeight                 = @WidgetHeight@
 InputBorder-disabled        = border-bottom:1px solid @darken(AppC,10)@;
 InputPadding                = padding:4px;
-InputBg                     = background-color:inherit;
+InputBg                     = 
 
 InputField                  = @InputPadding@    @TextCursor@            @InputHeight@         @FixBoxModel@         @InputBg@
 InputField-normal           = @InputText@       @ZFieldBg-normal@       @InputBorder@
@@ -1338,6 +1338,7 @@ ContactEditBetweenRowSpacing= 26px
 ContactEditInlineInput      = padding-right:@ContactEditInputSpacing@; padding-top: 17px;
 ContactEditHeaderCell       = padding:@ContactViewOutsidePadding@ .5em;
 ContactEditHeaderLastChild  = padding-right:@ContactViewOutsidePadding@; float:right;
+ContactEditHeaderInput      = background-color:inherit;
 ContactEditDepartmentSep    = padding:0px 13px 10px; vertical-align: bottom;
 ContactEditDepartment       = padding-right:0; 
 ContactEditJobTitle         = padding-right:0;


### PR DESCRIPTION
Issue: With change in zcs-823, all fields were inheriting background color from their parent element causing issues where it is not the required behaviour (Login page for example).

Fix: Reverting the change that make this behaviour and applying the change restricting it only to the contact header screen where its required at the moment.

Changeset:
 * zm.css: Adding selector to target input fields for contact edit header part.