### PR TITLE
ZCS-817 unexpected logout happening in html client

### DIFF
--- a/WebRoot/WEB-INF/tags/briefcase/briefcaseListViewToolbar.tag
+++ b/WebRoot/WEB-INF/tags/briefcase/briefcaseListViewToolbar.tag
@@ -36,7 +36,7 @@
                     </td>
                     <td><div class='vertSep'></div></td>
                     <td>
-                        <zm:currentResultUrl var="newUploadUrl" value="" context="${context}" action="newbrief"/>
+                        <zm:currentResultUrl var="newUploadUrl" value="" context="${context}" action="newbrief" crumb="${mailbox.accountInfo.crumb}"/>
                         <a <c:if test="${keys}">id="NEW_UPLOAD" </c:if>href="${fn:escapeXml(newUploadUrl)}&lbfums="><app:img altkey="uploadNewFile" src="startup/ImgAttachment.png"/><span>&nbsp;<fmt:message key="uploadNewFile"/></span></a>
                     </td>
                     <td><div class='vertSep'></div></td>

--- a/WebRoot/WEB-INF/tags/briefcase/newBriefCheck.tag
+++ b/WebRoot/WEB-INF/tags/briefcase/newBriefCheck.tag
@@ -24,6 +24,7 @@
 <app:handleError>
     <zm:getMailbox var="mailbox"/>
     <zm:composeUploader var="uploader"/>
+    <zm:checkCrumb crumb="${param.crumb}"/>
 
     <c:set var="needUploadView" value="${param.action eq 'newbrief'}"/>
     <c:set var="needListView" value="${false}"/>


### PR DESCRIPTION
Issue:
 - html client has jsp session timeout of 5 mins, so after that it needs to recreate jsp session based on valid authtoken but we had code that sets csrfSupported to false if request type is POST

 Resolution:
 - zm-taglib: ZJspSession.java, revert back change which checked request type for setting csrfSupported flag, which was done to fix https://bugzilla.zimbra.com/show_bug.cgi?id=104828 issue, I think we should blindly not consider all POST requests as CSRF vectors
 - zm-web-client: newBriefCheck.tag & briefcaseListViewToolbar.tag, properly fix https://bugzilla.zimbra.com/show_bug.cgi?id=104828 by checking for valid crumb when trying to upload briefcase attachment