### PR TITLE
ZCS-3320: Universal UI- Calendar list is not aligned in Move menu and incomplete calendar name is displayed if calendar name is very long

### DIFF
--- a/WebRoot/js/zimbraMail/share/view/ZmFolderChooser.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmFolderChooser.js
@@ -159,7 +159,8 @@ function(params) {
 ZmFolderChooser.prototype._setOverview =
 function(params, forceSingle) {
 	params.overviewClass = "menuOverview";
-	params.dynamicWidth = true;
+	//make folder chooser of fixed width
+	//params.dynamicWidth = true;
 
 	var overview = ZmDialog.prototype._setOverview.call(this, params, forceSingle); //reuse from ZmDialog
 


### PR DESCRIPTION
Changes:
* Made `ZmFolderChooser` dropdown of fixed width

https://jira.corp.synacor.com/browse/ZCS-3320