### PR TITLE
ZCS-2905: Universal UI- Calendar NavToolbar filling extra space on the right, making buttons next to it unclickable.

### DIFF
--- a/WebRoot/css/dwt.css
+++ b/WebRoot/css/dwt.css
@@ -2116,7 +2116,7 @@ INPUT.xform_field {
 
 .ZmMailMsgView .ZToolbar	{ @ToolbarContainer@	}
 
-.ZToolbarTable				{ /*width:100%;*/ }
+.ZToolbarTable				{ position: relative; }
 .ZToolbarPrefix				{ width:.5em; }
 .ZToolbarSuffix				{ width:100%; }
 

--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -3184,12 +3184,7 @@ HTML>BODY .appt-selected .appt_allday_body {
 	position:absolute;
 	top:0px;
 	left:50%;
-}
-
-.ZmCalendarNavToolbar > TABLE {
-	position:relative;
-	top:0px;
-	left:-50%;
+	transform: translateX(-50%);
 }
 
 .ZCalToggleBtn TABLE {


### PR DESCRIPTION
Fix:
* Used `transform` property to centre align container

https://jira.corp.synacor.com/browse/ZCS-2905