### PR TITLE
ZCS-1167 Universal UI: Task list action bar and left sidebar

### DIFF
--- a/WebRoot/css/dwt.css
+++ b/WebRoot/css/dwt.css
@@ -2026,7 +2026,7 @@ INPUT.xform_field {
 .ZSelected	.ZToolbarButtonTable .ZWidgetTitle	{							@ToolbarButtonText-selected@	}
 
 .ZToolbarButton.ZViewMenuButton	.ZToolbarButtonTable		                {       @ToolbarViewButtonContainer@       }
-.ZToolbarButton.ZViewMenuButton .ZToolbarButtonTable .ZWidgetTitle			{ 		@Text-light@ 		               }
+.ZToolbarButton.ZViewMenuButton .ZToolbarButtonTable TD.ZWidgetTitle			{ 		@Text-light@ 		               }
 .ZToolbarButton.ZViewMenuButton	.ZToolbarButtonTable  TD.ZDropDown 			{		@ToolbarViewButtonDropIcon@ 	   }
 
 /***************

--- a/WebRoot/js/zimbraMail/tasks/ZmTasksApp.js
+++ b/WebRoot/js/zimbraMail/tasks/ZmTasksApp.js
@@ -80,7 +80,7 @@ function() {
 	ZmOperation.registerOp(ZmId.OP_PRINT_TASK, {textKey:"printTask", image:"Print", shortcut:ZmKeyMap.PRINT}, ZmSetting.PRINT_ENABLED);
 	ZmOperation.registerOp(ZmId.OP_PRINT_TASKFOLDER, {textKey:"printTaskFolder", image:"Print"}, ZmSetting.PRINT_ENABLED);
     ZmOperation.registerOp(ZmId.OP_SORTBY_MENU, {tooltipKey:"viewTooltip", textKey:"taskFilterBy", image:"SplitPane", textPrecedence:80});
-    ZmOperation.registerOp(ZmId.OP_MARK_AS_COMPLETED, {tooltipKey:"markAsCompleted", textKey:"markAsCompleted", image:"CheckboxChecked", textPrecedence:80});
+    ZmOperation.registerOp(ZmId.OP_MARK_AS_COMPLETED, {tooltipKey:"complete", textKey:"complete", image:"CheckboxCheckedCircular", textPrecedence:80, showImageInToolbar: true, showTextInToolbar: true});
 };
 
 ZmTasksApp.prototype._registerSettings =

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -609,7 +609,7 @@ ToolbarNewButtonText-disabled   = @Text-disabled@
 ToolbarNewButtonDropIcon        = padding: 0 24px; fill: @PrimaryBrandingColor@
 
 ToolbarViewButtonContainer      = padding-right: 0;
-ToolbarViewButtonDropIcon       = padding-right: 8px;
+ToolbarViewButtonDropIcon       = padding-right: 8px; fill:#777777;
 
 NewButton                       = 
 NewTop                          = 


### PR DESCRIPTION
ZCS-1167 Universal UI: Task list action bar and left sidebar

Changeset:
* ZmTaskListController.js :
  * Removing icons for filterby feature.
  * Moving reading pane options into submenu similar to mail app.
  * Moving Print & Tag toolbar options into secondary menu dropdown (actions menu).

* ZmTasksApp.js : Updating icon for complete operation.
* dwt.css : Updating selector for view button in the toolbar to make it heavier than the other selector .
* Skin.properties: Updating the drop down icon color for view button on the toolbar.