### PR TITLE
ZCS-3282 Universal UI: Exception thrown when day view is selected in calendar in internet explorer

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalDayView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalDayView.js
@@ -480,10 +480,10 @@ function(workingHours) {
 	var endTime = workingHrs.endTime[0];
 	var minTimeFrame = startTime/100;
 	var maxTimeFrame = endTime/100;
-	
-	this.hoursLabelNodeList.forEach(function(node, index){
-		Dwt.condClass(node, index >= minTimeFrame && index < maxTimeFrame, "ZActive", "ZDisabled");
-	});
+
+	for(var index = 0, len = this.hoursLabelNodeList.length; index < len; index++) {
+		Dwt.condClass(this.hoursLabelNodeList[index], index >= minTimeFrame && index < maxTimeFrame, "ZActive", "ZDisabled");
+	}
 };
 
 ZmCalDayTabView.prototype.layoutWorkingHours =


### PR DESCRIPTION
- use normal for loop as forEach on NodeList is not supported in IE