### PR TITLE
ZCS-2394: Universal UI: Match the text input width of elements in all the sections in the Preferences

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -3830,6 +3830,11 @@ HTML>BODY .appt-selected .appt_allday_body
 	padding-right: 0;
 }
 
+.ZOptionsField .DwtInputField.ZmPrefInputField input[type='text'],
+.ZOptionsField input[type='text'].ZmPrefInputField {
+	@PrefInputTextControl@
+}
+
 /* Out-of-Office preference section */
 .ZmOutOfOfficeWrapper {
 	@PrefOOOWrapper@

--- a/WebRoot/js/zimbraMail/prefs/view/ZmPreferencesPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmPreferencesPage.js
@@ -859,7 +859,8 @@ function(id, setup, value) {
 		maxLen:setup.maxLen,
 		hint: setup.hint,
 		label: setup.label,
-		id: "Prefs_Input_" + id
+		id: "Prefs_Input_" + id,
+		className: (setup.className || "ZmPrefInputField") + " DwtInputField" 
 	};
 	var input = new DwtInputField(params);
 	this.setFormObject(id, input);

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -2302,6 +2302,7 @@ PrefShareFormContainer      = border-spacing: 0 0.5em; border-collapse: separate
 PrefSubHeadingLabel         = font-weight:bold; padding-top: @PrefSubHeadingSpacing@;
 PrefSubHeadingContent       = padding-top: @PrefSubHeadingSpacing@;
 PrefRowHint                 = line-height:20px; padding:5px 0;
+PrefInputTextControl        = width:@PrefRowControlWidth@; max-width:100%;
 
 ######################################
 #   WhiteBlackList SPECIFIC STUFF


### PR DESCRIPTION
Fix:
* Added new class `ZmPrefInputField` which can be applied directly to `input[type=text]` field or `DwtInputWidget` object.
* In preference section, almost all input control are created by method named `ZmPreferencesPage.prototype._setupInput`. So added this newly created class to all controls created by this method.
* In this case original class `DwtInputField` has also been kept to preserve other functionalities. (like disabled state etc.)
* In case input control is created with template, we can add class `ZmPrefInputField ` in template to retain staying.
* Tested across different preference section. Also inline inputs and other combos has no effect on this and seems to be working fine.

https://jira.corp.synacor.com/browse/ZCS-2394