### PR TITLE
ZCS-2167 Missing top tabs on IE11

### DIFF
--- a/WebRoot/js/zimbraMail/share/view/ZmAutocompleteListView.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmAutocompleteListView.js
@@ -1188,9 +1188,9 @@ function(list, context) {
 			}
 			cell = row.insertCell(-1);
 			if (matchTypeContact) {
-				cell.innerHTML = ("<span class='acRowTop'>" + match.name + "</span>" + "<br/>" + match.email) || "&nbsp;";
+				cell.innerHTML = ("<span class='acRowTop'>" + AjxStringUtil.htmlEncode(match.name) + "</span>" + "<br/>" + AjxStringUtil.htmlEncode(match.email)) || "&nbsp;";
 			} else {
-				cell.innerHTML = match.text || "&nbsp;";
+				cell.innerHTML = AjxStringUtil.htmlEncode(match.text) || "&nbsp;";
 			}
 			if (forgetEnabled) {
 				this._insertLinkCell(this._forgetLink, row, rowId, this._getId("Forget", i), (match.score > 0));

--- a/WebRoot/skins/_base/base4/skin.css
+++ b/WebRoot/skins/_base/base4/skin.css
@@ -155,10 +155,6 @@ BODY                                    {   margin:0px;     }
 #skin_spacing_app_chooser               {   @SkinSpacingAppChooser@     }
 #skin_border_app_chooser                {   @SkinBorderAppChooser@      }
 #skin_container_app_chooser             {
-    position:absolute;
-    width:auto;
-    height:auto;
-    z-index:1;
     @AppTabChooser@
 }
 #skin_container_app_chooser>TABLE   { @AppTabTable@     }


### PR DESCRIPTION
Issue:
- Height of individual tab was not propagating to the top level container

Resolution:
- Skin container was absolute positioned therefore it was not getting considered in same dom chain as the individual tabs, so it was not able to take height of individual tabs