### PR TITLE
Bug 108598: Properly jsEncode multi valued attrs

### DIFF
--- a/WebRoot/public/launchZCS.jsp
+++ b/WebRoot/public/launchZCS.jsp
@@ -470,8 +470,14 @@ delete text;
                     </c:when>
                     <c:otherwise>
                         <%--Multi value domain attribute--%>
-                        <c:set var="infoArray" value="${fn:join(info.value, '\", \"')}"/>
-                        ["${infoArray}"]
+                        [
+                        <c:forEach var="infoItem" varStatus="infoStatus" items="${info.value}">
+                            "${zm:jsEncode(infoItem)}"
+                            <c:if test="${not infoStatus.last}">
+                                ,
+                            </c:if>
+                        </c:forEach>
+                        ]
                     </c:otherwise>
                     </c:choose>
             </c:forEach>


### PR DESCRIPTION
This code was introduced in bug 61880 in 2011 but the `jsEncode`ing of the items was missed.