### PR TITLE
ZCS-1797 :- Universal UI - Integrate Progress bar with Task list, lis…

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -2028,6 +2028,10 @@ div.CompDragArea * {
 	@TaskReadingPaneRight-CompletedProgressBarImage@
 }
 
+.ZmTaskMultiView .DwtListView .Row-selected .ZmTaskProgress .tick-inside {
+	@TaskReadingPaneRight-CompletedProgressBarImage-Selected@
+}
+
 .ZmTaskMultiView .DwtListView  .RowDouble .BottomRow {
 	@TaskReadingPaneRight-BottomRowIconContainer@
 }

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1540,7 +1540,8 @@ TaskReadingPaneRight-ListViewItemCheckIconWrapper           = display:table-cell
 TaskReadingPaneRight-ProgressBarImageWrapper                = vertical-align:middle; width:55px; padding-left:0px;
 TaskReadingPaneRight-ProgressBarImage                       = width:42px; height:42px;
 TaskReadingPaneRight-BottomRowIconContainer                 = float:right;
-TaskReadingPaneRight-CompletedProgressBarImage              = fill:@PrimaryBrandingColor@
+TaskReadingPaneRight-CompletedProgressBarImage              = fill:@CircularProgressBarActiveBg@
+TaskReadingPaneRight-CompletedProgressBarImage-Selected     = fill:@CircularProgressBarInverseActiveBg@;
 
 ###################
 #   DRAG AND DROP STUFF


### PR DESCRIPTION
…t view - right view

Desc :- Added a Css Rule,  when in task list view, if a task which is fully completed (100%) and then selected, the circular progress bar should be visible. In this case, we are now applying fill color as white, which was earlier blue and hence the selection color and the circular progress bar’s having the same color, the circular progress bar was not visible.

Changeset :-
a) Zm.css
b) skin.properties