### PR TITLE
ZCS-736 Universal UI: Calendar month view fit and finish

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -2724,45 +2724,33 @@ INPUT[type="text"].InlineWidget {
 	@PageHeaderBg@
 }
 
-/* label for the month */
-.calendar_month_header_month {
-	@PageHeaderBg@
-	@PageHeaderText@
-	@FontSize-biggest@
-	@Label@
-	text-align:center;
-}
-
 /* day of week label for the month */
 .calendar_month_header_cells_text {
-	@PageHeaderBg@
-	@PageHeaderText@
-	@FontSize-big@
-	@SmallBoxPadding@
-	@BottomSeparator@
-	@Label@
-	text-align:center;
+	@CalendarMonthHeaderCell@
 }
 
 /* cell for each day in the month view in various states*/
 .calendar_month_cells_td {
-	@SeparatorBorder@
+	@TopSeparator@
+	@RightSeparator@
+	@BottomSeparator@
 	@NoWrap@
 	vertical-align:top;
 }
 
 .calendar_month_weekno_td {
-	@LeftSeparator@
 	@TopSeparator@
 	@BottomSeparator@
 	@NoWrap@
 	@Text-anchor@
+	@FontSize-slightly-big@
 	vertical-align:top;
 	text-align:center;
+	line-height:2;
 }
 
 .calendar_month_cells_td-selected {
-	@SelectedBg@
+	@AppBg@
 	@SeparatorBorder@
 	@NoWrap@
 	vertical-align:top;
@@ -2801,9 +2789,10 @@ INPUT[type="text"].InlineWidget {
 .calendar_month_day_label_off_month_today
 {
 	@NoWrap@
-	@FontSize-big@
+	@FontSize-slightly-big@
 	@TextPadding@
-	text-align:right;
+	text-align:left;
+	line-height:2;
 }
 
 .calendar_month_day_label_today {
@@ -2858,10 +2847,15 @@ INPUT[type="text"].InlineWidget {
 
 .calendar_month_day_item .subject {
 	padding-left:4px;
+	font-weight:bold;
 }
 
 .calendar_month_day_item .start_time {
 	padding-left:2px;
+}
+
+td.calendar_month_day_item table td {
+	padding: 2px 0;
 }
 
 .calendar_month_day_item-dnd {

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalMonthView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalMonthView.js
@@ -520,7 +520,6 @@ function() {
 	this._dayInfo = new Object();
 	this._fillers = [];
 	this._headerId = Dwt.getNextId();
-	this._titleId = Dwt.getNextId();	
 	this._daysId = Dwt.getNextId();	
 	this._bodyId = Dwt.getNextId();
 	this._weekNumBodyId = Dwt.getNextId();
@@ -550,9 +549,6 @@ function() {
 		html.append("<col id='", this._headerColId[i], "'/>");
 	}
 	html.append("</colgroup>");
-	html.append("<tr>");
-	html.append("<td colspan=7 class=calendar_month_header_month id='", this._titleId, "'></td>");
-	html.append("</tr>");
 	html.append("<tr>");
 
     // Week title to heading.
@@ -688,8 +684,6 @@ function() {
 	
 	var formatter = DwtCalendar.getMonthFormatter();
 	this._title = formatter.format(this._date);
-	var titleEl = document.getElementById(this._titleId);
-	titleEl.innerHTML = this._title;
 };
 
 ZmCalMonthView.prototype._calcDayIndex =

--- a/WebRoot/js/zimbraMail/share/view/ZmButtonToolBar.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmButtonToolBar.js
@@ -58,9 +58,10 @@ ZmButtonToolBar = function(params) {
 	if (!params.className && (params.controller && params.controller._elementsToHide == ZmAppViewMgr.LEFT_NAV)) {
 		params.className = "ZToolbar itemToolbar";
 	}
-    params.className = params.className || "ZToolbar";
-    params.id = params.context ? ZmId.getToolbarId(params.context, params.toolbarType) : null;
-    ZmToolBar.call(this, params);
+	params.className = params.className || "ZToolbar";
+	params.secondaryButtonsPosition = params.secondaryButtonsPosition || params.buttons.length;
+	params.id = params.context ? ZmId.getToolbarId(params.context, params.toolbarType) : null;
+	ZmToolBar.call(this, params);
 	
 	this._context = params.context;
 	this._toolbarType = params.toolbarType;

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -412,6 +412,7 @@ DropNotAllowedColor         = #ea493d
 
 # backgrounds for various states
 SelectedBg                  = background-color:@SelC@ !important;
+SelectedAltBg               = background-color:@SelAltColor@ !important;
 SelectedBg-blurred          = background-color:@lighten(SelC,25)@ !important;
 MatchedBg                   = background-color:@MatchedColor@;
 RightClickBg                = background-color:@RightClickColor@;
@@ -1598,6 +1599,7 @@ CalendarBorderColor         = #DBDBDB;
 CalendarSeparatorBg         = background-color:@CalendarBorderColor@; padding:0px;
 CalendarBottomSeparator     = @BottomSeparator@; border-color: @CalendarBorderColor@;
 CalendarNavToolbarTitle     = font-size:1.5em; font-weight:100; vertical-align:middle; @ToolbarButtonHeight@ @DisplayTableCell@
+CalendarMonthHeaderCell     = @PageHeaderBg@ @PageHeaderText@ @FontSize-slightly-big@ @BottomSeparator@ @Label@ text-align:left; padding: 8px @SmallBoxPaddingSize@;
 
 # Free-Busy view
 FreeBusyViewHeaderWidth     = width:27px;


### PR DESCRIPTION
ZCS-736 Universal UI: Calendar month view fit and finish

Changeset:
 * ZmCalMonthView.js: Removing code for current month title in the Month view.
 * ZmButtonToolbar.js: Adding logic for fallback of params.secondaryButtonsPosition to buttons length is position is not passed in params.
 * zm.css & skin.properties: Styling changes for calendar month view.

**NOTE:** : Styling changes have been done in zm.css and not created separate property variables to make it customisable at this moment. Reason being there are other related component style rules in similar form and all those can be moved at once sometime later if required.