### PR TITLE
ZCS-2995 Universal UI : Right Navbar options got disappeared on doing zoom out and then rest to default

### DIFF
--- a/WebRoot/js/zimbraMail/share/view/ZmAppChooser.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmAppChooser.js
@@ -152,7 +152,12 @@ function(display){
         while (this._isTabOverflow(moreBtnContainerEl)){
             //hide last visible tab if more button overFlow's
             var lastVisibleTab = this.getLastVisibleTab();
-            lastVisibleTab && lastVisibleTab.setVisible(false);
+            if(lastVisibleTab) {
+                lastVisibleTab.setVisible(false);
+            } else {
+                // If there is no visible tab available then break the loop
+                break;
+            }
         }
     }
 };


### PR DESCRIPTION
- fix issue where zooming to 200% was hanging browser
- make sure if we don't have any visible tab left then break the loop