### PR TITLE
ZCS-1890 Universal UI: Account interface update

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -3779,6 +3779,14 @@ HTML>BODY .appt-selected .appt_allday_body
 	@roundCorners(8px 8px 0px 0px)@
 }
 
+.ZOptionsSectionMain td.ZOptionsSubHeadingLabel {
+	@PrefSubHeadingLabel@
+}
+
+.ZOptionsSectionMain td.ZOptionsSubHeadingContent {
+	@PrefSubHeadingContent@
+}
+
 .ZOptionsSectionMain {
 	@PrefSectionContent@
 }

--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
@@ -1904,14 +1904,14 @@ function(id, setup, value) {
 		return listView;
 	}
 	if (id == "TEST") {
-		var button = new DwtButton({parent:this});
+		var button = new DwtButton({parent:this, className: "ZButton ZAltButton"});
 		button.setText(setup.displayName);
 		button.addSelectionListener(new AjxListener(this, this._handleTestButton));
 		return button;
 	}
 	if (id == "WHEN_IN_FOLDER_BUTTON") {
 		var button = new DwtButton({parent:this});
-		button.setImage("SearchFolder");
+		button.setImage("Search");
 		button.addSelectionListener(new AjxListener(this, this._handleFolderButton));
 		return button;
 	}
@@ -1984,7 +1984,7 @@ function() {
 	var deleteButtonDiv = document.getElementById(this._htmlElId+"_DELETE");
 	if (deleteButtonDiv) {
 		var button = new DwtButton({parent:this});
-		button.setText(ZmMsg.del);
+		button.setText(ZmMsg.removeAccount);
 		button.setEnabled(false);
 		button.addSelectionListener(new AjxListener(this, this._handleDeleteButton));
 		this._replaceControlElement(deleteButtonDiv, button);
@@ -2834,7 +2834,7 @@ function(account, field, html) {
 		el = document.getElementById(this._getCellId(account, field)+"_name");
     }
     if(field == ZmItem.F_EMAIL) {
-        html = "<div style='margin-left: 10px;'>"+ html +"</div>";    
+        html = "<div>"+ html +"</div>";
     }
 	el.innerHTML = html;
 };
@@ -2868,7 +2868,7 @@ function(buffer, i, item, field, col, params) {
         var email = item.getEmail();
         var identity = item.getIdentity();
         if (!item.isMain && identity.sendFromAddressType == ZmSetting.SEND_ON_BEHALF_OF) email = appCtxt.getActiveAccount().name + " " + ZmMsg.sendOnBehalfOf + " " + email;
-		buffer[i++] = "<div style='margin-left: 10px;'>"+ AjxStringUtil.htmlEncode(email) +"</div>";
+		buffer[i++] = "<div>"+ AjxStringUtil.htmlEncode(email) +"</div>";
 		return i;
 	}
 	if (field == ZmItem.F_TYPE) {
@@ -2887,7 +2887,7 @@ ZmAccountsListView.prototype._getHeaderList =
 function() {
 	return [
 		new DwtListHeaderItem({field:ZmItem.F_NAME, text:ZmMsg.accountName, width:ZmAccountsListView.WIDTH_NAME}),
-		new DwtListHeaderItem({field:ZmItem.F_STATUS, text:ZmMsg.status, width:ZmAccountsListView.WIDTH_STATUS, align:"center"}),
+		new DwtListHeaderItem({field:ZmItem.F_STATUS, text:ZmMsg.status, width:ZmAccountsListView.WIDTH_STATUS}),
 		new DwtListHeaderItem({field:ZmItem.F_EMAIL, text:ZmMsg.emailAddr}),
 		new DwtListHeaderItem({field:ZmItem.F_TYPE, text:ZmMsg.type, width:ZmAccountsListView.WIDTH_TYPE})
 	];
@@ -2938,7 +2938,7 @@ function(account, field, html) {
 		el = document.getElementById(this._getCellId(account, field)+"_name");
     }
     if(field == ZmItem.F_EMAIL) {
-        html = "<div style='margin-left: 10px;'>"+ html +"</div>";
+        html = "<div>"+ html +"</div>";
     }
 	el.innerHTML = html;
 };
@@ -2951,7 +2951,7 @@ function(buffer, i, item, field, col, params) {
 		var cellId = this._getCellId(item, field);
 		buffer[i++] = "<div id='";
 		buffer[i++] = cellId;
-		buffer[i++] = "_name' style='margin:0 5px; overflow:hidden;'>";
+		buffer[i++] = "_name' style='overflow:hidden;'>";
 		buffer[i++] = AjxStringUtil.htmlEncode(item.user);
 		buffer[i++] = "</div>";
 		return i;
@@ -2960,7 +2960,7 @@ function(buffer, i, item, field, col, params) {
         var cellId = this._getCellId(item, field);
 		buffer[i++] = "<div id='";
 		buffer[i++] = cellId;
-		buffer[i++] = "_type' style='margin:0 5px;'>";
+		buffer[i++] = "_type'>";
 		buffer[i++] = (item.sendAs && item.sendOnBehalfOf)  ? ZmMsg.sendAsAndSendOnBehalfOf : (item.sendAs ? ZmMsg.sendAs : ZmMsg.sendOnBehalfOflbl);
 		buffer[i++] = "</div>";
 		return i;

--- a/WebRoot/messages/ZmMsg.properties
+++ b/WebRoot/messages/ZmMsg.properties
@@ -2819,6 +2819,7 @@ remindersConfigure = Configure
 remindersConfigureNow = Configure Now
 remove = Remove
 removeAddr = Remove {0}
+removeAccount = Remove Account
 removeAll = Remove All
 removeAllAttachments = Remove All
 removed = Removed:
@@ -4239,9 +4240,9 @@ COLUMN_WIDTH_DATE_CALL = 180
 COLUMN_WIDTH_FROM_CALL = 300
 
 # accounts list view (prefs)
-COLUMN_WIDTH_NAME_ACC = 170
-COLUMN_WIDTH_STATUS_ACC = 80
-COLUMN_WIDTH_TYPE_ACC = 85
+COLUMN_WIDTH_NAME_ACC = 250
+COLUMN_WIDTH_STATUS_ACC = 140
+COLUMN_WIDTH_TYPE_ACC = 110
 
 # applications list view
 COLUMN_WIDTH_NAME_APPLICATION = 200

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -2247,6 +2247,7 @@ PrefViewWrapperPadding      = @SkinViewContentPadding@
 PrefViewFontSize            = @FontSize-slightly-big@
 PrefViewGutterSpace         = @SkinViewGutterSpace@
 PrefViewInnerSpacing        = @SkinViewInnerSpacing@
+PrefSubHeadingSpacing       = 50px
 
 PrefView                    = @FixBoxModel@; @FullWidth@; padding:@PrefViewWrapperPadding@; @PrefViewFontSize@;
 PrefSectionHeaderWrapper    = display:flex; justify-content:space-between; align-items:center;
@@ -2270,7 +2271,9 @@ CheckWidgetInputText        = padding-top:0; padding-bottom:0; height:auto; line
 PrefHeaderComment           = margin-bottom: 24px;
 PrefSharingViewActionIcon   = margin: 0 4px; fill: @darken(AppC, 70)@;
 PrefShareFormContainer      = border-spacing: 0 0.5em; border-collapse: separate;
-   
+PrefSubHeadingLabel         = font-weight:bold; padding-top: @PrefSubHeadingSpacing@;
+PrefSubHeadingContent       = padding-top: @PrefSubHeadingSpacing@;
+
 ######################################
 #   WhiteBlackList SPECIFIC STUFF
 ######################################

--- a/WebRoot/templates/prefs/Pages.template
+++ b/WebRoot/templates/prefs/Pages.template
@@ -967,7 +967,7 @@ and the container element is replaced with that control.
 						</tr>
 					<$ } $>
 					<tr><td colspan=2></td></tr>
-					<tr><td style='text-align:left' colspan=2><b><$=ZmMsg.accountFromPrompt$></b></td></tr>
+					<tr><td class='ZOptionsSubHeadingLabel' colspan=2><$=ZmMsg.accountFromPrompt$></td></tr>
 					<tr>
 						<td class='ZOptionsLabel'><$=ZmMsg.fromLabel$></td>
 						<td class='ZOptionsField'><$=ZmMsg.fromDetail$></td>
@@ -1009,18 +1009,23 @@ and the container element is replaced with that control.
 					<tr><td colspan=2></td></tr>
 					<$ if (appCtxt.get(ZmSetting.TWO_FACTOR_AUTH_AVAILABLE)) { $>
 						<tr valign=top>
-							<td class='ZOptionsLabel'><$=ZmMsg.twoStepAccountSecurity$></td>
-							<td class='ZOptionsField' valign='middle'>
-								<span id='${id}_TWO_STEP_AUTH'>
+							<td class='ZOptionsLabel ZOptionsSubHeadingLabel'><$=ZmMsg.twoStepAccountSecurity$></td>
+							<td class='ZOptionsField ZOptionsSubHeadingContent' valign='middle'>
+								<div id='${id}_TWO_STEP_AUTH'>
 									<$ if (appCtxt.get(ZmSetting.TWO_FACTOR_AUTH_ENABLED)) { $>
 										<$=ZmMsg.twoStepAuth$>
 									<$ } $>
 									<$ else { $>
 										<$=ZmMsg.twoStepStandardAuth$>
 									<$ } $>
-								</span>
+								</div>
+							</td>
+						</tr>
+						<tr>
+							<td class='ZOptionsLabel'>&nbsp;</td>
+							<td class='ZOptionsField ZOptionsSubField'>
 								<$ if (!appCtxt.get(ZmSetting.TWO_FACTOR_AUTH_REQUIRED)) { $>
-									<a style="margin:20px;" href="#" id='${id}_TWO_STEP_AUTH_LINK'>
+									<a href="#" id='${id}_TWO_STEP_AUTH_LINK'>
 										<$ if (appCtxt.get(ZmSetting.TWO_FACTOR_AUTH_ENABLED)) { $>
 											<$=ZmMsg.twoStepAuthDisableLink$>
 										<$ } $>
@@ -1091,8 +1096,8 @@ and the container element is replaced with that control.
 						<tr><td colspan=2></td></tr>
 					<$ } $>
 					<tr>
-						<td class='ZOptionsLabel'><$=ZmMsg.delegatesLabel$></td>
-						<td style='text-align:left'><$=ZmMsg.delegateRightsPrompt$></td></tr>
+						<td class='ZOptionsLabel ZOptionsSubHeadingLabel'><$=ZmMsg.delegatesLabel$></td>
+						<td style='text-align:left' class='ZOptionsSubHeadingContent'><$=ZmMsg.delegateRightsPrompt$></td></tr>
 					<tr>
 						<td></td>
 						<td>
@@ -1222,7 +1227,7 @@ and the container element is replaced with that control.
 					</tr>
 					<tr><td colspan=2></td></tr>
 					<tr>
-						<td class='ZOptionsLabel' style='text-align:left' colspan=2><$=ZmMsg.accountFromPrompt$></td>
+						<td class='ZOptionsLabel ZOptionsSubHeadingLabel' colspan=2><$=ZmMsg.accountFromPrompt$></td>
 					</tr>
 					<tr>
 						<td class='ZOptionsLabel'><$=ZmMsg.fromLabel$></td>
@@ -1288,7 +1293,7 @@ and the container element is replaced with that control.
 					</tr>
 					<tr><td colspan=2></td></tr>
 					<tr>
-						<td class='ZOptionsLabel' style='text-align:left' colspan=2><$=ZmMsg.accountFromPrompt$></td>
+						<td class='ZOptionsLabel ZOptionsSubHeadingLabel' colspan=2><$=ZmMsg.accountFromPrompt$></td>
 					</tr>
 					<tr>
 						<td class='ZOptionsLabel'><$=ZmMsg.fromLabel$></td>


### PR DESCRIPTION
ZCS-1890 Universal UI: Account interface update

Changeset:
 * zm.css: Adding style rules to target preferences sub-heading label & its content selectors. (css classesZOptionsSubHeadingLabel & ZOptionsSubHeadingContent)
 * ZmAccountsPage.js:
   *  Update buttons to use ZAltButton styles.
   *  Update searchFolder icon to Search icon.
   *  Updated button label from “Delete” to “Remove Account”
 * ZmMsg.properties: Updating the strings & widths of preferences account section columns.
 * skin.properties: Updating related style variables.
 * Pages.template: Updating template for layout changes & adding css classes for subheadings.