### PR TITLE
ZCS-1769 Universal UI: Preference tab sending Batch Request on each click.

### DIFF
--- a/WebRoot/js/zimbraMail/prefs/controller/ZmPrefController.js
+++ b/WebRoot/js/zimbraMail/prefs/controller/ZmPrefController.js
@@ -304,6 +304,7 @@ function() {
 								elements:	elements,
 								controller:	this,
 								callbacks:	callbacks,
+								isAppView:	true,
 								tabParams:	this._getTabParams()});
 		this._initializeTabGroup();
 	}


### PR DESCRIPTION
ZCS-1769 Universal UI: Preference tab sending Batch Request on each click.

Description: isAppView coming as true in the UI framework causing the Preferences app to be initialised on each click causing networks requests to be sent all again.

Fix: Setting isAppView for the preferences view as true.

Changeset:
* ZmPrefController::_setView() : Passing isAppView as true while creating a new view through AppViewManager.