### PR TITLE
ZCS-2418: Universal UI- Share folder dialog

### DIFF
--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmSharePropsDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmSharePropsDialog.js
@@ -214,6 +214,7 @@ function(mode, object, share) {
 	this._reply.reparentHtmlElement(this._replyId);
 
 	DwtDialog.prototype.popup.call(this);
+	Dwt.setLocation(this.getHtmlElement(), Dwt.DEFAULT, 10);
 
 	this.setButtonEnabled(DwtDialog.OK_BUTTON, false);
 	if (isNewShare) {

--- a/WebRoot/skins/_base/base4/skin.properties
+++ b/WebRoot/skins/_base/base4/skin.properties
@@ -1764,7 +1764,7 @@ WindowInnerBorder           = padding-top: @SkinWrapperPadding@;
 LightWindowInnerBorder      = @WindowInnerBorder@
 WindowButtonBar             = padding-top: @SkinWrapperPadding@;
 
-Dialog                      = min-width:320px; max-width:90vw; max-height:90vh; overflow:auto;
+Dialog                      = min-width:320px; max-width:90vw; max-height:90vh; overflow:auto; @FixBoxModel@;
 DialogBackGroundColor       = background-color: @lighten(SecondaryBrandingColor, 94)@;
 DialogBodyText              = @FontSize-slightly-big@
 DialogBody                  = @DialogBodyText@; cursor:default; overflow:auto;


### PR DESCRIPTION
* Positioned shared folder dialog at `center top` while opening, so that when content grows it doesn't go beyond the screen

https://jira.corp.synacor.com/browse/ZCS-2418