### PR TITLE
ZCS-908: Universal UI- From / To expansion and collapsed interface on the inbox reading pane

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -696,20 +696,9 @@ INPUT[type="text"].search_input-expanded:focus {
 
 .MsgHeaderTable {}
 
-.MsgHeaderContactImage, .InvHeaderContactImage {
-	width:48px;
-	margin:4px;
-	@MailMsgHeaderImageRadius@
-}
-
 .MsgHeaderTable>TBODY>TR>TD, 
 .InvHeaderTable>TBODY>TR>TD {
 	vertical-align:top;
-}
-
-.MsgHeaderContactContainer, .InvHeaderContactContainer {
-	width:56px;
-	text-align:center;
 }
 
 /* Container for the header of the message */
@@ -719,9 +708,7 @@ INPUT[type="text"].search_input-expanded:focus {
 }
 
 .InvHeaderTable .date {
-	@Text-light@
-	padding: @MailViewInnerSpacing@ @MailViewGutterSpace@;
-    margin: @MailViewGutterSpace@ @MailViewGutterSpace@ 0;
+	@MailMsgHeaderDate@
 }
 
 .InvHeaderDiv .InvHeaderPropertySheetWrapper {
@@ -766,13 +753,10 @@ INPUT[type="text"].search_input-expanded:focus {
 .ZmMailMsgView .InvHeaderDiv .LabelColName,
 .ZmMailMsgCapsuleView .InvHeaderDiv .LabelColName {
 	@FontSize-big@
-	padding-bottom: @MailViewGutterSpace@;
-	line-height: 1;
 }
 
 .InvHeaderTable {
 	@MailInvHeaderLight@
-	width:100%;
 }
 
 .ZmConvDoublePaneView .calendar_view, 
@@ -900,33 +884,27 @@ div.AttachmentImgContainer {
 
 .ZmMailMsgView .LabelColValue, 
 .ZmMailMsgCapsuleView .LabelColValue {
-	@FontSize-big@
-	vertical-align: top;
-	line-height: 1.5;
-	white-space:normal;
-	padding:0 0 5px 0;
+	@MailMsgHeaderValue@
 }
 
 .ZmMailMsgView .SubjectCol {
 	@MailMsgHeaderText@
 }
 
+.ZmMailMsgView .MsgPriorityImg {
+	@MailMsgHeaderPriorityImg@
+}
+
 .ZmMailMsgView .MsgHeaderTable .info {
-	@ActiveCursor@
-	white-space:nowrap;
-	@TextSelection@
-	padding: @MailViewGutterSpace@ @MailViewGutterSpace@ @MailViewInnerSpacing@;
-	margin: @MailViewInnerSpacing@ @MailViewGutterSpace@ 0;
+	@MailMsgHeaderAddress@
 }
 
 .ZmMailMsgView .MsgHeaderTable .date {
-	padding: 0 @MailViewGutterSpace@;
-	margin: 0 @MailViewGutterSpace@;
-	@Text-light@
+	@MailMsgHeaderDate@
 }
 
 .ZmMailMsgView div.MsgBody {
-	padding: @MailViewInnerSpacing@ @MailViewGutterSpace@;
+	padding: 0 @MailViewGutterSpace@;
 }
 
 /* ??? USE? */
@@ -1041,7 +1019,6 @@ div.AttachmentImgContainer {
 }
 
 .Conv2Messages .InvHeaderTable {
-	background-color:@MailMsgBkgdColor@;
 	margin-top:0;
 }
 
@@ -1245,8 +1222,7 @@ div.AttachmentImgContainer {
 .ZmMailMsgCapsuleView .LabelColValue.InLineList .addrBubble-selected:not(.TagBubble) *,
 .ZmMailMsgCapsuleView .LabelColValue.InLineList .addrBubble-actioned:not(.TagBubble),
 .ZmMailMsgCapsuleView .LabelColValue.InLineList .addrBubble-actioned:not(.TagBubble) * {
-	display: inline-block;
-	vertical-align: top;
+	width: auto;
 }
 
 .ZmMailMsgView .LabelColValue.InLineList .addrBubble:not(.TagBubble):not(:last-of-type)::after,
@@ -1286,6 +1262,18 @@ div.AttachmentImgContainer {
     font-size: 1.18rem;
     line-height: 1.27;
     padding: 0;
+}
+
+.Conv2MsgHeader .info-collapsed TABLE TD,
+.MsgHeaderTable .info-collapsed TABLE TD {
+	@MailAddressCollapsedCell@
+}
+
+.Conv2MsgHeader .info-collapsed TABLE TD.InfoLabel,
+.MsgHeaderTable .info-collapsed TABLE TD.InfoLabel,
+.Conv2MsgHeader .info TABLE TD.InfoLabel,
+.MsgHeaderTable .info TABLE TD.InfoLabel {
+	@MailAddressLabelCell@
 }
 
 /* ??? MOVE ME */

--- a/WebRoot/js/zimbraMail/mail/view/ZmConvView2.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmConvView2.js
@@ -2313,7 +2313,9 @@ function(state, force) {
 			bwoId:			id +  ZmId.CMP_BWO_SPAN,
 			addressTypes:	ai.addressTypes,
 			participants:	ai.participants,
-			isOutDated:		msg.invite && msg.invite.isEmpty()
+			isOutDated:     msg.invite && msg.invite.isEmpty(),
+			toAddrs:        msg.getAddresses(AjxEmailAddress.TO).getArray(),
+			fromAddrs:      msg.getAddresses(AjxEmailAddress.FROM).getArray(),
 		});
 		html = AjxTemplate.expand("mail.Message#Conv2MsgHeader-expanded", subs);
 	}
@@ -2329,6 +2331,9 @@ function(state, force) {
 			showMoreLink.notoggle = 1;
 		}
 	}
+
+	//setup listeners for expanding/collapsing mail address container
+	this._msgView._setupMailAdressExpandCollapse();
 };
 
 /**

--- a/WebRoot/js/zimbraMail/mail/view/ZmMailMsgView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailMsgView.js
@@ -1500,12 +1500,14 @@ function(msg, container, doNotClearBubbles) {
 		attachmentsCount:	attachmentsCount,
 		bwo:                ai.bwo,
 		bwoAddr:            ai.bwoAddr,
-		bwoId:              ZmId.getViewId(this._viewId, ZmId.CMP_BWO_SPAN, this._mode)
+		bwoId:              ZmId.getViewId(this._viewId, ZmId.CMP_BWO_SPAN, this._mode),
+		toAddrs:            msg.getAddresses(AjxEmailAddress.TO).getArray(),
+		fromAddrs:          msg.getAddresses(AjxEmailAddress.FROM).getArray(),
 	};
 
 	if (msg.isHighPriority || msg.isLowPriority) {
 		subs.priority =			msg.isHighPriority ? "high" : "low";
-		subs.priorityImg =		msg.isHighPriority ? "ImgPriorityHigh_list" : "ImgPriorityLow_list";
+		subs.priorityImg =		msg.isHighPriority ? "PriorityHigh" : "PriorityLow";
 		subs.priorityDivId =	ZmId.getViewId(this._view, ZmId.MV_PRIORITY);
 	}
 
@@ -1570,6 +1572,11 @@ function(msg, container, doNotClearBubbles) {
 		topToolbar.reparentHtmlElement(container);
 		topToolbar.setVisible(Dwt.DISPLAY_BLOCK);
 		this._headerTabGroup.addMember(topToolbar);
+	}
+
+	//setup listeners for expanding/collapsing mail address container, if it's not invite header
+	if(!invite) {
+		this._setupMailAdressExpandCollapse();
 	}
 };
 
@@ -2849,3 +2856,30 @@ function(check) {
 ZmMailMsgView.prototype._getIframeTitle = function() {
 	return AjxMessageFormat.format(ZmMsg.messageTitle, this._msg.subject);
 };
+
+/**
+ * Setup listeners for mail addresses expand/collapse feature
+ */
+ZmMailMsgView.prototype._setupMailAdressExpandCollapse = function() {
+	this._addressInfoExpanded = Dwt.byId(this._hdrTableId + "_info_expanded");
+	this._addressInfoCollapsed = Dwt.byId(this._hdrTableId + "_info_collapsed");
+	this._addressInfoExpandBtn = Dwt.byId(this._hdrTableId + "_info_expand_btn");
+	this._addressInfoCollapseBtn = Dwt.byId(this._hdrTableId + "_info_collapse_btn");
+	//setup listeners
+	Dwt.setHandler(this._addressInfoExpandBtn, DwtEvent.ONCLICK, this._expandMailAdressContainer.bind(this, false));
+	Dwt.setHandler(this._addressInfoCollapseBtn, DwtEvent.ONCLICK, this._expandMailAdressContainer.bind(this, true));
+	//collapse address container initially
+	this._expandMailAdressContainer(true);
+}
+
+
+/**
+ * @description Expand/collapse detailed address container in mail header
+ * @param collapse: true | false
+ * If collapse = true, collapse the widget else expant it
+ */
+ZmMailMsgView.prototype._expandMailAdressContainer = function(collapse, event) {
+	collapse = !!collapse; //casting to boolean
+	this._addressInfoExpanded && Dwt.setVisible(this._addressInfoExpanded, collapse !== true);
+	this._addressInfoCollapsed && Dwt.setVisible(this._addressInfoCollapsed, collapse === true);
+}

--- a/WebRoot/js/zimbraMail/share/view/ZmSearchToolBar.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmSearchToolBar.js
@@ -392,7 +392,7 @@ function() {
 
 	var menu = this._searchMenu = new DwtMenu({
 				parent:		this._button[ZmSearchToolBar.TYPES_BUTTON],
-				className:	"ActionMenu ZHideCheckIconMenuType ZTopSearchPopupMenu",
+				className:	"DwtMenu ActionMenu ZHideCheckIconMenuType ZTopSearchPopupMenu",
 				id:			ZmId.getMenuId(ZmId.SEARCH)
 			});
 	var mi;

--- a/WebRoot/skins/_base/base4/skin.css
+++ b/WebRoot/skins/_base/base4/skin.css
@@ -511,6 +511,11 @@ BODY                                    {   margin:0px;     }
     display: none;
 }
 
+/* Hide CheckIcon for menus */
+.DwtMenu.ZHideCheckIconMenuType .ZCheckIcon { 
+    display: none;
+}
+
 #ENDIF
 
 #IFDEF MSIE_LOWER_THAN_9

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1180,10 +1180,14 @@ MsgSubject                  = @AppContainerBg@; overflow: hidden; width: 100%; p
 MailMsgView                 = @FullWidth@; @PanelBorder@; @MailConvExpanded@; overflow:auto; box-sizing: border-box;
 MailMsgHeader               = background-color:@HeaderColor@; @BottomSeparator@ padding:3px;
 MailMsgHeaderLight          = background-color:@AppC@;margin-top: @MailViewInnerSpacing@;
-MailInvHeaderLight          = @MailMsgHeaderLight@
-MailMsgHeaderText           = @FontSize-biggest@ ;padding: 0 5px;@Text@
+MailInvHeaderLight          = @MailMsgHeaderLight@; @FullWidth@; margin-top:24px;
+MailMsgHeaderText           = @FontSize-biggest@; padding: 0 5px; @Text@
+MailMsgHeaderValue          = @FontSize-big@; vertical-align:top; line-height:1.5; white-space:normal; padding:0 0 5px 0;
 MailMsgHeaderLabel          = @Label@ padding:0 20px 5px 0; @Text-light@; vertical-align: top; line-height: 1.5; width: 1%;
 MailMsgHeaderImageRadius    = @MediumRoundCorners@
+MailMsgHeaderPriorityImg    = display:inline-block; vertical-align:middle; margin-right:@MailViewInnerSpacing@;
+MailMsgHeaderDate           = padding:@MailViewGutterSpace@; padding-top:0; margin:0 @MailViewGutterSpace@; @Text-light@;
+MailMsgHeaderAddress        = @ActiveCursor@; white-space:nowrap; @TextSelection@; padding:@MailViewGutterSpace@; padding-bottom:@MailViewInnerSpacing@; margin:@MailViewInnerSpacing@ @MailViewGutterSpace@; margin-bottom:0;
 
 MailMsgBkgdColor            = @AppC@
 MailMsgBkgd                 = background-color:@MailMsgBkgdColor@;
@@ -1216,7 +1220,7 @@ Conv2MsgHeaderImageRadius           = @MediumRoundCorners@
 Conv2MsgHeaderCollapsedImageRadius  = @MediumRoundCorners@
 ConvExpandIcon              = display:none;
 ConvExpanded                = margin-bottom: @MailViewInnerSpacing@;
-MailAddressBubble           = display: block; border: none; background: transparent; padding: 0 0 5px 0; margin: 0; @Text@; height: auto; line-height: 1;
+MailAddressBubble           = display: inline-block; @FullWidth@; vertical-align:top; border: none; background: transparent; padding: 0 0 5px 0; margin: 0; @Text@; height: auto; line-height: 1;
 MailAddressBubbleChild      = padding: 0px;
 MailViewInfoBar             = background: @AppC@; padding: 20px 0;
 
@@ -1252,6 +1256,9 @@ AttachBriefcaseItemFirstChild = padding:0 0 0 @SkinWrapperPadding@;
 AttachBriefcaseItemIcon     = height:28px; width:28px;
 
 MailHeaderDropDown          = @TransparentBg@; border:none;
+
+MailAddressCollapsedCell        = @Label@; @FontSize-big@;
+MailAddressLabelCell            = @MailAddressCollapsedCell@; text-transform:lowercase; @Text-light@; padding:0 5px;
 
 ###################
 #   CONTACTS-APP SPECIFIC STUFF

--- a/WebRoot/templates/mail/Message.template
+++ b/WebRoot/templates/mail/Message.template
@@ -6,12 +6,12 @@
 					<$ if (data.isSyncFailureMsg) { $>
 						<td id='${reportBtnCellId}'></td>
 					<$ } $>
-					<$ if (data.priorityImg) { $>
-					<td>
-						<div priority='<$=data.priority$>' id='<$=data.priorityDivId$>' style='margin-left:4px;' class='<$=data.priorityImg$>'></div>
-					</td>
-					<$ } $>
 					<td class='LabelColValue SubjectCol'>
+						<$ if (data.priorityImg) { $>
+							<div priority='<$=data.priority$>' id='<$=data.priorityDivId$>' class='MsgPriorityImg'>
+								<$= AjxImg.getImageHtml(data.priorityImg) $>
+							</div>
+						<$ } $>
 						<$= data.subject $>
 					</td>
 				</tr>
@@ -22,28 +22,33 @@
 				<td>
 					<div>
 						<div class="info">
-						<table id='${hdrTableId}' class='ZPropertySheet' cellspacing='6'>
-							<tr id='${expandRowId}'>
-								<td class='LabelColName'><$= ZmMsg.fromLabel $></td>
-								<td id="OBJ_PREFIX_<$=Dwt.getNextId()$>_from" class='LabelColValue InLineList' style='white-space:nowrap'>
-									<$= AjxTemplate.expand("#SentBy", data) $>
-								</td>
-							</tr>
+							<div class="info-collapsed" id='${hdrTableId}_info_collapsed'>
+								<$= AjxTemplate.expand("#CollapsedAddress", data) $>
+							</div>
+							<div class="info-expanded" id='${hdrTableId}_info_expanded'>
+								<table id='${hdrTableId}' class='ZPropertySheet' cellspacing='6'>
+									<tr id='${expandRowId}'>
+										<td class='LabelColName'><$= ZmMsg.fromLabel $></td>
+										<td id="OBJ_PREFIX_<$=Dwt.getNextId()$>_from" class='LabelColValue InLineList' style='white-space:nowrap'>
+											<$= AjxTemplate.expand("#SentBy", data) $>
+										</td>
+									</tr>
 
-							<$ for (var i = 0; i < data.addressTypes.length; i++) { 
-									var participants = data.participants[data.addressTypes[i]]; $>
-								<tr id='OBJ_PREFIX_<$=Dwt.getNextId()$>_<$=participants.prefix.toLowerCase()$>'>
-									<td class='LabelColName'>
-										<$= participants.prefix ? AjxMessageFormat.format(ZmMsg.makeLabel, participants.prefix) : "&nbsp;" $>
-									</td>
-									<td class='LabelColValue'><$= participants.partStr $></td>
-								</tr>
-							<$ } $>
+									<$ for (var i = 0; i < data.addressTypes.length; i++) { 
+										var participants = data.participants[data.addressTypes[i]]; $>
+										<tr id='OBJ_PREFIX_<$=Dwt.getNextId()$>_<$=participants.prefix.toLowerCase()$>'>
+											<td class='LabelColName'>
+												<$= participants.prefix ? AjxMessageFormat.format(ZmMsg.makeLabel, participants.prefix) : "&nbsp;" $>
+											</td>
+											<td class='LabelColValue'><$= participants.partStr $></td>
+										</tr>
+									<$ } $>
 
-							<$= AjxTemplate.expand("#AutoSend", data) $>
-							<$= AjxTemplate.expand("#AddedHeaders", data) $>
+									<$= AjxTemplate.expand("#AutoSend", data) $>
+									<$= AjxTemplate.expand("#AddedHeaders", data) $>
 
-						</table>
+								</table>
+							</div>
 						</div>
 						<div class="date">${dateString}</div>
 
@@ -67,19 +72,30 @@
 </template>
 
 <template id='mail.Message#SentBy'>
-	<span>${sentBy}</span>
 	<$
 		var useObo = data.obo && (data.oboAddr != data.sentByAddr);
 		var useBwo = data.bwo && (data.bwoAddr != data.sentByAddr);
-		if (useObo) {
-			$><span style='margin:0 .5em;'><$= ZmMsg.onBehalfOfMidLabel $></span>
-			<span id="${oboId}"><$= data.obo $></span><$
-		}
-		if (useBwo) {
-			$><span style='margin:0 .5em;'><$= ZmMsg.byWayOfMidLabel $></span>
-			<span id="${bwoId}"><$= data.bwo $></span><$
-		}
 	$>
+	<table role="presentation">
+		<tbody>
+			<tr>
+				<td>${sentBy}</td>
+				<$ if (useObo) { $>
+					<td class="InfoLabel"><$= ZmMsg.onBehalfOfMidLabel $></td>
+					<td><span id="${oboId}"><$= data.obo $></span></td>
+				<$ } $>
+				<$ if (useBwo) { $>
+					<td class="InfoLabel"><$= ZmMsg.byWayOfMidLabel $></td>
+					<td><span id="${bwoId}"><$= data.bwo $></span></td>
+				<$ } $>
+				<td>
+					<div id='${hdrTableId}_info_collapse_btn' notoggle="1">
+						<$= AjxImg.getImageHtml("NodeExpanded") $>
+					</div>
+				</td>
+			</tr>
+		</tbody>
+	</table>
 </template>
 
 
@@ -668,19 +684,24 @@
 
 <template id='mail.Message#Conv2MsgHeader-expanded'>
 	<div class='info'>
-		<table role="presentation" id='${hdrTableId}' class='ZPropertySheet' cellspacing='6'>
-			<tr>
-			<td class='LabelColName'><$= ZmMsg.fromLabel $></td>
-			<td class='LabelColValue InLineList'>
-				<$= AjxTemplate.expand("#SentBy", data) $>
-			</td>
-			</tr>
+		<div class="info-collapsed" id='${hdrTableId}_info_collapsed'>
+			<$= AjxTemplate.expand("#CollapsedAddress", data) $>
+		</div>
+		<div class="info-expanded" id='${hdrTableId}_info_expanded'>
+			<table role="presentation" id='${hdrTableId}' class='ZPropertySheet' cellspacing='6'>
+				<tr>
+				<td class='LabelColName'><$= ZmMsg.fromLabel $></td>
+				<td class='LabelColValue InLineList'>
+					<$= AjxTemplate.expand("#SentBy", data) $>
+				</td>
+				</tr>
 
-		<$ for (var i = 0; i < data.addressTypes.length; i++) { $>
-			<$= AjxTemplate.expand("#Conv2MsgAddressRow", data.participants[data.addressTypes[i]]); $>
-		<$ } $>
+			<$ for (var i = 0; i < data.addressTypes.length; i++) { $>
+				<$= AjxTemplate.expand("#Conv2MsgAddressRow", data.participants[data.addressTypes[i]]); $>
+			<$ } $>
 
-		</table>
+			</table>
+		</div>
 	</div>
 	<div class='date' id='${dateCellId}' title='${dateTooltip}'>${date}</div>
 	<$ if (data.isOutDated) { $>
@@ -711,5 +732,37 @@
 			<td><input checked value='0' type='checkbox' id='${id}_dontRemind' name='${id}_dontRemind'></td>
 			<td style='white-space:nowrap'><label id='${id}_dontRemindMsg' for='${id}_dontRemind'><$=ZmMsg.dontRemind$></label></td>
 		</tr>
+	</table>
+</template>
+
+<!-- Collapsed mail addresses template -->
+<template id='mail.Message#CollapsedAddress'>
+	<table role="presentation">
+		<tbody>
+			<tr>
+				<td>
+					<$ var from = []; $>
+					<$ for(var i = 0; i < data.fromAddrs.length; i++) {
+						from.push(data.fromAddrs[i].getText());
+					} $>
+					<$= AjxStringUtil.fitString(from.join(", "), 200); $>
+				</td>
+				<td class="InfoLabel">
+					<$= ZmMsg.to $>
+				</td>
+				<td>
+					<$ var to = []; $>
+					<$ for(var i = 0; i < data.toAddrs.length; i++) {
+						to.push(data.toAddrs[i].getText());
+					} $>
+					<$= AjxStringUtil.fitString(to.join(", "), 300); $>
+				</td>
+				<td>
+					<div id='${hdrTableId}_info_expand_btn' notoggle="1">
+						<$= AjxImg.getImageHtml("NodeCollapsed-rev") $>
+					</div>
+				</td>
+			</tr>
+		</tbody>
 	</table>
 </template>


### PR DESCRIPTION
Changes:

* Message.template:
  * Added new template `#CollapsedAddress ` for collapsed address view
  * Updated mail header template as per requirement
* ZmMailMsgView.js:
   * Updated `_renderMessageHeader` method  to add new parameters `toAddrs`, `fromAddrs` for template
   * Added new method `ZmMailMsgView.prototype._setupMailAdressExpandCollapse` for expand/collapse feature
     and its related methods
* ZmConvView2.js:
   * Updated `ZmMailMsgCapsuleViewHeader.prototype.set` method to pass new parameters `toAddrs` and
     `fromAddrs` to template and called method to collapse address header.
* Added/updated required CSS for  `skin.css`, `zm.css`
* Added/updated required strings for `skin.properties`

https://jira.corp.synacor.com/browse/ZCS-908