### PR TITLE
ZCS-2450 Style the drag proxy element for Contact list

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -1944,11 +1944,11 @@ div.CompDragArea * {
 	@ContactListView@
 }
 
-.ZmContactSimpleView .SimpleContact {
+.SimpleContact {
 	@ContactListItem@
 }
 
-.ZmContactSimpleView .SimpleContact > DIV {
+.SimpleContact > DIV {
 	@ContactListItemContainer@
 }
 
@@ -1961,25 +1961,25 @@ div.CompDragArea * {
 	@DragBg@
 }
 
-.ZmContactSimpleView .SimpleContact .ImgCheckboxUnchecked-svg,
-.ZmContactSimpleView .SimpleContact .ImgCheckboxChecked-svg {
+.SimpleContact .ImgCheckboxUnchecked-svg,
+.SimpleContact .ImgCheckboxChecked-svg {
 	@ContactItemCheckIcon@
 }
 
-.ZmContactSimpleView .SimpleContact .ZmContactIcon .svg-icon,
-.ZmContactSimpleView .SimpleContact .ZmContactIcon IMG {
+.SimpleContact .ZmContactIcon .svg-icon,
+.SimpleContact .ZmContactIcon IMG {
 	@ContactItemIcon@
 }
 
-.ZmContactSimpleView .SimpleContact .ZmContactName {
+.SimpleContact .ZmContactName {
 	@ContactItemName@
 }
 
-.ZmContactSimpleView .SimpleContact .ZmListFlagsWrapper {
+.SimpleContact .ZmListFlagsWrapper {
 	@ContactItemFilterList@
 }
 
-.ZmContactSimpleView .SimpleContact .ZmListFlagsWrapper DIV {
+.SimpleContact .ZmListFlagsWrapper DIV {
 	@ContactItemFilterItem@
 }
 

--- a/WebRoot/js/zimbraMail/abook/view/ZmContactSplitView.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmContactSplitView.js
@@ -1036,7 +1036,7 @@ ZmContactSimpleView = function(params) {
 	params.className = "ZmContactSimpleView";
 	ZmContactsBaseView.call(this, params);
 
-	this._normalClass = DwtListView.ROW_CLASS + " SimpleContact";
+	this._normalClass = "SimpleContact " + DwtListView.ROW_CLASS;
 	this._selectedClass = [DwtListView.ROW_CLASS, DwtCssStyle.SELECTED].join("-");
 };
 
@@ -1193,12 +1193,6 @@ function(contact, params, asHtml, count) {
 		var div = this._getDiv(contact, params);
 	}
 	var folder = this._folderId && appCtxt.getById(this._folderId);
-	if (div) {
-		if (params.isDragProxy) {
-			div.style.width = "175px";
-			div.style.padding = "4px";
-		}
-	}
 
 	idx = this._getRow(htmlArr, idx, contact, params);
 


### PR DESCRIPTION
**Fix Description**: 
The new styling changes which includes CSS selectors were targeting elements inside the ListView (ZmContactSimpleView). In case of proxy element, there’s no context of the ListView or its classes & thus partially some rules were not getting applied on the proxy & was breaking the UI. Fix the issue by removing the scope of the list view class & depending only on the Contact row specific class “SimpleContact”.

**Changeset**:
 * zm.css: Updated Row specific style selectors to not depend on the listview  class ZmContactSimpleView  but on the specific class i.e. SimpleContact only
 * ZmContactSplitView.js:
   *  Removing dragProxy specific logic for changing width/padding. Matching the UI element to be same as the list item element.
   *  Changing the order of row class for the Contact list item so that a consistent class name is applied across the apps for dragProxy. (Row-dragProxy)