### PR TITLE
ZCS-2282 Build script changes for deploying timezone files in dev setup

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -117,7 +117,7 @@
 			<equals arg1="${zimbra.buildinfo.type}" arg2="NETWORK" />
 		</condition>
         <property name='common.web.includes' value='${custom.web.includes},js/**,css/**'/>
-        <property name='common.web.excludes' value='${custom.web.excludes},js/*/package/**,**/AjxTimezoneData.js'/>
+        <property name='common.web.excludes' value='${custom.web.excludes},js/*/package/**'/>
         <property name='common.jsp.includes' value='${custom.jsp.includes},**'/>
         <property name='common.jsp.excludes' value='${custom.jsp.excludes}'/>
         <property name='common.img.includes' value='${custom.img.includes},**'/>
@@ -1148,7 +1148,24 @@ ext = BeanUtils.cook(ext);
         <unzip dest='${webapp.dir}' src="${webapp.file}"/>
 
         <antcall target='webxml-deploy-replace'/>
+        <antcall target='timezones-deploy'/>
         <antcall target='restart-webserver'/>
+    </target>
+
+    <!-- Timezone data is packaged separately so for dev setup we need to manually copy that data -->
+    <target name='timezones-deploy' depends='resolve'>
+        <!-- Download timezones zip -->
+        <ivy:install organisation='zimbra' module='zm-timezones' revision='latest.integration' settingsRef='dev.settings' from='chain-resolver-zip' to='build-tmp' overwrite='true' transitive='true' type='zip' />
+
+        <unzip dest='${build.tmp.dir}/zm-timezones' overwrite='true'>
+            <fileset dir='${build.tmp.dir}'>
+                <include name='**/zm-timezones-*.zip' />
+            </fileset>
+        </unzip>
+
+        <!-- Deploy files to desired locations -->
+        <chmod file='${build.tmp.dir}/zm-timezones/bin/deploy-timezones' perm='a+x'/>
+        <exec executable='${build.tmp.dir}/zm-timezones/bin/deploy-timezones' />
     </target>
 
     <target name='webxml-package-replace' depends='init'>


### PR DESCRIPTION
- fix of https://github.com/Zimbra/zm-web-client/pull/110#discussion_r131870886 introduced a change which broke dev setup
- for dev setup, we will copy timezone files after deploying webapp and extracting it