### PR TITLE
Fixing: Free Busy calendar view breaking with latest changes.

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
@@ -1072,7 +1072,8 @@ function(buttons) {
 		ZmOperation.WORK_WEEK_VIEW,
 		ZmOperation.WEEK_VIEW,
 		ZmOperation.MONTH_VIEW,
-		ZmOperation.CAL_LIST_VIEW];
+		ZmOperation.CAL_LIST_VIEW,
+		ZmOperation.FB_VIEW];
 
 	var overrides = {};
 

--- a/WebRoot/js/zimbraMail/calendar/view/ZmFreeBusySchedulerView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmFreeBusySchedulerView.js
@@ -263,7 +263,7 @@ function() {
 
 
     Dwt.setHandler(this._showMoreLink, DwtEvent.ONCLICK, ZmFreeBusySchedulerView._onShowMore);
-    this.updateSchedulerDate(this._appt.startDate);
+    this._appt && this._appt.startDate && this.updateSchedulerDate(this._appt.startDate);
 
 	this._rendered = true;
 };
@@ -1103,7 +1103,7 @@ function(sched, attendee, index) {
         }
         else {
             var deleteButton = new DwtBorderlessButton({parent:this, className:"Label"});
-            deleteButton.setImage("Disable");
+            deleteButton.setImage("Cancel");
             deleteButton.setText("");
             deleteButton.addSelectionListener(new AjxListener(this, this._deleteAttendeeRow, [attendee.getEmail()]));
             deleteButton.getHtmlElement().style.cursor = 'pointer';


### PR DESCRIPTION
Fixing: Free Busy calendar view breaking with latest changes.

Root cause: The same view is used in new appointment where the start date is displayed inside the scheduler. In case of Free Busy view, there won’t be any appointment associated and thus this._appt is undefined.

Changeset:
* Adding condition to check for presence of this._appt to be defined.
* Adding ZmOperation.FB_VIEW to the list of tabs to be styled as tab in Calendar App.
* Changing the delete action button to use ImgCancel.svg