### PR TITLE
ZCS-1216 :- Universal UI - Browse for vcard modal, visual update

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -3572,22 +3572,56 @@ HTML>BODY .appt-selected .appt_allday_body
 }
 
 .ZmContactSearch {
-	width:500px;
+	@ContactSearchWidget@
 }
+
 .ZmContactSearch .contactSearchResultsDiv {
-	margin-top:15px;
+	@ContactSearchResultsContainer@
 }
 
 .ZmContactSearch .ZmContactSearchListView {
-	width:100%;
-	height:300px;
-	background-color:white;
+	@ContactSearchListContainer@
 }
 
 .ZmContactSearch .searchFieldHint {
-	@Text-light@
+	@ContactSearchInputFieldHint@
 }
 
+.ZmContactSearch INPUT[type="text"] {
+	@ContactSearchInputField@
+}
+
+.ZmContactSearch .Row {
+	@ContactSearchListRow@
+}
+
+.ZmContactSearch .Row-selected {
+	@ContactSearchListRowSelected@
+}
+
+.ZmContactSearch .ZmContactGroupItemContent > div {
+	@ContactSearchContactGroupItemContent@
+}
+
+.ZmContactSearch .Row div {
+	@ContactSearchListRowItems@
+}
+
+.ZmContactSearchDialog .WindowOuterContainer {
+	@ContactSearchDialogOuterContainer@
+}
+
+.ZmContactSearchTable {
+	@ContactSearchQueryWidget@
+}
+
+.ZmContactSearchButton {
+	@ContactSearchButton@
+}
+
+.ZmContactSearchListView .Row  table > tbody > tr > td {
+	@ContactSearchGroupItemTableCell@;
+}
 
 /*
  *  Autocompletion

--- a/WebRoot/js/zimbraMail/abook/view/ZmContactSearch.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmContactSearch.js
@@ -125,8 +125,6 @@ function(ascending, firstTime, lastId, lastSortVal) {
 		}
 	}
 
-	this._searchIcon.className = "DwtWait16Icon";
-
 	// XXX: line below doesn't have intended effect (turn off column sorting for GAL search)
 //	this._chooser.sourceListView.sortingEnabled = (this._contactSource == ZmItem.CONTACT);
 
@@ -157,7 +155,6 @@ function(firstTime, result) {
 		}
 	}
 
-	this._searchIcon.className = "ImgSearch";
 	this._searchButton.setEnabled(true);
 };
 
@@ -210,16 +207,9 @@ function() {
 
 	this.getHtmlElement().innerHTML = this._contentHtml();
 
-	if (this._options.preamble) {
-		var div = document.getElementById(this._htmlElId + "_preamble");
-		div.innerHTML = this._options.preamble;
-	}
-
-	this._searchIcon = document.getElementById(this._htmlElId + "_searchIcon");
-
 	// add search button
 	this._searchButton = new DwtButton({parent:this, parentElement:(this._htmlElId + "_searchButton")});
-	this._searchButton.setText(ZmMsg.search);
+	this._searchButton.setImage("Search2");
 	this._searchButton.addSelectionListener(new AjxListener(this, this._searchButtonListener));
 
 	// add select menu, if needed
@@ -428,10 +418,24 @@ ZmContactSearchListView.prototype._getHeaderList =
 function() {
 	var headerList = [];
 	headerList.push(new DwtListHeaderItem({field:ZmItem.F_TYPE, width:ZmMsg.COLUMN_WIDTH_FOLDER_CN}));
-	headerList.push(new DwtListHeaderItem({field:ZmItem.F_NAME, text:ZmMsg._name, width:ZmMsg.COLUMN_WIDTH_NAME_CN}));
-	headerList.push(new DwtListHeaderItem({field:ZmItem.F_EMAIL, text:ZmMsg.email}));
-
+	headerList.push(new DwtListHeaderItem({field:ZmItem.F_NAME, text:ZmMsg._name}));
 	return headerList;
+};
+
+// Overriding the DwtListView.prototype.createHeaderHtml as we donot need a header, here.
+
+ZmContactSearchListView.prototype.createHeaderHtml =
+function(defaultColumnSort, isColumnHeaderTableFixed) {
+	return;
+};
+
+ZmContactSearchListView.prototype._getCellClass =
+function(item, field) {
+	if (field == ZmItem.F_TYPE) {
+		return "ZmContactGroupItemImage";
+	} else if (field == ZmItem.F_NAME) {
+		return "ZmContactGroupItemContent";
+	}
 };
 
 /**
@@ -440,11 +444,20 @@ function() {
 ZmContactSearchListView.prototype._getCellContents =
 function(htmlArr, idx, contact, field, colIdx, params) {
 	if (field == ZmItem.F_TYPE) {
-		htmlArr[idx++] = AjxImg.getImageHtml(contact.getIcon());
+		var avatarUrl = contact.getImageUrl();
+		if (avatarUrl) {
+			htmlArr[idx++] = "<div class='ZmContactIcon'>";
+			htmlArr[idx++] = "<img src='" + avatarUrl + "' alt='" + contact.getFullName() + "' />";
+			htmlArr[idx++] = "</div>";
+		} else {
+			htmlArr[idx++] = AjxImg.getImageHtml(contact.getIcon());
+		}
 	} else if (field == ZmItem.F_NAME) {
+		htmlArr[idx++] = "<div><strong>";
 		htmlArr[idx++] = AjxStringUtil.htmlEncode(contact.getFileAs());
-	} else if (field == ZmItem.F_EMAIL) {
+		htmlArr[idx++] = "</strong></div><div>";
 		htmlArr[idx++] = AjxStringUtil.htmlEncode(contact.getEmail());
+		htmlArr[idx++] = "</div>";
 	}
 	return idx;
 };

--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
@@ -3198,7 +3198,7 @@ ZmGrantRightsDialog = function(parent, className, callback) {
 	this._addrInputField.reparentHtmlElement(cellId);
 	this._initAutoComplete();
 	var okBtn = this.getButton(DwtDialog.OK_BUTTON);
-	okBtn.setText(ZmMsg.save);
+	okBtn.setText(ZmMsg.attach);
 };
 
 ZmGrantRightsDialog.prototype = new ZmDialog;

--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmSignaturesPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmSignaturesPage.js
@@ -1163,10 +1163,13 @@ ZmVcardPicker = function(params) {
 	params = params || {};
 	params.parent = appCtxt.getShell();
 	params.title = ZmMsg.selectContact;
+	params.className = 'ZmContactSearchDialog'
 	DwtDialog.call(this, params);
 
 	this._sigPage = params.sigPage;
 	this.setButtonListener(DwtDialog.OK_BUTTON, new AjxListener(this, this._okButtonListener));
+	var okBtn = this.getButton(DwtDialog.OK_BUTTON);
+	okBtn.setText(ZmMsg.attach);
 };
 
 ZmVcardPicker.prototype = new DwtDialog;

--- a/WebRoot/messages/ZmMsg.properties
+++ b/WebRoot/messages/ZmMsg.properties
@@ -816,7 +816,7 @@ contactCreated = Contact Created
 contactGroupToolTip = Create a new contact group
 contactList = List
 contactLists = Contact Lists
-contactPickerHint = Type recipient's name here.
+contactPickerHint = Type a name or email to search.
 contactPickerEmailHint = Type recipient's email address here.
 contactPickerDepartmentHint = Type recipient's department here.
 contactPickerPhoneticHint = Type recipient's phonetic name here.
@@ -3036,7 +3036,7 @@ selectAddrText = Sorting on recipient is currently unavailable. Instead, you may
 selectAllMembers = Select all {0} addresses
 selectAfterDeleteLabel = Message Selection:
 selectAlternateLocation = Select Alternate Location
-selectContact = Select Contact
+selectContact = Attach Contact as vCard
 selectIdentityWhen = Select this identity when:
 selectiveCallForwardingDescription = Forward <b>only</b> the following numbers to:
 selectiveCallForwardingError = The selective call forwarding number is invalid
@@ -4217,7 +4217,7 @@ COLUMN_WIDTH_PCOMPLETE_TLV = 80
 COLUMN_WIDTH_STATUS_TLV = 105
 
 # contact picker, group list
-COLUMN_WIDTH_FOLDER_CN = 20
+COLUMN_WIDTH_FOLDER_CN = 50
 COLUMN_WIDTH_NAME_CN = 100
 COLUMN_WIDTH_DEPARTMENT_CN = 100
 COLUMN_WIDTH_TYPE_CN = 20

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1478,6 +1478,22 @@ ContactListPaginationChild          = display:inline-block;
 ContactListPaginationLink           = 
 ContactListPaginationLinkIcon       = height:30px; width:30px;
 
+# Contact Search
+
+ContactSearchWidget                    = width:500px;
+ContactSearchResultsContainer          = margin-top:@SkinWrapperPadding@; @PanelBorder@
+ContactSearchListContainer             = @FullWidth@; @PageBg@; height:300px;
+ContactSearchInputField                = @InputPadding@; @ButtonHeight@; @NoWrap@; border-width: 0 1px 0 0; width:93%;
+ContactSearchListRow                   = @GroupEditContentListRow@;
+ContactSearchListRowSelected           = @GroupEditContentListRowSelected@;
+ContactSearchContactGroupItemContent   = @ContactGroupItemContent@
+ContactSearchListRowItems              = @GroupEditContentListRowText@
+ContactSearchDialogOuterContainer      = @DialogBackGroundColor@
+ContactSearchQueryWidget               = @FullWidth@; @PanelBorder@;
+ContactSearchButton                    = float:right; width:7%; @ButtonHeight@;
+ContactSearchGroupItemTableCell        = @ContactGroupItemTableCell@; padding-right:0px;
+ContactSearchInputFieldHint            = @Text-hint@
+
 # DL view create/edit
 DLEditViewWrapper           =
 DLEditViewHeader            = border-bottom:none; padding-bottom:0;

--- a/WebRoot/templates/abook/Contacts.template
+++ b/WebRoot/templates/abook/Contacts.template
@@ -1109,26 +1109,26 @@
 <!------------------------------ ZmContactSearch ------------------------------>
 <!----------------------------------------------------------------------------->
 <template id='abook.Contacts#ZmContactSearch'>
-	<div id='${id}_preamble'></div>
 	<table role="presentation" width='100%'>
 		<tr>
 			<td>
-				<table role="presentation">
+				<table class='ZmContactSearchTable' role="presentation">
 					<tr>
-						<td width='20' valign='middle'><div id='${id}_searchIcon' class='ImgSearch'></div></td>
-						<td><input type='text' autocomplete='off' size='30' nowrap id='${id}_searchField'>&nbsp;</td>
-						<td id='${id}_searchButton'></td>
+						<td>
+							<input type='text' autocomplete='off' size='30' id='${id}_searchField'>
+							<span class='ZmContactSearchButton' id='${id}_searchButton'></span>
+						</td>
 					</tr>
 				</table>
 			</td>
 			<td align='right'>
 				<$ if (data.showSelect) { $>
-					<table role="presentation">
-						<tr>
-							<td class='Label nobreak'><$= ZmMsg.showNames $>&nbsp;</td>
-							<td id='${id}_folders'></td>
-						</tr>
-					</table>
+				<table role="presentation">
+					<tr>
+						<td class='Label nobreak'><$= ZmMsg.showNames $>&nbsp;</td>
+						<td id='${id}_folders'></td>
+					</tr>
+				</table>
 				<$ } $>
 			</td>
 		</tr>


### PR DESCRIPTION
Desc:- Changes done to the layout to adjust the look and feel as similar to mock up.

Added support for avatar image if present in contact .
Overriding the DwtListView.prototype.createHeaderHtml as we donot need a header.
Using image instead of text for search.
Added code to add classes to contact search results list cell.

Changeset :-
WebRoot/css/zm.css
WebRoot/js/zimbraMail/abook/view/ZmContactSearch.js
WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
WebRoot/js/zimbraMail/mail/view/prefs/ZmSignaturesPage.js
WebRoot/messages/ZmMsg.properties
WebRoot/skins/_base/base4/skin.properties
WebRoot/templates/abook/Contacts.template