### PR TITLE
ZCS-1897: Width of the rows in Member list view of Contact Group is not uniform for members added from GAL and by adding email address

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -6804,8 +6804,12 @@ a.ZmLinkDisabled {
 	@ContactGroupItemImage@
 }
 
-.ZmContactGroupItemTable .ZmContactGroupItemContent * {
+.ZmContactGroupItemTable .ZmContactGroupItemContent > DIV {
 	@ContactGroupItemContent@
+}
+
+.ZmContactGroupItemTable .ZmContactGroupItemAction > DIV {
+	@ContactGroupItemViewAction@
 }
 
 .ZmContactInfoView .ZmContactGroupListContent .ZmContactGroupItemTable .ZmContactGroupItemContent {

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1403,6 +1403,7 @@ ContactGroupItemImage               = @ContactChip@;
 ContactGroupItemContent             = @ContactItemName@
 ContactGroupItemViewContentWrapper  =
 ContactGroupItemViewImageWrapper    = padding-left:@ContactViewWrapperPadding@;
+ContactGroupItemViewAction          = display:inline-block; vertical-align:middle; margin:0 0 0 @SkinViewInnerSpacing@;
 
 # Contact Edit View
 ContactImageRadius          = @MediumRoundCorners@

--- a/WebRoot/templates/abook/Contacts.template
+++ b/WebRoot/templates/abook/Contacts.template
@@ -322,12 +322,14 @@
 				<$ if (email) {$>
 					<div>
 						<$=email$>
-						<$ if (data.isInline) {$><$=AjxImg.getImageHtml("Plus", "", quickAdd)$><$ }$>
 					</div>
 				<$}$>
 			</td>
 		<$ if (isEdit) {$>
-			<td width='20' valign='middle' class='ZmContactGroupItemAction'><$=AjxImg.getImageHtml("Close", "", delId)$></td>
+			<td width='20' valign='middle' class='ZmContactGroupItemAction'>
+				<$ if (data.isInline) {$><$=AjxImg.getImageHtml("AddContact", "", quickAdd)$><$ }$>
+				<$=AjxImg.getImageHtml("Close", "", delId)$>
+			</td>
 		<$}$>
 		</tr>
 	</table>


### PR DESCRIPTION
Changes:
* Updated contact edit group row to show `Quick Add to Contact` button when user enters email address in textarea.

https://jira.corp.synacor.com/browse/ZCS-1897