### PR TITLE
ZCS-2417: Universal UI: Appointment Reminder dialog

### DIFF
--- a/WebRoot/css/dwt.css
+++ b/WebRoot/css/dwt.css
@@ -675,6 +675,14 @@ UL.DwtListView-Rows {
 	@DialogButton@
 }
 
+.DwtDialogButtonBar .ZInlineButton.ZButton > .ZButtonTable {
+	@DialogInlineButtonTable@
+}
+
+.DwtDialogButtonBar .ZInlineButton.ZButton {
+	@DialogInlineButton@
+}
+
 
 /* TODO: Rationalize this ? */
 

--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -3163,28 +3163,58 @@ HTML>BODY .appt-selected .appt_allday_body
  * Reminder Dialog
  */
 
+.ZmReminderDialogContainer > div.WindowOuterContainer {
+	@ReminderDialogContainer@
+}
+
+.ZmReminderDialogContainer .DwtDialogTitle {
+	@ReminderDialogTitle@
+}
+
+.ZMReminderDialogContainer .WindowInnerContainer {
+	@ReminderDialogInnerContainer@
+}
+
+/*Content along with action buttons*/
 .ZmReminderDialog {
-	overflow:hidden;
-	width:auto; 			/*??? SIZE */
-	@BoxMargin@
-	margin-bottom:0px;
+	@ReminderDialogFullContent@
+}
+
+.ZmReminderDialog .horizSep {
+	@ReminderDialogSeparator@
+}
+
+/* Content without bottom action buttons*/
+.ZmReminderDialogContent > table {
+	@ReminderDialogContentTable@
+}
+
+.ZmReminderDialogContent {
+	@ReminderDialogContent@
+}
+
+/* Individual appointment snooze/dismiss buttons */
+.ZAppointmentReminderButton {
+	@ReminderDialogAppointmentButton@
+}
+
+.ZmReminderDialog .ZAppointmentReminderButton .ZButtonTable {
+	@DialogButton@
 }
 
 /* Overdue appt text */
 .ZmReminderOverdue {
-	@Text-important@
-	font-weight:bold;
+	@ReminderDialogText-overdue@
 }
 
 /* Appt coming soon text */
 .ZmReminderSoon {
-	@Text-important@
-	font-weight:bold;
+	@ReminderDialogText-soon@
 }
 
 /* Appt somewhere in the future */
 .ZmReminderFuture {
-
+	@ReminderDialogText-future@
 }
 
 /* ??? USE?  Label or field value */
@@ -3193,6 +3223,13 @@ HTML>BODY .appt-selected .appt_allday_body
 	text-align:right;
 }
 
