### PR TITLE
ZCS-1779 Persistent XSS - Resource Name field

### DIFF
--- a/WebRoot/templates/calendar/Appointment.template
+++ b/WebRoot/templates/calendar/Appointment.template
@@ -1121,9 +1121,9 @@
 
 <template id='calendar.Appointment#LocationSuggestion'>
 	<div id='${id}' class="ZmLocationSuggestion">
-		<$= data.locationName $>
+		<$= AjxStringUtil.htmlEncode(data.locationName) $>
 		<$ if (data.locationDescription) { $>
-			<br><$= data.locationDescription $>
+			<br><$= AjxStringUtil.htmlEncode(data.locationDescription) $>
 		<$ } $>
 	</div>
 </template>


### PR DESCRIPTION
Issue:
- XSS attack was possible in webclient by creating a resource with malicious name

Resolution:
- html encode resource name and description before adding it to DOM