### PR TITLE
 ZCS-904 Support SVG sprite in IE11

### DIFF
--- a/WebRoot/js/zimbraMail/package/NewWindow_1.js
+++ b/WebRoot/js/zimbraMail/package/NewWindow_1.js
@@ -109,6 +109,8 @@ AjxPackage.require("ajax.dwt.widgets.DwtPropertySheet");
 AjxPackage.require("ajax.dwt.widgets.DwtPropertyPage");
 AjxPackage.require("ajax.dwt.widgets.DwtTabView");
 AjxPackage.require("ajax.dwt.widgets.DwtTimeSelect");
+
 AjxPackage.require("ajax.3rdparty.jquery.jquery");
+AjxPackage.require("ajax.3rdparty.svg4everybody.svg4everybody");
 
 AjxPackage.require("zimbraMail.share.view.ZmTagsHelper");

--- a/WebRoot/js/zimbraMail/package/Startup1_1.js
+++ b/WebRoot/js/zimbraMail/package/Startup1_1.js
@@ -122,6 +122,7 @@ AjxPackage.require("ajax.dwt.widgets.DwtChooser");
 AjxPackage.require("ajax.dwt.widgets.DwtTimeSelect");
 
 AjxPackage.require("ajax.3rdparty.jquery.jquery");
+AjxPackage.require("ajax.3rdparty.svg4everybody.svg4everybody");
 
 AjxPackage.require("zimbra.csfe.ZmBatchCommand");
 AjxPackage.require("zimbra.csfe.ZmCsfeCommand");

--- a/WebRoot/public/launchNewWindow.jsp
+++ b/WebRoot/public/launchNewWindow.jsp
@@ -210,7 +210,13 @@ delete text;
 			// use main window's debug object
 			window.DBG = window.opener.DBG;
 		}
+
 		ZmNewWindow.run();
+
+		// Inititialize svg4everybody for IE11
+		if(AjxEnv.isModernIE && !AjxEnv.isMSEdge && svg4everybody) {
+			svg4everybody();
+		}
 	}
 	AjxCore.addOnloadListener(launch);
 	AjxCore.addOnunloadListener(ZmNewWindow.unload);

--- a/WebRoot/public/launchZCS.jsp
+++ b/WebRoot/public/launchZCS.jsp
@@ -489,6 +489,11 @@ delete text;
 			virtualAcctDomain:virtualAcctDomain
 		};
 		ZmZimbraMail.run(params);
+
+		// Inititialize svg4everybody for IE11
+		if(AjxEnv.isModernIE && !AjxEnv.isMSEdge && svg4everybody) {
+			svg4everybody();
+		}
 		
 		delete virtualAcctDomain;
 	}

--- a/WebRoot/skins/_base/base4/skin.css
+++ b/WebRoot/skins/_base/base4/skin.css
@@ -106,7 +106,7 @@ BODY                                    {   margin:0px;     }
 #skin_spacing_search,
 #skin_spacing_people_search             {   @AppTabHeight@  }
 #skin_container_search                  {   @SkinSearchHeight@ }
-#skin_container_search .svg-icon         {   fill: initial; opacity: 1;  }
+#skin_container_search .svg-icon         {   fill: @SVGIconDefaultColor@; opacity: 1;  }
 
 #skin_container_search .ZmSearchToolbar {   @SkinSearchToolbar@         }
 #skin_container_search .ZButton         {   @SkinSearchHeight@ border-right: 1px solid @hexToRGBA(SecondaryBrandingColor, 17)@;  }

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1923,6 +1923,7 @@ AddVerticalSpace            =
 ImagePadding                = padding-right:@BoxMarginSize@;
 
 SVGIcon                     = @SmallIconSize@  vertical-align: middle; pointer-events: none;
+SVGIconDefaultColor         = black
 
 SmallIconSize               = width:@SmallIconWidth@; height:@SmallIconHeight@;
 BigIconSize                 = width:@BigIconWidth@; height:@BigIconHeight@;

--- a/build.xml
+++ b/build.xml
@@ -94,6 +94,10 @@
     <property name="jquery.version" value="1.11.0"/>
     <property name="jquery.dir" value="${build.js.dir}/ajax/3rdparty/jquery"/>
 
+    <!-- SVG4Everybody INTEGRATION -->
+    <property name="svg4everybody.version" value="2.1.8"/>
+    <property name="svg4everybody.dir" value="${build.js.dir}/ajax/3rdparty/svg4everybody"/>
+
     <!-- Paths and Filesets -->
 
     <!-- pseudo-fileset so that targets that rely on it don't fail -->
@@ -279,7 +283,7 @@
         <delete dir="${build.tmp.dir}"/>
     </target>
 
-    <target name='sync' depends='resolve,copy-ajax,jquery,modernizr,tinymce,templates'>
+    <target name='sync' depends='resolve,copy-ajax,jquery,svg4everybody,modernizr,tinymce,templates'>
         <!-- NOTE: Keep order in sync with list of war filesets. -->
         <copy todir='${webapp.dir}/WEB-INF' verbose='${sync.verbose}'>
             <fileset refid="webinf.fileset" />
@@ -912,7 +916,7 @@
         </if>
     </target>
 
-    <target name='jam-files' depends='jquery,modernizr,tinymce,templates'>
+    <target name='jam-files' depends='jquery,svg4everybody,modernizr,tinymce,templates'>
         <property name='jam.jsp.dir' value='${build.web.dir}/public/jsp'/>
         <mkdir dir='${build.js.dir}'/>
         <mkdir dir='${jam.jsp.dir}'/>
@@ -1217,6 +1221,7 @@ ext = BeanUtils.cook(ext);
         <delete dir='${build.dir}'/>
         <delete dir='${customer.build.dir}'/>
         <delete dir='${web.dir}/jquery'/>
+        <delete dir='${web.dir}/svg4everybody'/>
         <delete dir='${web.dir}/modernizr'/>
         <delete dir='${web.dir}/yui'/>
         <delete dir='${web.dir}/js/ajax'/>
@@ -1592,6 +1597,19 @@ ext = BeanUtils.cook(ext);
 
     <target name="jquery">
         <copy todir='${jquery.dir}' file='${web.dir}/jquery/${jquery.version}/jquery.js' verbose='${sync.verbose}'/>
+    </target>
+
+    <target name="svg4everybody" depends="resolve">
+        <!-- Download library jar file -->
+        <ivy:install organisation='org.webjars.npm' module='svg4everybody' revision='${svg4everybody.version}' settingsRef='dev.settings' from='chain-resolver' to='build-tmp' overwrite='true' transitive='true' />
+
+        <unzip dest='${build.tmp.dir}/svg4everybody' overwrite='true'>
+            <fileset dir='${build.tmp.dir}'>
+                <include name='svg4everybody-${svg4everybody.version}.jar' />
+            </fileset>
+        </unzip>
+
+        <copy tofile='${svg4everybody.dir}/svg4everybody.js' file='${build.tmp.dir}/svg4everybody/META-INF/resources/webjars/svg4everybody/${svg4everybody.version}/dist/svg4everybody.js' verbose='${sync.verbose}'/>
     </target>
 
     


### PR DESCRIPTION
- Use svg4everybody lib for adding support for using svg fragments in IE11
- fill: initial was not working in IE11, instead use black color