### PR TITLE
ZCS-1874 Read Receipt is not working correctly for POP/IMAP accounts

### DIFF
--- a/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
+++ b/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
@@ -2792,9 +2792,25 @@ function(addrNodes) {
 ZmMailMsg.prototype._addReadReceipt =
 function(addrNodes, accountName) {
 	var addrNode = {t:"n"};
-	if (this.identity) {
-		addrNode.a = this.identity.readReceiptAddr || this.identity.sendFromAddress;
-		addrNode.p = this.identity.sendFromDisplay;
+	var identity = this.identity;
+	var ac = window.parentAppCtxt || window.appCtxt;
+
+	if (identity) {
+		addrNode.a = identity.readReceiptAddr || identity.sendFromAddress;
+		addrNode.p = identity.sendFromDisplay;
+
+		// ZCS-1874, if read receipt is for external POP/IMAP account then set proper email and display name
+		if (identity.isFromDataSource) {
+			var dataSource = ac.getDataSourceCollection().getById(identity.id);
+			if (dataSource) {
+				// mail is "from" external account
+				addrNode.a = dataSource.getEmail();
+				if (ac.get(ZmSetting.DEFAULT_DISPLAY_NAME)) {
+					var dispName = dataSource.identity && dataSource.identity.sendFromDisplay;
+					addrNode.p = dispName || dataSource.userName || dataSource.getName();
+				}
+			}
+		}
 	} else {
 		addrNode.a = accountName || appCtxt.getActiveAccount().getEmail();
 	}


### PR DESCRIPTION
Issue:
- For external POP/IMAP account is selected as from address and read receipt is requested then email address to send read receipt was not populating correctly

Resolution:
- in case of external account get email address from datasource instead of getting from identity