### PR TITLE
Cleanup of ZmComposeController.SETTINGS usage

### DIFF
--- a/WebRoot/js/zimbraMail/mail/controller/ZmComposeController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmComposeController.js
@@ -193,12 +193,6 @@ ZmComposeController.prototype.getDefaultViewType = ZmComposeController.getDefaul
 */
 ZmComposeController.prototype.dispose =
 function() {
-	var settings = appCtxt.getSettings();
-	if (ZmComposeController.SETTINGS) { //no SETTINGS in child window
-		for (var i = 0; i < ZmComposeController.SETTINGS.length; i++) {
-			settings.getSetting(ZmComposeController.SETTINGS[i]).removeChangeListener(this._settingChangeListener);
-		}
-	}
 	this._composeView.dispose();
 
 	var app = this.getApp();


### PR DESCRIPTION
Was removed in ZmComposeController.SETTINGS because are not used anymore.