### PR TITLE
ZCS-2997: Universal UI - Reminder dialog should not change size for appointment with longer subjects

### DIFF
--- a/WebRoot/skins/_base/base4/skin.css
+++ b/WebRoot/skins/_base/base4/skin.css
@@ -1277,3 +1277,8 @@ div[name='_mergeBtnContainerId'] .ZCalToggleBtnSelected .ZWidgetTitle {
 .ZmCalPrintDialog td[id$="todayButtonContainer"] .ZWidgetTitle {
     @AlignLeft@
 }
+
+.ZmApptQuickAddDialog .ZSelect .ZWidgetTitle {
+    max-width: 1px;
+    @OverflowEllipsis@
+}

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1670,18 +1670,19 @@ ZmQuickAddApptDialogSelect      = display: block;
 ZmQuickAddApptDialogMoreDetails = padding-left: @SkinViewInnerSpacing@;
 
 # Reminder Dialog
+ReminderDialogMaxWidth      = 600px
 ReminderDialogContainer     = padding:0;
 ReminderDialogTitle         = padding: @SkinViewGutterSpace@ @SkinWrapperPadding@; @SlightlyBigRoundCorners@; @FontSize-normal@; background-color: @WidgetBgColor@; 
 ReminderDialogSeparator     = margin: @SkinViewInnerSpacing@ 0;
-ReminderDialogFullContent   = overflow:hidden; width:auto; padding: @SkinWrapperPadding@; padding-top:0;
+ReminderDialogFullContent   = overflow:hidden; width:auto; max-width:@ReminderDialogMaxWidth@; padding: @SkinWrapperPadding@; padding-top:0;
 ReminderDialogContentTable  = min-width:420px; width:100%;
 ReminderDialogContent       = overflow-y:auto; max-height:400px; max-height: 50vh; display:block;
-ReminderDialogApptLink      = @FontSize-slightly-bigger@
+ReminderDialogApptLink      = @FontSize-slightly-bigger@; @OverflowEllipsis@; display:block;
 ReminderDialogText          = @Text-important@; padding-right: @SkinViewInnerSpacing@;
 ReminderDialogText-future   = @ReminderDialogText@
 ReminderDialogText-soon     = @ReminderDialogText@
 ReminderDialogText-overdue  = @ReminderDialogText@
-ReminderDialogApptLinkContainer = margin-bottom:1.333rem;
+ReminderDialogApptLinkContainer = margin-bottom:1.333rem; max-width:@ReminderDialogMaxWidth@;
 ReminderDialogAppointmentButton = display:inline-block;
 
 # Suggestion preference dialog


### PR DESCRIPTION
Fix:
* Set `max-width` of reminder dialog and it’s subject as well
* Added custom css rule to handle very long calendar name in calendar select dropdown.

https://jira.corp.synacor.com/browse/ZCS-2997