### PR TITLE
ZCS-3066: Universal UI - Closing and reopening conversation in reading pane shows empty dropdown in the reading pane.

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/ZmInviteMsgView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmInviteMsgView.js
@@ -771,11 +771,11 @@ function() {
 		button.setMenu(menu);
 	}
 
-	this._respondOnBehalfLabel = new DwtControl({parent:tb.parent});
+	this._respondOnBehalfLabel = new DwtControl({parent:tb});
 	// tb.addFiller();
 
 	// folder picker
-	this._inviteMoveSelect = new DwtSelect({parent:tb.parent});
+	this._inviteMoveSelect = new DwtSelect({parent:tb});
 	this._inviteMoveSelect.setVisible(false); //by default hide it. bug 74254
 
 	return tb;


### PR DESCRIPTION
Fix:
* Setting parent of `moveSelect` container to `inviteToolbar` which was `inviteMessage` before

https://jira.corp.synacor.com/browse/ZCS-3066