### PR TITLE
ZCS-1294:  Compose view text inputs should align with the text editor

### DIFF
--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1311,7 +1311,7 @@ ComposeViewSubjectInputField= border:none; color:@TxtC@; height:3rem; @FullWidth
 ComposeViewTinyMceContainer =
 ComposeViewHtmlEditor       = padding:@ComposeViewOutsidePadding@; background-color: @AppC@;
 ComposeViewPlainTextEditor  = @FontSize-big@ @FontFamily-fixed@ @FullWidth@ @AppBorder@ overflow:auto; padding:8px;
-ComposeViewHeaderEmptyRight = padding-right: 18px; width: 1%;
+ComposeViewHeaderEmptyRight = padding-right: 18px; width: 1px;
 
 AttachBriefcaseItem         = border-style:solid; border-width:0 0 1px 0; border-color:transparent;
 AttachBriefcaseItemSelected = border-bottom-color:@PanelBorderColor@;

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1311,7 +1311,7 @@ ComposeViewSubjectInputField= border:none; color:@TxtC@; height:3rem; @FullWidth
 ComposeViewTinyMceContainer =
 ComposeViewHtmlEditor       = padding:@ComposeViewOutsidePadding@; background-color: @AppC@;
 ComposeViewPlainTextEditor  = @FontSize-big@ @FontFamily-fixed@ @FullWidth@ @AppBorder@ overflow:auto; padding:8px;
-ComposeViewHeaderEmptyRight = padding-right: 18px;
+ComposeViewHeaderEmptyRight = padding-right: 18px; width: 1%;
 
 AttachBriefcaseItem         = border-style:solid; border-width:0 0 1px 0; border-color:transparent;
 AttachBriefcaseItemSelected = border-bottom-color:@PanelBorderColor@;


### PR DESCRIPTION
ZCS-1294  Compose view text inputs should align with the text editor in all cases.

Issue: The empty padding td at the end is taking the available space which is more in case where from drop down is not available.

Fix: Adding width as 1% to the last div that’s there for space so that it doesn’t take all available space.

Changeset:
* skin.properties:  Adding width of 1% to ComposeViewHeaderEmptyRight property variable.