### PR TITLE
ZCS-2259 Universal UI: Toolbar in new-window-view-mail should match the default style 

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
+++ b/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
@@ -1594,7 +1594,7 @@ function(fullVersion, width, height, name) {
 	url[i++] = "&childId=" + this.__childWindowId;
 
     name = name || "_blank";
-	width = width || 705;
+	width = width || 750;
 	height = height || 465;
 	var args = ["height=", height, ",width=", width, ",location=no,menubar=no,resizable=yes,scrollbars=no,status=yes,toolbar=no"].join("");
 	if (window.appDevMode) {

--- a/WebRoot/js/zimbraMail/core/ZmOperation.js
+++ b/WebRoot/js/zimbraMail/core/ZmOperation.js
@@ -117,7 +117,7 @@ function() {
 	ZmOperation.registerOp(ZmId.OP_CANCEL, {textKey:"cancel", tooltipKey:"cancelTooltip", image:"Cancel", shortcut:ZmKeyMap.CANCEL, showImageInToolbar: true, showTextInToolbar: true});
 	ZmOperation.registerOp(ZmId.OP_CHECK_ALL, {textKey:"checkAll", image:"Check"});
 	ZmOperation.registerOp(ZmId.OP_CLEAR_ALL, {textKey:"clearAll", image:"Cancel"});
-	ZmOperation.registerOp(ZmId.OP_CLOSE, {textKey:"close", tooltipKey:"closeTooltip", image:"Close", shortcut:ZmKeyMap.CANCEL});
+	ZmOperation.registerOp(ZmId.OP_CLOSE, {textKey:"close", tooltipKey:"closeTooltip", image:"Close", shortcut:ZmKeyMap.CANCEL, showImageInToolbar: true, showTextInToolbar: true});
 	ZmOperation.registerOp(ZmId.OP_COMPOSE_FORMAT, {textKey:"format", tooltipKey:"formatTooltip", image:"SwitchFormat", shortcut:ZmKeyMap.HTML_FORMAT}, ZmSetting.HTML_COMPOSE_ENABLED);
 	ZmOperation.registerOp(ZmId.OP_CONTACTGROUP_MENU, {textKey: "AB_CONTACT_GROUP", tooltipKey:"contactGroupTooltip", image:"GroupFolder"}, null,
 		AjxCallback.simpleClosure(function(parent) {

--- a/WebRoot/js/zimbraMail/mail/controller/ZmMsgController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmMsgController.js
@@ -209,7 +209,7 @@ function(map) {
 
 ZmMsgController.prototype._getToolBarOps = 
 function() {
-	var list = [ZmOperation.CLOSE, ZmOperation.SEP];
+	var list = [ZmOperation.CLOSE];
 	list = list.concat(ZmMailListController.prototype._getToolBarOps.call(this));
 	return list;
 };
@@ -230,7 +230,7 @@ function() {
 
 ZmMsgController.prototype._initializeToolBar =
 function(view) {
-	var className = appCtxt.isChildWindow ? "ZmMsgViewToolBar_cw" : null;
+	var className = appCtxt.isChildWindow ? "ZToolbar ZmMsgViewToolBar_cw" : null;
 
 	ZmMailListController.prototype._initializeToolBar.call(this, view, className);
 };


### PR DESCRIPTION
ZCS-2259 Universal UI: Toolbar in new-window-view-mail should match the default style.

Changeset:
 * ZmApPCtxt.js: Increasing width of new window to fit the toolbar in default view.
 * ZmOperation.js: Setting flags true to show icon & text both for Close operation.
 * ZmMsgController.js:  Adding class ZToolbar for msg view to inherit common styling for toolbar’s.