### PR TITLE
Bug 102701: Added trailing space to search value.

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -2152,7 +2152,7 @@ function(view) {
 				if (appCtxt.get(ZmSetting.SHOW_SEARCH_STRING) && stb) {
 					var value = currentSearch ? currentSearch.query : app.currentQuery;
 					value = appName === ZmApp.SEARCH ? "" : value;
-					stb.setSearchFieldValue(value || "");
+					stb.setSearchFieldValue(value + " " || "");
 				}
 			}
 


### PR DESCRIPTION
When using the hotkey "/" to set focus to the search box, the current search query is added to the search box without a trailing space. This leads to the situation where anything added by the user to the search is appended to the original query, causing a malformed query string. This fix simply adds a space to the end of the query string when the search field value is set.

Manual testing has verified the fix. Additional tests will be added to the selenim test suite to future-proof the fix.