### PR TITLE
ZCS-2348 XSS possible in webclient using malicious account name

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
@@ -507,7 +507,7 @@ function(granter, grantee, sendAs,sendObo,isGrant) {
         subject = (sendAs && sendObo) ? ZmMsg.revokeRightsSubject : ZmMsg.revokeRightSubject;
     }
     subject = AjxMessageFormat.format(subject, [granter]);
-    status = AjxMessageFormat.format(status, grantee);
+    status = AjxMessageFormat.format(status, AjxStringUtil.htmlEncode(grantee));
     var text = (isGrant)?ZmMsg.delegateCreatedText : ZmMsg.delegateRevokedText;
     text = AjxMessageFormat.format(text, [permissions, grantee, granter]);
     var html = (isGrant)?ZmMsg.delegateCreatedHtml : ZmMsg.delegateRevokedHtml;
@@ -3236,7 +3236,7 @@ function(ev) {
 ZmGrantRightsDialog.prototype.setData =
 function(item){
     if (item){
-        this.setTitle(ZmMsg.editDelegatePermissions + " - " + item.user);
+        this.setTitle(ZmMsg.editDelegatePermissions + " - " + AjxStringUtil.htmlEncode(item.user));
         this._delegateEmailRow.style.display ="none";
         this._sendAs.checked = item.sendAs;
         this._sendObo.checked = item.sendOnBehalfOf;

--- a/WebRoot/js/zimbraMail/share/view/ZmStatusView.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmStatusView.js
@@ -315,7 +315,7 @@ function(work) {
         // we use and add a dedicated SPAN to make sure that we trigger all
         // screen readers
         var span = document.createElement('SPAN');
-        span.innerHTML = AjxStringUtil.htmlEncode(work.msg) || "";
+        span.innerHTML = work.msg || "";
 
         Dwt.removeChildren(this._textEl);
         this._textEl.appendChild(span);


### PR DESCRIPTION
- fix implemented in https://github.com/Zimbra/zm-web-client/commit/8426bc1a3911f4f5ea1ff319d122cc0c5c70bbe9 created a regression where adding anchor links in toast message was not working and showing html content
- encode data only when needed instead of adding fix at core level