### PR TITLE
ZCS-1865 Universal UI: Mail compose screen is not being rendered properly in MS Edge browser

### DIFF
--- a/WebRoot/js/zimbraMail/share/view/ZmAddressInputField.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmAddressInputField.js
@@ -620,7 +620,7 @@ function(params) {
 	this._label = params.label;
 	this._dragInsertionBarId = Dwt.getNextId();
 	var data = {
-		inputTagName:		AjxEnv.isIE || AjxEnv.isModernIE ? 'textarea' : 'input type="text" ',
+		inputTagName:		'input type="text" ',
 		holderId:			this._holderId,
 		inputId:			this._inputId,
 		label:				this._label,


### PR DESCRIPTION
- remove use of textarea instead of input fields in IE, as I don't see any issues in IE11 and Edge