### PR TITLE
ZCS-3316: Universal UI- Attendee list displayed on hover tooltip on meeting invite is broken

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -7647,6 +7647,12 @@ input[type="radio"] + label {
 	@AppointmentTooltipValue@	
 }
 
+.ZmAppointmentTooltip TD.ZmAppointmentTooltipValue ul {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
 /* Appointment create/edit view */
 .ZmApptEditView {
 	@ApptEditView@

--- a/WebRoot/js/zimbraMail/calendar/model/ZmAppt.js
+++ b/WebRoot/js/zimbraMail/calendar/model/ZmAppt.js
@@ -332,7 +332,7 @@ function(ptstHashKey) {
 ZmAppt.prototype.getAttendeeToolTipString =
 function(val) {
 	var str;
-	var maxLimit = 10;
+	var maxLimit = 3;
 	if (val && val.length > maxLimit) {
 		var origLength = val.length;
 		var newParts = val.splice(0, maxLimit);

--- a/WebRoot/templates/calendar/Appointment.template
+++ b/WebRoot/templates/calendar/Appointment.template
@@ -1009,7 +1009,15 @@
 		$>
 			<tr>
 				<td colspan='2' class='ZmAppointmentTooltipLabel'>
-					<$= AjxStringUtil.htmlEncode(data.attendeesText) $>
+					<$ 
+						var attendees = data.attendeesText;
+						attendees = attendees.split(",");
+					$>
+					<ul>
+						<$ for (var i = 0; i < attendees.length; i++) { $>
+							<li><$= AjxStringUtil.htmlEncode(attendees[i]); $></li>
+						<$ } $>
+					</ul>
 				</td>
 			</tr>
 		<$
@@ -1023,7 +1031,15 @@
 						<$= AjxMessageFormat.format(ZmMsg.makeLabel, AjxStringUtil.htmlEncode(i) + "&nbsp;(" + ptstStatus[i].count + ")&nbsp;") $>
 					</td>
 					<td class='ZmAppointmentTooltipValue'>
-						<$= AjxStringUtil.htmlEncode(ptstStatus[i].attendees) $>
+						<$ 
+							var attendees = ptstStatus[i].attendees;
+							attendees = attendees.split(",");
+						$>
+						<ul>
+							<$ for (var i = 0; i < attendees.length; i++) { $>
+								<li><$= AjxStringUtil.htmlEncode(attendees[i]); $></li>
+							<$ } $>
+						</ul>
 					</td>
 				</tr>
 		<$


### PR DESCRIPTION
Changes:
* Shown max upto 3 attendees on tooltip on new line each
* Updated template to display attendee on separate row

https://jira.corp.synacor.com/browse/ZCS-3316