### PR TITLE
ZCS-1577 UI interface shifts up when navigating to empty lists in WebClient.

### DIFF
--- a/WebRoot/css/dwt.css
+++ b/WebRoot/css/dwt.css
@@ -498,8 +498,6 @@
 /* Container for the list header */
 .DwtListView-ColHeader {
 	@ListHeaderContainer@
-	position:relative;
-	overflow:hidden;
 }
 
 /* Header for one column of the list */

--- a/WebRoot/skins/_base/base4/ZmSkin.js
+++ b/WebRoot/skins/_base/base4/ZmSkin.js
@@ -22,7 +22,7 @@ function ZmSkin(hints) {
     this.hints = this.mergeObjects(ZmSkin.hints, hints);
 
     if(typeof DwtListView != 'undefined') {
-        DwtListView.HEADERITEM_HEIGHT = 26;
+        DwtListView.HEADERITEM_HEIGHT = 36;
 
         // @TODO change these in core files
         // 5px added as padding to make it 35px

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -880,7 +880,7 @@ AddNewMenuItem              = @MenuItem@; font-style: italic;
 ListContainer                   = @ListBg@ @ListBorder@
 ListContainerWithBorder         = @AppBg@ @NormalInsetBorder@
 
-ListHeaderContainer             = @ListItemHeaderHeight@  @ListColHeaderShadow@  z-index: 1;  @BottomSeparator@ border-left: 4px solid @HeaderColor@;
+ListHeaderContainer             = @ListItemHeaderHeight@  @ListColHeaderShadow@  z-index: 1;  @BottomSeparator@ border-left: 4px solid @HeaderColor@; position:relative; overflow:hidden; box-sizing: border-box;
 
 ListColHeaderContainer          = padding-left: 5px;  @NoWrap@  @OverflowEllipsis@  @ActiveCursor@  @ListItemHeaderHeight@ @BottomSeparator@
 ListColHeaderContainer-normal   = @WidgetHeaderContainer-normal@
@@ -1730,7 +1730,7 @@ WidgetHeight                = height:32px; height:2.65rem;
 ButtonHeight                = height: 36px; height: 3rem;
 TextButtonWidth             = width:60px; overflow:visible;
 ListItemHeight              = height: 38px; height: 3.16rem;
-ListItemHeaderHeight        = height: 35px; height: 2.91rem;
+ListItemHeaderHeight        = height: 35px; height: 2.917rem;
 ListItemHeightDouble        = height: 80px; height: 6.6rem;
 ListItemIconWrapperSize     = width:32px; width:2.667rem
 ListItemBottomRowRightIconSize = width: 1.5em;


### PR DESCRIPTION
ZCS-1577: UI interface shifts up when navigating to empty lists in WebClient.

Issue: There is height calculation that takes place for the list view and for Tasks & Briefcase thats dependent on the height on ListView Header height. The issue was invalid value of constant storing the height value.

Changeset:
* ZmSkin.js: Updating the value of List View header item.
* skin.properties:
  * Updating height relative value to be more specific so that it resolves more close to 35px.
  * Updating property to apply border-box sizing to ListView header item.

**Note:** The height for header node is set to 35px and there’s a 1px bottom border that makes it 36px and the calculations are made based on 36px height for list view.