+.ZmApptOpenLink {
+	@ReminderDialogApptLinkContainer@
+}
+
+.ZmApptOpenLink > span > a {
+	@ReminderDialogApptLink@
+}
 
 /*
  *	Edit appointment view (the one with the tabs)

--- a/WebRoot/skins/_base/base4/skin.css
+++ b/WebRoot/skins/_base/base4/skin.css
@@ -1135,8 +1135,8 @@ svg.progress-circle.tick-inside {
     margin-right:18px;
 }
 
-/*Resetting text transform for dialog action buttons that are inline */
-.DwtDialogButtonBar .ZInlineButton>.ZButtonTable {
+/*Resetting text transform for dialog action buttons that are inline for Folder PropsDialog*/
+.ZmFolderPropsDialog .DwtDialogButtonBar .ZInlineButton>.ZButtonTable {
     text-transform:none;
     padding-left:13px;
 }
@@ -1176,4 +1176,10 @@ svg.progress-circle.tick-inside {
 .ZmApptRecurDialog [id^="MONTHLY_DAY_SELECT"] .ZWidgetTitle,
 .ZmApptRecurDialog [id^="YEARLY_DAY_SELECT"] .ZWidgetTitle {
     text-transform: capitalize;
+}
+
+/* Hiding buttons section as this is not used for showing anything but takes padding space by default.*/
+#ZmReminderDialog_appt_buttons,
+#ZmReminderDialog_task_buttons {
+    display:none;
 }

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -342,8 +342,8 @@ Text-focused                = @Text@
 Text-today                  = 
 Text-unread                 = font-weight: bold;
 Text-deleted                = @Text-disabled@ text-decoration:line-through;
-Text-important              = color:darkred;
-Text-error                  = color:darkred; font-weight:bold;
+Text-important              = color:#c30016;
+Text-error                  = color:#c30016; font-weight:bold;
 Text-success                = color:green;
 Text-matched                = @Text@
 Text-hint                   = color:@lighten(TxtC,50)@; font-style:italic; cursor:default;
@@ -1643,6 +1643,21 @@ ZmExternalCalendarDialogFieldLabel  = padding-right: @SkinWrapperPadding@;
 ZmExternalCalendarDialogInput       = @DialogInputFiled@
 ZmExternalCalendarDialogSelect      = min-width: 300px;
 
+# Reminder Dialog
+ReminderDialogContainer     = padding:0;
+ReminderDialogTitle         = padding: @SkinViewGutterSpace@ @SkinWrapperPadding@; @SlightlyBigRoundCorners@; @FontSize-normal@; background-color: @WidgetBgColor@; 
+ReminderDialogSeparator     = margin: @SkinViewInnerSpacing@ 0;
+ReminderDialogFullContent   = overflow:hidden; width:auto; padding: @SkinWrapperPadding@; padding-top:0;
+ReminderDialogContentTable  = min-width:420px; width:100%;
+ReminderDialogContent       = overflow-y:auto; max-height:400px; max-height: 50vh; display:block;
+ReminderDialogApptLink      = @FontSize-slightly-bigger@
+ReminderDialogText          = @Text-important@; padding-right: @SkinViewInnerSpacing@;
+ReminderDialogText-future   = @ReminderDialogText@
+ReminderDialogText-soon     = @ReminderDialogText@
+ReminderDialogText-overdue  = @ReminderDialogText@
+ReminderDialogApptLinkContainer = margin-bottom:1.333rem;
+ReminderDialogAppointmentButton = display:inline-block;
+
 
 ################
 #   BORDERS
@@ -1704,6 +1719,8 @@ DialogMessageBodyWide       = @DialogBodyText@; width:650px; max-height:400px; o
 DialogField                 = width:290px; @MediumRoundCorners@ @FontSize-slightly-big@ 
 
 DialogButton                = @FontSize-big@; color: @AltC@; height: auto; padding: 8px 16px; @SlightlyBigRoundCorners@; text-transform: uppercase; border:none;
+DialogInlineButton          = vertical-align:middle;
+DialogInlineButtonTable     = padding-left:0;
 
 AttachDialogContainer       = @DialogBackGroundColor@
 

--- a/WebRoot/templates/calendar/Calendar.template
+++ b/WebRoot/templates/calendar/Calendar.template
@@ -350,7 +350,7 @@
 
 <template id='calendar.Calendar#ReminderDialogRow'>
 	<tr id='${rowId}'>
-		<td style="max-width:350px;" valign=top>
+		<td valign=top>
 			<div id='${openLinkId}' class='ZmApptOpenLink'></div>
 			<div id='${reminderDescContainerId}'>
 			<$ if (data.durationText != "") { $>
@@ -377,23 +377,23 @@
 				<$= ZmMsg.locationLabel $> ${location}<br>
 			<$ } $>
 			</div>
-		</td>
-		<td valign=top align=right>
-			<table role="presentation" style="margin-left:15px;">
+		
+			<table role="presentation" width="100%">
 				<tr id='${actionsRowId}'>
-					<td valign=top align=right>
-						<table role="presentation" class='ZPropertySheet' cellspacing='6'>
+					<td align=left>
+						<table role="presentation" class='ZPropertySheet' cellspacing='6' width="100%">
 							<tr>
-								<td valign=top id='${snoozeSelectInputId}' style="padding-right:0;"></td>
-								<td valign=top id='${snoozeSelectBtnId}' style="padding-left:0" width="1%"></td>
-								<td valign=top id='${snoozeBtnId}'></td>
-								<td valign=top id='${dismissBtnId}'></td>
+								<td style='white-space:nowrap; padding-left:0;' align='left' id='${deltaId}'></td>
+								<td align='left' id='${snoozeSelectInputId}' style="padding:0;"></td>
+								<td align='left' id='${snoozeSelectBtnId}' style="padding:0" width="1%"></td>
+								<td width='100%'></td>
+								<td align='right' id='${snoozeBtnId}' style="padding:0"></td>
+								<td align='right' id='${dismissBtnId}' style="padding:0"></td>
 							</tr>
 						</table>
 					</td>
 				</tr>
 				<tr>
-					<td style='white-space:nowrap;' align='right' id='${deltaId}'></td>
 				</tr>
 			</table>
 		</td>
@@ -407,15 +407,15 @@
 </template>
 
 <template id='calendar.Calendar#ReminderDialogAllSection'>
-	<table role="presentation" class='ZPropertySheet' cellspacing='6' cellpadding=0 border=0 width="100%">
+	<table role="presentation" id="${containerId}" class='ZPropertySheet' cellspacing='6' cellpadding=0 border=0 width="100%">
 		<tr>
-			<td width=100% valign=middle align=right>
+			<td id='${dismissBtnId}' class="DwtDialogButtonBar"></td>
+			<td id='${snoozeBtnId}' class="DwtDialogButtonBar"></td>
+			<td>
 				<span id='${snoozeAllLabelId}'></span>
 			</td>
-			<td valign=top id='${snoozeSelectInputId}' style="padding-right:0"></td>
-			<td valign=top id='${snoozeSelectBtnId}' style="padding-left:0"></td>
-			<td valign=top id='${snoozeBtnId}' class="DwtDialogButtonBar"></td>
-			<td valign=top id='${dismissBtnId}' class="DwtDialogButtonBar"></td>
+			<td id='${snoozeSelectInputId}' style="padding-right:0"></td>
+			<td id='${snoozeSelectBtnId}' style="padding-left:0"></td>
 		</tr>
 	</table>
 </template>


### PR DESCRIPTION
ZCS-2417: Universal UI: Appointment Reminder dialog

Changeset:

* ZmReminderDialog.js:
	* Adding logic to show the bottom actions bar only if there are more than 1 appointments in the dialog.
	* Styling changes and adding identifying CSS class names to different dialog sections.
* Calendar.template: Alignment & styling changes.
* skin.css, zm.css & dwt.css: Related styling changes to match the new UX design.