### PR TITLE
ZCS-1365: Bug 107925 - Persistent XSS - snippet [CWE-79]

### DIFF
--- a/WebRoot/js/zimbraMail/mail/controller/ZmMailListController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmMailListController.js
@@ -386,7 +386,10 @@ function(actionCode, ev) {
 						frag = item.invite ? item.invite.getToolTip() : this.getMsg().invite.getToolTip();
 					} else {
 						frag = item.fragment ? item.fragment : ZmMsg.fragmentIsEmpty;
-						if (frag != "") { lv.setToolTipContent(AjxStringUtil.htmlEncode(frag), true); }
+						if (frag != "") {
+							frag = AjxStringUtil.htmlEncode(frag);
+							lv.setToolTipContent(frag, true);
+						}
 					}
 					var tooltip = this._shell.getToolTip();
 					tooltip.popdown();


### PR DESCRIPTION
Issue: Shortcut key “q” that triggers to have mail contents in the tooltip is not XSS safe and set’s the content without encoding.

Changeset:
* ZmMailListController.js: Html encoding the mail fragment before setting it to the ui.