### PR TITLE
ZCS-1941 Exception while viewing document in Briefcase

### DIFF
--- a/WebRoot/WEB-INF/tags/rest/restDocumentPreview.tag
+++ b/WebRoot/WEB-INF/tags/rest/restDocumentPreview.tag
@@ -91,6 +91,9 @@
         </jsp:include>
 
         <!-- Packages -->
+        <script type="text/javascript">
+            <jsp:include page="/js/ajax/util/AjxTimezoneData.js" />
+        </script>
         <c:set var="packages" value="Boot,DocsPreview,Debug" scope="request"/>
         <c:set var="pnames" value="${fn:split(packages,',')}" scope="request"/>
         <c:set var="pprefix" value="js" scope="request"/>

--- a/WebRoot/WEB-INF/tags/rest/restSlidePreview.tag
+++ b/WebRoot/WEB-INF/tags/rest/restSlidePreview.tag
@@ -87,6 +87,9 @@
         </jsp:include>
 
         <!-- Packages -->
+        <script type="text/javascript">
+            <jsp:include page="/js/ajax/util/AjxTimezoneData.js" />
+        </script>
         <c:set var="packages" value="Boot,DocsPreview,Debug" scope="request"/>
         <c:set var="pnames" value="${fn:split(packages,',')}" scope="request"/>
         <c:set var="pprefix" value="js" scope="request"/>


### PR DESCRIPTION
Issue:
- AjxTimezoneData.js file was removed from DocsPreview package as part of changes in https://github.com/Zimbra/zm-web-client/commit/d5ea31d2d168522a3b7a3856caed8ad782a58cab, this was done to make sure we are not packaging timezone data file and always access it through file system to make sure we take care of updates in timezone data

Resolution:
- include AjxTimezoneData.js file wherever DocsPreview package is getting included