### PR TITLE
Updated look and feel of calendar week view and work week view as per mockup

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -2543,7 +2543,6 @@ INPUT[type="text"].InlineWidget {
 	font-size:0px;
 	height:4px;
 	line-height:0px;
-	margin:-3px;
 	position:static;
 }
 
@@ -2583,13 +2582,7 @@ INPUT[type="text"].InlineWidget {
 
 /* Year label */
 .calendar_heading_year_text {
-	@Label@
-	padding-top:@TextPaddingSize@;
-	position:absolute;
-	left:0px;
-	overflow:hidden;
-	vertical-align:middle;
-	text-align:center;
+	@CalendarHeadingYearText@
 }
 
 /* day label in various states */
@@ -2597,26 +2590,23 @@ INPUT[type="text"].InlineWidget {
 .calendar_heading_day-selected,
 .calendar_heading_day_today,
 .calendar_heading_day_today-selected {
-	@Label@
-	@FullSize@
-	padding-top:@TextPaddingSize@;
-	text-align:center;
-	vertical-align:middle;
+	@CalendarHeadingDay@
 }
 
 .calendar_heading_day-selected {
-	@SelectedBg@
+	@CalendarHeadingDaySelected@
 }
 
 .calendar_heading_day_today {
-	@Text-today@
-	font-weight:bold;
+	@CalendarHeadingDayToday@
+}
+
+.calendar_heading_day_today_txt {
+	@CalendarHeadingDayTodayTxt@
 }
 
 .calendar_heading_day_today-selected {
-	@SelectedBg@
-	@Text-today@
-	font-weight:bold;
+	@CalendarHeadingDayTodaySelectedTxt@
 }
 
 .calendar_heading_day_tab {
@@ -2632,7 +2622,6 @@ INPUT[type="text"].InlineWidget {
 	@HSashSize@
 	@CalendarSeparatorBg@
 	@ActiveCursor@
-	@CalendarBottomSeparator@
 }
 
 /* Separator between all-day and hourly sections */
@@ -2659,6 +2648,10 @@ INPUT[type="text"].InlineWidget {
 .calendar_day_separator {
 	@CalendarSeparatorBg@
 	font-size:0px;
+}
+
+.calendar_day_selected_separator {
+	@CalendarSeparatorSelectedBg@
 }
 
 .calendar_edit_field {

--- a/WebRoot/js/zimbraMail/calendar/ZmCalendarApp.js
+++ b/WebRoot/js/zimbraMail/calendar/ZmCalendarApp.js
@@ -421,13 +421,13 @@ function() {
 
 ZmCalendarApp.prototype._registerOperations =
 function() {
-	ZmOperation.registerOp(ZmId.OP_CAL_LIST_VIEW, {textKey:"list", tooltipKey:"viewCalListTooltip", image:"CalListView", shortcut:ZmKeyMap.CAL_LIST_VIEW});
+	ZmOperation.registerOp(ZmId.OP_CAL_LIST_VIEW, {textKey:"list", tooltipKey:"viewCalListTooltip", shortcut:ZmKeyMap.CAL_LIST_VIEW});
 	ZmOperation.registerOp(ZmId.OP_CAL_REFRESH, {textKey:"refresh", tooltipKey:"calRefreshTooltip", image:"Refresh", shortcut:ZmKeyMap.REFRESH, showImageInToolbar: true});
-	ZmOperation.registerOp(ZmId.OP_CAL_VIEW_MENU, {textKey:"view", image:"Appointment"}, null,
+	ZmOperation.registerOp(ZmId.OP_CAL_VIEW_MENU, {textKey:"view"}, null,
 		AjxCallback.simpleClosure(function(parent) {
 			ZmOperation.addDeferredMenu(ZmCalendarApp.addCalViewMenu, parent);
 	}));
-	ZmOperation.registerOp(ZmId.OP_DAY_VIEW, {textKey:"viewDay", tooltipKey:"viewDayTooltip", image:"DayView", shortcut:ZmKeyMap.CAL_DAY_VIEW});
+	ZmOperation.registerOp(ZmId.OP_DAY_VIEW, {textKey:"viewDay", tooltipKey:"viewDayTooltip", shortcut:ZmKeyMap.CAL_DAY_VIEW});
 	ZmOperation.registerOp(ZmId.OP_EDIT_REPLY_ACCEPT, {textKey:"replyAccept", image:"Check"});
 	ZmOperation.registerOp(ZmId.OP_EDIT_REPLY_CANCEL);
 	ZmOperation.registerOp(ZmId.OP_EDIT_REPLY_TENTATIVE, {textKey:"replyTentative", image:"QuestionMark"});
@@ -439,19 +439,19 @@ function() {
 			ZmOperation.addDeferredMenu(ZmCalendarApp.addInviteReplyMenu, parent);
 	}));
 	ZmOperation.registerOp(ZmId.OP_INVITE_REPLY_TENTATIVE, {textKey:"editReply"});
-	ZmOperation.registerOp(ZmId.OP_MONTH_VIEW, {textKey:"viewMonth", tooltipKey:"viewMonthTooltip", image:"MonthView", shortcut:ZmKeyMap.CAL_MONTH_VIEW});
+	ZmOperation.registerOp(ZmId.OP_MONTH_VIEW, {textKey:"viewMonth", tooltipKey:"viewMonthTooltip", shortcut:ZmKeyMap.CAL_MONTH_VIEW});
 	ZmOperation.registerOp(ZmId.OP_MOUNT_CALENDAR, {textKey:"mountCalendar", image:"GroupSchedule"});
-	ZmOperation.registerOp(ZmId.OP_NEW_ALLDAY_APPT, {textKey:"newAllDayAppt", tooltipKey:"newAllDayApptTooltip", image:"NewAppointment"});
+	ZmOperation.registerOp(ZmId.OP_NEW_ALLDAY_APPT, {textKey:"newAllDayAppt", tooltipKey:"newAllDayApptTooltip"});
 	ZmOperation.registerOp(ZmId.OP_NEW_APPT, {textKey:"newAppt", tooltipKey:"newApptTooltip", shortcut:ZmKeyMap.NEW_APPT});
 	ZmOperation.registerOp(ZmId.OP_NEW_CALENDAR, {textKey:"newCalendar", tooltipKey: "newCalendarTooltip", shortcut:ZmKeyMap.NEW_CALENDAR});
-	ZmOperation.registerOp(ZmId.OP_ADD_EXTERNAL_CALENDAR, {textKey:"addExternalCalendar", image:"NewAppointment", tooltipKey: "addExternalCalendarTooltip", shortcut:ZmKeyMap.ADD_EXTERNAL_CALENDAR});
-    ZmOperation.registerOp(ZmId.OP_PRINT_CALENDAR, {textKey:"print", tooltipKey:"printTooltip", image:"Print", shortcut:ZmKeyMap.PRINT, textPrecedence:30, showImageInToolbar: true}, ZmSetting.PRINT_ENABLED);
-    ZmOperation.registerOp(ZmId.OP_PROPOSE_NEW_TIME, {textKey:"proposeNewTime", showTextInToolbar: true, showImageInToolbar: true});
-    ZmOperation.registerOp(ZmId.OP_REINVITE_ATTENDEES, {textKey:"reinviteAttendees", image:"MeetingRequest"});
-    ZmOperation.registerOp(ZmId.OP_FB_VIEW, {textKey:"viewFB", tooltipKey:"viewFBTooltip", image:"GroupSchedule", shortcut:ZmKeyMap.CAL_FB_VIEW});
+	ZmOperation.registerOp(ZmId.OP_ADD_EXTERNAL_CALENDAR, {textKey:"addExternalCalendar", tooltipKey: "addExternalCalendarTooltip", shortcut:ZmKeyMap.ADD_EXTERNAL_CALENDAR});
+	ZmOperation.registerOp(ZmId.OP_PRINT_CALENDAR, {textKey:"print", tooltipKey:"printTooltip", image:"Print", shortcut:ZmKeyMap.PRINT, textPrecedence:30, showImageInToolbar: true}, ZmSetting.PRINT_ENABLED);
+	ZmOperation.registerOp(ZmId.OP_PROPOSE_NEW_TIME, {textKey:"proposeNewTime", showTextInToolbar: true, showImageInToolbar: true});
+	ZmOperation.registerOp(ZmId.OP_REINVITE_ATTENDEES, {textKey:"reinviteAttendees", image:"MeetingRequest"});
+	ZmOperation.registerOp(ZmId.OP_FB_VIEW, {textKey:"viewFB", tooltipKey:"viewFBTooltip", image:"GroupSchedule", shortcut:ZmKeyMap.CAL_FB_VIEW});
 	ZmOperation.registerOp(ZmId.OP_SEARCH_MAIL, {textKey:"searchMail", image:"SearchMail"}, ZmSetting.MAIL_ENABLED);
 	ZmOperation.registerOp(ZmId.OP_SHARE_CALENDAR, {textKey:"shareCalendar", image:"CalendarFolder"});
-	ZmOperation.registerOp(ZmId.OP_TODAY, {textKey:"today", tooltipKey:"todayTooltip", image:"Date", shortcut:ZmKeyMap.TODAY});
+	ZmOperation.registerOp(ZmId.OP_TODAY, {textKey:"today", tooltipKey:"todayTooltip", shortcut:ZmKeyMap.TODAY});
 	ZmOperation.registerOp(ZmId.OP_VIEW_APPOINTMENT, {textKey:"viewAppointment", image:"Appointment"});
 	ZmOperation.registerOp(ZmId.OP_OPEN_APPT_INSTANCE, {textKey:"openApptInstance", image:"Appointment"});
 	ZmOperation.registerOp(ZmId.OP_OPEN_APPT_SERIES, {textKey:"openApptSeries", image:"Appointment"});
@@ -459,8 +459,8 @@ function() {
 	ZmOperation.registerOp(ZmId.OP_DELETE_APPT_SERIES, {textKey:"deleteApptSeries", image:"Delete"});
 	ZmOperation.registerOp(ZmId.OP_VIEW_APPT_INSTANCE, {textKey:"apptInstance", image:"Appointment"});
 	ZmOperation.registerOp(ZmId.OP_VIEW_APPT_SERIES, {textKey:"apptSeries", image:"Appointment"});
-	ZmOperation.registerOp(ZmId.OP_WEEK_VIEW, {textKey:"viewWeek", tooltipKey:"viewWeekTooltip", image:"WeekView", shortcut:ZmKeyMap.CAL_WEEK_VIEW});
-	ZmOperation.registerOp(ZmId.OP_WORK_WEEK_VIEW, {textKey:"viewWorkWeek", tooltipKey:"viewWorkWeekTooltip", image:"WorkWeekView", shortcut:ZmKeyMap.CAL_WORK_WEEK_VIEW});
+	ZmOperation.registerOp(ZmId.OP_WEEK_VIEW, {textKey:"viewWeek", tooltipKey:"viewWeekTooltip", shortcut:ZmKeyMap.CAL_WEEK_VIEW});
+	ZmOperation.registerOp(ZmId.OP_WORK_WEEK_VIEW, {textKey:"viewWorkWeek", tooltipKey:"viewWorkWeekTooltip", shortcut:ZmKeyMap.CAL_WORK_WEEK_VIEW});
 	ZmOperation.registerOp(ZmId.OP_FORWARD_APPT, {textKey:"forward", tooltipKey:"forward", image:"Forward"});
 	ZmOperation.registerOp(ZmId.OP_FORWARD_APPT_INSTANCE, {textKey:"forwardInstance", tooltipKey:"forwardInstance", image:"Forward"});
 	ZmOperation.registerOp(ZmId.OP_FORWARD_APPT_SERIES, {textKey:"forwardSeries", tooltipKey:"forwardSeries", image:"Forward"});

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1598,13 +1598,21 @@ DndNotAllowedContainer      = border:2px solid @DropNotAllowedColor@ !important;
 ###################
 
 MailCalendarView            = border-left: none; border-right:none;
-CalendarHeading             = background-color: @AppC@; padding-top:2px; box-shadow: 0 1px 2px 0 rgba(120, 120, 120, 0.5);
+CalendarHeading             = background-color: @AppC@; padding-top:4px;
 CalendarBorderColor         = #DBDBDB;
 CalendarSeparatorBg         = background-color:@CalendarBorderColor@; padding:0px;
+CalendarSeparatorSelectedBg = background-color:@PrimaryBrandingColor@;
 CalendarBottomSeparator     = @BottomSeparator@; border-color: @CalendarBorderColor@;
 CalendarNavToolbarTitle     = font-size:1.5em; font-weight:100; vertical-align:middle; @ToolbarButtonHeight@ @DisplayTableCell@
 CalendarMonthHeaderCell     = @PageHeaderBg@ @PageHeaderText@ @FontSize-slightly-big@ @BottomSeparator@ @Label@ text-align:left; padding: 8px @SmallBoxPaddingSize@;
 CalendarDayMergedTitle      = max-width:none; width:1px; padding:@SkinViewInnerSpacing@ 0 0 0; text-indent:14px; z-index:99;
+
+CalendarHeadingYearText             = @Label@ padding-top:@TextPaddingSize@; position:absolute; left:0px; overflow:hidden; vertical-align:middle; text-align:center; @FontSize-slightly-big@;
+CalendarHeadingDay                  =  @Label-light@; @FullSize@; padding-top:@TextPaddingSize@; vertical-align:middle; text-indent:8px; @FontSize-slightly-big@;
+CalendarHeadingDaySelected          = 
+CalendarHeadingDayToday             = @Label@; @Text-today@; font-weight:bold;
+CalendarHeadingDayTodayTxt          = float: right; font-weight: normal; @Text-link@; @Text-uppercase@; display:inline-block; margin-right:8px;
+CalendarHeadingDayTodaySelectedTxt  = @Text-today@; font-weight:bold;
 
 # Free-Busy view
 FreeBusyViewHeaderWidth     = width:27px;


### PR DESCRIPTION
Changes:
* `ZmCalColView.js`
  * Updated and adjusted spacing between different calendar elements as per mockup
  * Added logic for highlighting vertical separators for today as per mockup
  * Updated logic to stretch current time indicator from end-to-end
* Updated `zm.css` and `skin.properties` as per requirement

https://jira.corp.synacor.com/browse/ZCS-749