### PR TITLE
ZCS-2993: Universal UI - Confirm Delete dialog not display properly

### DIFF
--- a/WebRoot/css/dwt.css
+++ b/WebRoot/css/dwt.css
@@ -797,13 +797,12 @@ UL.DwtListView-Rows {
 
 /* Outer container for the confirmation dialog */
 .DwtConfirmDialog {
-	max-width:400px;
+	max-width:70%;
 }
 
 /* Font for confirmation dialogs ('Are you sure you want to delete?') */
 .DwtConfirmDialogQuestion {
 	@FontSize-big@
-	@BoxMargin@
 }
 
 


### PR DESCRIPTION
Fix:
* Increased `max-width` of `DwtConfirmDialog` to `70%`, which should be enough for all cases
* Removed unwanted margins on `DwtConfirmDialogQuestion `

https://jira.corp.synacor.com/browse/ZCS-2993