### PR TITLE
ZCS-1892 Universal UI: Mail with no message body shows 'ZmMailMsg' or 'ZmConv' in mail list right reading pane view.

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/ZmConvListView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmConvListView.js
@@ -411,7 +411,7 @@ function(htmlArr, idx, item, field, colIdx, params, classes) {
 			}
 			htmlArr[idx++] = "</div>";
 		}
-		else if (field == ZmItem.F_FRAGMENT && appCtxt.get(ZmSetting.SHOW_FRAGMENTS) && item.fragment) {
+		else if (field == ZmItem.F_FRAGMENT && appCtxt.get(ZmSetting.SHOW_FRAGMENTS)) {
 				htmlArr[idx++] = this._getFragmentSpan(item);
 		}
 		else if (field === ZmItem.F_FOLDER) {

--- a/WebRoot/js/zimbraMail/mail/view/ZmMailMsgListView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailMsgListView.js
@@ -180,7 +180,7 @@ function(htmlArr, idx, msg, field, colIdx, params, classes) {
 		}
 		htmlArr[idx++] = "</div>";
 
-	} else if (field == ZmItem.F_FRAGMENT && appCtxt.get(ZmSetting.SHOW_FRAGMENTS) && msg.fragment) {
+	} else if (field == ZmItem.F_FRAGMENT && appCtxt.get(ZmSetting.SHOW_FRAGMENTS)) {
 			htmlArr[idx++] = this._getFragmentSpan(msg);
 	} else if (field == ZmItem.F_FOLDER) {
 		htmlArr[idx++] = "<div " + AjxUtil.getClassAttr(classes) + " id='";


### PR DESCRIPTION
ZCS-1892
Universal UI: Mail with no message body shows 'ZmMailMsg' or 'ZmConv' in mail list right reading pane view.

Issue:
	 *  Fragment comes as undefined if there’s no mail body, presence of a condition against the fragment causing the execution to reach 	  DwtListView::_getCellContents() from where item.String() is causing item name to be returned to UI.

Fix Description:
	*  Removed the condition to check presence of mail object fragment, as this._getFragmentSpan take’s care of empty/undefined fragment.

Changeset:
	*  ZmConvListView.js
	*  ZmMailMsgListView.js