### PR TITLE
ZCS-3570: Unable to close time frame in Calendar with Month view

### DIFF
--- a/WebRoot/WEB-INF/tags/calendar/zoomView.tag
+++ b/WebRoot/WEB-INF/tags/calendar/zoomView.tag
@@ -79,7 +79,7 @@
                 </span>
             </td>
             <td align="right">
-                <app:calendarUrl var="monthUrl" view="month" timezone="${timezone}" rawdate="${currentDay}"/>
+                <app:calendarUrl var="monthUrl" zoom="${null}" view="month" timezone="${timezone}" rawdate="${currentDay}"/>
                 <a href="${fn:escapeXml(monthUrl)}"><app:img src="common/ImgCancel.png" alt="close"/></a>
             </td>
         </tr>


### PR DESCRIPTION
Fix:
* Set `zoom` param to null for close button URL

https://jira.corp.synacor.com/browse/ZCS-3570