### PR TITLE
ZCS-2449 Universal UI - Folder Properties Dialog

### DIFF
--- a/WebRoot/css/common.css
+++ b/WebRoot/css/common.css
@@ -166,6 +166,11 @@ INPUT[type="password"] {
 	@InputField@
 	@InputField-normal@
 }
+
+INPUT[type="number"] {
+	@InputFieldNumber@
+}
+
 INPUT[disabled] {
 	@InputField-disabled@
 }

--- a/WebRoot/css/dwt.css
+++ b/WebRoot/css/dwt.css
@@ -659,7 +659,7 @@ UL.DwtListView-Rows {
 	@Label@
 }
 .DwtDialog .Field {
-	width:290px;
+	@DialogField@
 }
 .DwtDialog TEXTAREA {
 	width:100%;
@@ -758,7 +758,6 @@ UL.DwtListView-Rows {
 /* MERGE WITH ZmFieldLabelRight ? */
 .DwtPropertySheet .Label {
 	@Label@
-	text-align:right;
 }
 .DwtPropertySheet>TABLE {
 	@PropertySheet@

--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -6086,26 +6086,24 @@ DIV .SuggestBtn {
 	
 }
 
-.ZmFolderRetentionLabel {
-	font-weight:bold;
-	text-align:left;
-	white-space:nowrap;
+.ZmFolderRetentionLabel{
+	@FolderPropertyDialogHeadingContainer@
 }
 
-.ZmFolderPolicyAmountInput {
-	height:1.6rem;
-	margin-left:20px;
-	width:60px;
-}
-.ZmFolderPolicyUnitSelect {
-	margin-left:4px;
+.ZmFolderRetentionLabel label {
+	@FolderPropertyDialogHeading@
 }
 
-.ZmFolderPolicySelect {
-	margin-left:4px;
+.ZmFolderRetentionCheckbox {
+	@FolderPropertyDialogCheckbox@
 }
+
+INPUT[type="text"].ZmFolderPolicyAmountInput {
+	@FolderPropertyRetentionInput@
+}
+
 .ZmFolderPolicySelection {
-	width:100%;
+	@FolderPropertyPolicyContainer@
 }
 
 .ZmDialogTabViewBusy {
@@ -6114,21 +6112,15 @@ DIV .SuggestBtn {
 }
 
 .ZmFolderPropertiesDialog-container {
-	margin:-8px -8px 0px;
-	overflow:hidden;
-	width:500px;
+	@FolderPropertyDialogContainer@
 }
 
 .ZmFolderPropertiesDialog-container .ZTabBar {
 	background: @AppC@;
 }
 
-.ZmFolderPropertyView .ZHasDropDown{
-	display:inline-block;
-}
-
 .ZmFolderPropertyView {
-	margin:10px;
+	@FolderPropertyView@
 }
 
 .ZmFolderPropSharing {

--- a/WebRoot/js/zimbraMail/share/model/ZmShare.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmShare.js
@@ -148,6 +148,11 @@ ZmShare.ACTION_LABEL[ZmShare.EDIT]		= ZmMsg.edit;
 ZmShare.ACTION_LABEL[ZmShare.RESEND]	= ZmMsg.resend;
 ZmShare.ACTION_LABEL[ZmShare.REVOKE]	= ZmMsg.revoke;
 
+ZmShare.ACTION_ICON = {};
+ZmShare.ACTION_ICON[ZmShare.EDIT]	= "Edit";
+ZmShare.ACTION_ICON[ZmShare.RESEND]	= "MsgStatusSent";
+ZmShare.ACTION_ICON[ZmShare.REVOKE]	= "Close";
+
 // allowed permission bits
 /**
  * Defines the "read" allowed permission.

--- a/WebRoot/js/zimbraMail/share/view/ZmColorButton.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmColorButton.js
@@ -28,6 +28,9 @@ ZmColorButton = function(params) {
     }
 
     DwtButton.call(this, params);
+    //to make color button visually look like select widget.
+    this.addClassName("ZSelect");
+
     var menu = new ZmColorMenu({parent:this,hideNone:params.hideNone});
     menu.addSelectionListener(new AjxListener(this, this._handleSelection));
     this.setMenu(menu);

--- a/WebRoot/js/zimbraMail/share/view/ZmShareReply.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmShareReply.js
@@ -191,7 +191,7 @@ ZmShareReply.prototype._initControl = function(params) {
 	div.appendChild(this._replyNoteEl);
 	
 	this._replyControlsEl = doc.createElement("DIV");
-	this._replyControlsEl.style.marginLeft = "1.5em";
+	this._replyControlsEl.style.marginTop = "1em";
 	this._replyControlsEl.appendChild(this._replyTypeEl);
 	this._replyControlsEl.appendChild(this._replyStandardMailNoteEl);
 	this._replyControlsEl.appendChild(div);

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropertyView.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropertyView.js
@@ -183,14 +183,16 @@ function(event) {
     }
 
 	if (organizer.isSystem() || organizer.isDataSource()) {
-		this._nameOutputEl.innerHTML = AjxStringUtil.htmlEncode(organizer.name);
-        Dwt.setVisible(this._nameOutputEl, true);
-        Dwt.setVisible(this._nameInputEl,  false);
+		Dwt.setVisible(this._nameInputEl,  true);
+		this._nameInputEl.value = organizer.name;
+		this._nameInputEl.disabled = true;
+		this._nameInputEl.style.cursor = "not-allowed";
 	}
 	else {
 		this._nameInputEl.value = organizer.name;
-        Dwt.setVisible(this._nameOutputEl, false);
-        Dwt.setVisible(this._nameInputEl,  true);
+		this._nameInputEl.disabled = false;
+		Dwt.setVisible(this._nameInputEl,  true);
+		this._nameInputEl.style.cursor = "text";
 	}
 
 	var hasFolderInfo = !!organizer.getToolTip();
@@ -288,14 +290,15 @@ function(response) {
 ZmFolderPropertyView.prototype._createView = function() {
 
 	// create html elements
-	this._nameOutputEl = document.createElement("SPAN");
 	this._nameInputEl = document.createElement("INPUT");
-	this._nameInputEl.style.width = "20em";
+	this._nameInputEl.setAttribute("type", "text");
+	Dwt.addClass(this._nameInputEl, "Field");
 	this._nameInputEl._dialog = this;
 	var nameElement = this._nameInputEl;
 
 	this._queryInputEl = document.createElement("INPUT");
-	this._queryInputEl.style.width = "20em";
+	this._queryInputEl.setAttribute("type", "text");
+	Dwt.addClass(this._queryInputEl, "Field");
 	this._queryInputEl._dialog = this;
 	var queryElement = this._queryInputEl;
 
@@ -309,7 +312,6 @@ ZmFolderPropertyView.prototype._createView = function() {
 	this._sizeEl = document.createElement("SPAN");
 
 	var nameEl = document.createElement("DIV");
-	nameEl.appendChild(this._nameOutputEl);
 	nameEl.appendChild(nameElement);
 
 	var queryEl = document.createElement("DIV");
@@ -335,7 +337,7 @@ ZmFolderPropertyView.prototype._createView = function() {
     if (appCtxt.isWebClientOfflineSupported) {
         this._offlineEl = document.createElement("DIV");
 		this._offlineEl.style.whiteSpace = "nowrap";
-		this._offlineEl.innerHTML = ZmMsg.offlineFolderSyncInterval;
+		this._offlineEl.innerHTML = AjxMessageFormat.format(ZmMsg.offlineFolderSyncInterval, '<input id="folderOfflineLblId" class="ZmOfflineSyncInterval" type="number" min="0" max="30">');
         this._offlineId = this._props.addProperty(ZmMsg.offlineLabel,  this._offlineEl);
     }
 

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
@@ -54,6 +54,7 @@ ZmFolderPropsDialog = function(parent, className) {
 
 	if (appCtxt.get(ZmSetting.SHARING_ENABLED))	{
 		this.registerCallback(ZmFolderPropsDialog.ADD_SHARE_BUTTON, this._handleAddShareButton, this);
+		this.getButton(ZmFolderPropsDialog.ADD_SHARE_BUTTON).addClassName("ZInlineButton");
 	}
 	this.setButtonListener(DwtDialog.OK_BUTTON, new AjxListener(this, this._handleOkButton));
 	this.setButtonListener(DwtDialog.CANCEL_BUTTON, new AjxListener(this, this._handleCancelButton));
@@ -345,6 +346,7 @@ function(displayShares, organizer) {
 	if (displayShares.length) {
 		var table = document.createElement("TABLE");
 		table.className = "ZPropertySheet";
+		table.width = "100%";
 		table.cellSpacing = "6";
 		for (var i = 0; i < displayShares.length; i++) {
 			var share = displayShares[i];
@@ -391,6 +393,7 @@ function(row, share) {
 	}
 
 	var actions = [ZmShare.EDIT, ZmShare.REVOKE, ZmShare.RESEND];
+	var iconStyle = "text-align:right";
 	var handlers = [this._handleEditShare, this._handleRevokeShare, this._handleResendShare];
 
 	for (var i = 0; i < actions.length; i++) {
@@ -404,11 +407,13 @@ function(row, share) {
             ((isAllShare || share.isPublic()) && action == ZmShare.RESEND)) { continue; }
 
 		var link = document.createElement("A");
+		Dwt.addClass(link, "ZmSharingActionLink");
 		link.href = "#";
-		link.innerHTML = ZmShare.ACTION_LABEL[action];
+		link.title = ZmShare.ACTION_LABEL[action];
+		link.innerHTML = AjxImg.getImageHtml(ZmShare.ACTION_ICON[action], iconStyle);
 
 		Dwt.setHandler(link, DwtEvent.ONCLICK, handlers[i]);
-		Dwt.associateElementWithObject(link, share);
+		Dwt.associateElementWithObject(link.childNodes[0], share);
 		this._sharesGroup.getTabGroupMember().addMember(link);
 
 		cell.appendChild(link);

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmRevokeShareDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmRevokeShareDialog.js
@@ -125,7 +125,6 @@ function() {
 ZmRevokeShareDialog.prototype._createView =
 function() {
 	this._confirmMsgEl = document.createElement("DIV");
-	this._confirmMsgEl.style.fontWeight = "bold";
 	this._confirmMsgEl.style.marginBottom = "0.25em";
 	
 	var view = new DwtComposite(this);

--- a/WebRoot/messages/ZmMsg.properties
+++ b/WebRoot/messages/ZmMsg.properties
@@ -1522,7 +1522,7 @@ folderTabProperties = Properties
 folderTabRetention = Retention
 folders = Folders
 foldersLabel = Folders:
-folderSharing = Sharing for this folder
+folderSharing = Shares for this folder
 foldersSearches = Folders and Saved Searches
 foldersShown = {0} {1} shown
 folderSize = Folder Size
@@ -2449,7 +2449,7 @@ offlineBackupRestored = Backup of account "{0}" restored.
 offlineBackupStartedForAcct = Backup of account "{0}" has begun
 offlineCachingDone = Zimbra is ready for offline use
 offlineCachingSync = Synchronizing data for offline use
-offlineFolderSyncInterval =  Store up to <input id="folderOfflineLblId" class="ZmOfflineSyncInterval" type="number" min="0" max="30"> days of messages. (set to 0 for no sync)
+offlineFolderSyncInterval =  Store up to {0} days of messages. <br/> (set to 0 for no sync)
 invalidFolderSyncInterval = Invalid folder sync interval value. It should be a number between 0 and 30.
 offlineChangeRestart = Would you like to reload the application now to enable offline access? <br>\
 		(Otherwise, the offline access will be available the next time you sign in.)

--- a/WebRoot/skins/_base/base4/skin.css
+++ b/WebRoot/skins/_base/base4/skin.css
@@ -616,7 +616,7 @@ TEXTAREA .BannerBar * {
 /* styles for the HTML client */
 INPUT[type="text"],
 INPUT[type="password"]      {   @FieldBorder@   }
-SELECT                      {   @FieldBorder@   }
+SELECT                      {   @NativeSelect@  }
 .TabSpacer                  {   display:none;       }
 .Tab                        {   white-space:nowrap; height:30px; padding-right:5px !important;  }
 .TbTop                      {   border-width:0px 1px 1px 0px !important; padding-right:5px !important;  }
@@ -1130,5 +1130,35 @@ svg.progress-circle.tick-inside {
 
 /* Preference filter view */
 .ZmFilterRuleList .Row:last-of-type {
-    border:none;
+    border: none;
+}
+
+/*Action button container styling, matching the alignments with icons in FolderPropsDialog*/
+#FolderProperties_buttons {
+    margin-right:18px;
+}
+
+/*Resetting text transform for dialog action buttons that are inline */
+.DwtDialogButtonBar .ZInlineButton>.ZButtonTable {
+    text-transform:none;
+}
+
+/*************
+ *
+ *	DwtGrouper: Use to show groups in dialogs like ZmSharePropsDialog & ZmFolderPropsDialog
+ *
+ *************/
+
+.DwtGrouper > fieldset {
+    border: none;
+}
+
+.DwtGrouper legend {
+    font-weight: normal;
+    @FontSize-bigger@
+}
+
+.DwtDialog .Label {
+    vertical-align: middle;
+    padding-right:30px;
 }

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -470,6 +470,7 @@ InputPadding                = padding:@WidgetInternalPadding@;
 InputBg                     = 
 
 InputField                  = @InputPadding@    @TextCursor@            @InputHeight@         @FixBoxModel@         @InputBg@
+InputFieldNumber            = @TextCursor@      @InputHeight@           @FixBoxModel@         @InputBg@ 
 InputField-normal           = @InputText@       @ZFieldBg-normal@       @InputBorder@
 InputField-focused          = @InputText@       @ZFieldBg-focused@      @FocusBorder@ outline: none;
 InputField-error            = @InputText@       @ZFieldBg-error@        @InputBorder@
@@ -674,6 +675,7 @@ TaskbarItem-selected            = @ToolbarColor@
 #####################
 
 Select                      = @SelectHeight@ @ActiveCursor@
+NativeSelect                = @Select@ @FieldBorder@ background:@white@;
 SelectHeight                = @WidgetHeight@
 SelectSpacing               =
 SelectPadding               = @WidgetInternalPadding@
@@ -1647,6 +1649,7 @@ DialogBodyText              = @FontSize-slightly-big@
 DialogBody                  = @DialogBodyText@; cursor:default;
 DialogMessageBody           = @DialogBodyText@; width:450px; max-height:400px; overflow:auto;
 DialogMessageBodyWide       = @DialogBodyText@; width:650px; max-height:400px; overflow:auto;
+DialogField                 = width:290px; @MediumRoundCorners@ @FontSize-slightly-big@ 
 
 DialogButton                = @FontSize-big@; color: @AltC@; height: auto; padding: 8px 16px; @SlightlyBigRoundCorners@; text-transform: uppercase; border:none;
 
@@ -1672,6 +1675,18 @@ CreateContactGroupDialog        =
 CreateContactGroupDialogTable   = @FullWidth@
 CreateContactGroupDialogCell    = padding:0 0 8px 0;
 CreateContactGroupDialogInput   = @FullWidth@
+
+#######################################################################
+#   Folder Properties Dialog
+#######################################################################
+
+FolderPropertyDialogContainer   = overflow:hidden; width:500px;
+FolderPropertyView              = margin:10px; line-height:2;
+FolderPropertyDialogHeading     = @FontSize-bigger@
+FolderPropertyDialogCheckbox    = padding: 0 @CheckBoxTableCellSpacing@ @BoxPaddingSize@ 0; @Text@
+FolderPropertyRetentionInput    = margin: 0 @SkinViewInnerSpacing@; width:60px; @MediumRoundCorners@
+FolderPropertyPolicyContainer   = @FullWidth@; padding-left:@SkinViewInnerSpacing@;
+FolderPropertyDialogHeadingContainer = font-weight: normal; white-space:nowrap; @BottomBoxPadding@
 
 #######################################################################
 #   Grant Rights Dialog
@@ -1800,6 +1815,7 @@ BoxMargin                   = margin:@BoxMarginSize@;
 BoxPadding                  = padding:@BoxPaddingSize@;
 BoxSpacing                  = @BoxPadding@ @BoxMargin@
 LeftBoxPadding              = padding-left:@BoxPaddingSize@;
+BottomBoxPadding            = padding-bottom:@BoxPaddingSize@;
 
 SmallBoxPadding             = padding:@SmallBoxPaddingSize@;
 SmallBoxMargin              = margin:@SmallBoxMarginSize@;

--- a/WebRoot/templates/share/Dialogs.template
+++ b/WebRoot/templates/share/Dialogs.template
@@ -628,8 +628,9 @@
 
 <template id="share.Dialogs#ZmFolderRetentionView">
      <table role="presentation" style='margin:10px;'>
+        <tr><td colspan=3>&nbsp;</td></tr>
         <tr>
-            <td><input id="${id}_keepCheckbox" type='checkbox'></td>
+            <td class='ZmFolderRetentionCheckbox'><input id="${id}_keepCheckbox" type='checkbox'></td>
             <td class='ZmFolderRetentionLabel' colspan=2>
                 <label for="${id}_keepCheckbox">
                     <$=ZmMsg.messageRetentionEnable$>
@@ -642,7 +643,7 @@
         </tr>
         <tr>
             <td></td>
-            <td class='ZmFieldLabelRight'><span id='${id}_retentionLabel'><$=ZmMsg.messageRetentionRange$></span></td>
+            <td class='ZmFieldLabelLeft'><span id='${id}_retentionLabel'><$=ZmMsg.messageRetentionRange$></span></td>
             <td class='ZmFolderPolicySelection'>
                 <select id='${id}_keep' aria-label='<$=ZmMsg.type$>' class='ZmFolderPolicySelect'/>
                 <input id='${id}_keepValue' class='ZmFolderPolicyAmountInput' type='text' aria-labelledby='${id}_retentionLabel' />
@@ -650,8 +651,9 @@
             </td>
         </tr>
         <tr><td colspan=3>&nbsp;</td></tr>
+        <tr><td colspan=3>&nbsp;</td></tr>
         <tr>
-            <td><input id="${id}_purgeCheckbox" type='checkbox'></td>
+            <td class='ZmFolderRetentionCheckbox'><input id="${id}_purgeCheckbox" type='checkbox'></td>
             <td class='ZmFolderRetentionLabel' colspan=2>
                 <label for="${id}_purgeCheckbox">
                     <$=ZmMsg.messageDisposalEnable$>
@@ -664,7 +666,7 @@
         </tr>
         <tr>
             <td></td>
-            <td class='ZmFieldLabelRight'><span id='${id}_disposalLabel'><$=ZmMsg.messageDisposalThreshold$></span></td>
+            <td class='ZmFieldLabelLeft'><span id='${id}_disposalLabel'><$=ZmMsg.messageDisposalThreshold$></span></td>
             <td class='ZmFolderPolicySelection'>
                 <select id='${id}_purge' aria-label='<$=ZmMsg.type$>' class='ZmFolderPolicySelect'/>
                 <input id='${id}_purgeValue' class='ZmFolderPolicyAmountInput' type='text' aria-labelledby='${id}_disposalLabel' />


### PR DESCRIPTION
**Description**: Changes to simplify the UX and match the styling as per new UX mockups.

**Changeset**:
* ZmFolderPropertyView.js:
   * Removing the span for showing the folder name that cannot be edited, using disabled input field now.
   * Formatting ZmMsg.offlineFolderSyncInterval to replace placeholder with the input field for offline sync interval.
* ZmShare.js:
    * Adding action items for sharing: edit,revoke & resend.
* ZmColorButton.js:
   * Adding class "ZSelect" to widget to make it look like DwtSelect.
* ZmFolderPropsDialog.js:
   * Using new icons for the actions instead of text labels.
* skin.css:
   * Adding related styles.
* Dialogs.template:
   * Updating ZmFolderRetentionView dialog.