### PR TITLE
ZCS-3228 Right-align "New" button arrow with arrows in folder tree

### DIFF
--- a/WebRoot/skins/_base/base4/skin.css
+++ b/WebRoot/skins/_base/base4/skin.css
@@ -198,6 +198,7 @@ BODY                                    {   margin:0px;     }
 #skin_spacing_app_top_toolbar           {   @ToolbarButtonHeight@     }
 #skin_container_app_top_toolbar         {   @SkinBorderAppToolbar@ width:auto; padding-left:@SashSize@; }
 #skin_container_app_new_button          {   @SkinBorderAppToolbar@ width: 10px; }
+#skin_container_app_new_button_filler   {   width: @TreeStartWidth@;   }
 
 
 /** App  **/


### PR DESCRIPTION
- Fix for setting default width so for new users new button will have some width and will not overlap with right side toolbar