### PR TITLE
ZCS-2645 Bug 108265 - Persistent XSS - message view as text [CWE-79]

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/ZmMailMsgView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailMsgView.js
@@ -1856,7 +1856,7 @@ ZmMailMsgView.prototype._renderMessageBody1 = function(params, part) {
             }
             else {
                 // this can happen if a message only has an HTML part and the user wants to view mail as text
-                content = "<div style='white-space:pre-wrap;'>" + AjxStringUtil.convertHtml2Text(content) + "</div>"
+                content = "<div style='white-space:pre-wrap;'>" + AjxStringUtil.htmlEncode(AjxStringUtil.convertHtml2Text(content)) + "</div>"
             }
         }
 


### PR DESCRIPTION
Issue:
- When viewing html mail content in plain text mode, script was getting executed

Resolution:
- After converting html content to plain text we need to html ecnode it so the contents will not be executed when added in dom