### PR TITLE
Updated schema Version

### DIFF
--- a/WebRoot/WEB-INF/web.xml
+++ b/WebRoot/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <web-app xmlns="http://java.sun.com/xml/ns/j2ee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-    version="2.4">
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">
 
   <context-param>
     <param-name>org.eclipse.jetty.servlet.SessionPath</param-name>


### PR DESCRIPTION
The tag async-supported only exists from schema version 3.0 onwards. So the XML version was upped and both schema location changed to the correct ones