### PR TITLE
Bugzilla-77129: display received time in email list

### DIFF
--- a/WebRoot/js/zimbraMail/mail/ZmMailApp.js
+++ b/WebRoot/js/zimbraMail/mail/ZmMailApp.js
@@ -286,6 +286,7 @@ function() {
 				ZmSetting.DEDUPE_MSG_TO_SELF,
                 ZmSetting.DEDUPE_MSG_ENABLED,
 				ZmSetting.DISPLAY_EXTERNAL_IMAGES,
+				ZmSetting.DISPLAY_TIME_IN_MAIL_LIST,
 				ZmSetting.GET_MAIL_ACTION,
 				ZmSetting.INITIAL_SEARCH,
 				ZmSetting.MAIL_BLACKLIST,
@@ -397,6 +398,11 @@ function() {
 
 	ZmPref.registerPref("DISPLAY_EXTERNAL_IMAGES", {
 		displayName:		ZmMsg.showExternalImages,
+		displayContainer:	ZmPref.TYPE_CHECKBOX
+	});
+
+	ZmPref.registerPref("DISPLAY_TIME_IN_MAIL_LIST", {
+		displayName:		ZmMsg.displayTimeInMailList,
 		displayContainer:	ZmPref.TYPE_CHECKBOX
 	});
 

--- a/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
@@ -318,7 +318,8 @@ function(htmlArr, idx, item, field, colIdx, params, classes) {
 		idx = this._getImageHtml(htmlArr, idx, item.getAccount().getIcon(), this._getFieldId(item, field), classes);
 	} 
 	else if (field == ZmItem.F_DATE) {
-		var date = AjxDateUtil.computeDateStr(params.now || new Date(), item.date);
+		var displayTime = appCtxt.get(ZmSetting.DISPLAY_TIME_IN_MAIL_LIST);
+		var date = AjxDateUtil.computeDateStr(params.now || new Date(), item.date, displayTime);
 		htmlArr[idx++] = "<div id='";
 		htmlArr[idx++] = this._getFieldId(item, field);
 		htmlArr[idx++] = "' ";
@@ -447,7 +448,8 @@ function() {
 		this._headerInit[ZmItem.F_SUBJECT]		= {text:ZmMsg.subject, sortable:ZmItem.F_SUBJECT, noRemove:true, resizeable:true, cssClass:"ZmMsgListColSubject"};
 		this._headerInit[ZmItem.F_FOLDER]		= {text:ZmMsg.folder, width:ZmMsg.COLUMN_WIDTH_FOLDER, resizeable:true, cssClass:"ZmMsgListColFolder"};
 		this._headerInit[ZmItem.F_SIZE]			= {text:ZmMsg.size, width:ZmMsg.COLUMN_WIDTH_SIZE, sortable:ZmItem.F_SIZE, resizeable:true, cssClass:"ZmMsgListColSize"};
-		this._headerInit[ZmItem.F_DATE]			= {text:ZmMsg.received, width:ZmMsg.COLUMN_WIDTH_DATE, sortable:ZmItem.F_DATE, resizeable:true, cssClass:"ZmMsgListColDate"};
+		var column_width_date = appCtxt.get(ZmSetting.DISPLAY_TIME_IN_MAIL_LIST) ? ZmMsg.COLUMN_WIDTH_DATE_TIME : ZmMsg.COLUMN_WIDTH_DATE;
+		this._headerInit[ZmItem.F_DATE]			= {text:ZmMsg.received, width:column_width_date, sortable:ZmItem.F_DATE, resizeable:true, cssClass:"ZmMsgListColDate"};
 		this._headerInit[ZmItem.F_SORTED_BY]	= {text:AjxMessageFormat.format(ZmMsg.arrangedBy, ZmMsg.date), sortable:ZmItem.F_SORTED_BY, resizeable:false};
 	}
 };

--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -119,6 +119,7 @@ function() {
 	this.getSetting(ZmSetting.ATTACHMENTS_BLOCKED).addChangeListener(listener);
 	this.getSetting(ZmSetting.CHAT_PLAY_SOUND).addChangeListener(listener);
 	this.getSetting(ZmSetting.CHAT_ENABLED).addChangeListener(listener);
+	this.getSetting(ZmSetting.DISPLAY_TIME_IN_MAIL_LIST).addChangeListener(listener);
 
 
 	if (appCtxt.isOffline) {
@@ -1044,6 +1045,7 @@ function() {
 	this.registerSetting("VIEW_AS_HTML",					{name:"zimbraPrefMessageViewHtmlPreferred", type:ZmSetting.T_PREF, dataType:ZmSetting.D_BOOLEAN, defaultValue:false, isGlobal:true});
 	this.registerSetting("VOICE_ACCOUNTS",					{type: ZmSetting.T_PREF, dataType: ZmSetting.D_HASH});
 	this.registerSetting("WARN_ON_EXIT",					{name:"zimbraPrefWarnOnExit", type:ZmSetting.T_PREF, dataType:ZmSetting.D_BOOLEAN, defaultValue:true});
+	this.registerSetting("DISPLAY_TIME_IN_MAIL_LIST",		{name:"zimbraPrefDisplayTimeInMailList", type:ZmSetting.T_PREF, dataType:ZmSetting.D_BOOLEAN, defaultValue:false});
 
 	this._registerOfflineSettings();
 	this._registerZimletsSettings();
@@ -1174,6 +1176,9 @@ function(ev) {
 	}
     else if (id === ZmSetting.CHAT_ENABLED || id === ZmSetting.CHAT_PLAY_SOUND || (id === ZmSetting.CHAT_PLAY_SOUND && id === ZmSetting.CHAT_ENABLED)) {
 		this._showConfirmDialog(ZmMsg.chatFeatureChangeRestart, this._refreshBrowserCallback.bind(this));
+	}
+	else if (id === ZmSetting.DISPLAY_TIME_IN_MAIL_LIST) {
+		this._showConfirmDialog(value ? ZmMsg.timeInMailListChangeRestartShow : ZmMsg.timeInMailListChangeRestartHide, this._refreshBrowserCallback.bind(this));
 	}
 };
 

--- a/WebRoot/messages/ZmMsg.properties
+++ b/WebRoot/messages/ZmMsg.properties
@@ -1023,6 +1023,7 @@ displayIM = Choose how IM chats are displayed
 displayExternalImages = Display Images
 displayMail = Display Mail:
 displayMailToolTip = Choose how mail is displayed
+displayTimeInMailList = Always display received time in email list
 distributionList = Distribution List
 distributionLists = Distribution Lists
 distributionListCreated = Distribution List Created
@@ -3499,6 +3500,8 @@ theme-venice = Venice
 theme-waves = Waves
 tiffImage = TIFF Image
 time = Time
+timeInMailListChangeRestartHide = Would you like to reload the application now to hide time in email list?
+timeInMailListChangeRestartShow = Would you like to reload the application now to show time in email list?
 timeLabel = Time:
 timePlaced = Time Placed
 timePreferences = Time Preferences
@@ -4179,6 +4182,7 @@ spreadSheet_func_if = Returns one of 2 values depending on the condition
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 135
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_ar.properties
+++ b/WebRoot/messages/ZmMsg_ar.properties
@@ -4146,6 +4146,7 @@ spreadSheet_func_if = \u0625\u0631\u062c\u0627\u0639 \u0642\u064a\u0645\u0629 \u
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 130
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_ca.properties
+++ b/WebRoot/messages/ZmMsg_ca.properties
@@ -4168,6 +4168,7 @@ spreadSheet_func_if = Retorna un de dos valors segons la condici\u00f3
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_da.properties
+++ b/WebRoot/messages/ZmMsg_da.properties
@@ -3966,6 +3966,7 @@ spreadSheet_func_if = Beregner 1 af 2 v\u00e6rdier afh\u00e6ngig af betingelsern
 
 # mail list views
 COLUMN_WIDTH_DATE = 80
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_de.properties
+++ b/WebRoot/messages/ZmMsg_de.properties
@@ -4077,6 +4077,7 @@ spreadSheet_func_if = Gibt je nach Bedingung einen von zwei Werten aus
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 105
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_en_AU.properties
+++ b/WebRoot/messages/ZmMsg_en_AU.properties
@@ -4146,6 +4146,7 @@ spreadSheet_func_if = Returns one of 2 values depending on the condition
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 135
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_en_GB.properties
+++ b/WebRoot/messages/ZmMsg_en_GB.properties
@@ -3965,6 +3965,7 @@ spreadSheet_func_if = Returns one of 2 values depending on the condition
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_es.properties
+++ b/WebRoot/messages/ZmMsg_es.properties
@@ -4085,7 +4085,8 @@ spreadSheet_func_if = Devuelve uno de dos valores seg\u00fan la condici\u00f3n
 # column widths for columns in various list views
 
 # mail list views
-COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE = 110
+COLUMN_WIDTH_DATE_TIME = 145
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_eu.properties
+++ b/WebRoot/messages/ZmMsg_eu.properties
@@ -4145,6 +4145,7 @@ spreadSheet_func_if = Bi baliotatik bat itzultzen du baldintzaren arabera
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_fr.properties
+++ b/WebRoot/messages/ZmMsg_fr.properties
@@ -4090,6 +4090,7 @@ spreadSheet_func_if = Renvoie l\u2019une ou l\u2019autre de deux valeurs (selon 
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_fr_CA.properties
+++ b/WebRoot/messages/ZmMsg_fr_CA.properties
@@ -4157,6 +4157,7 @@ spreadSheet_func_if = Renvoie l\u2019une ou l\u2019autre de deux valeurs selon l
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_hi.properties
+++ b/WebRoot/messages/ZmMsg_hi.properties
@@ -3965,7 +3965,8 @@ spreadSheet_func_if = \u0938\u094d\u0925\u093f\u0924\u093f \u092a\u0930 \u0928\u
 # column widths for columns in various list views
 
 # mail list views
-COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE = 80
+COLUMN_WIDTH_DATE_TIME = 150
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_hu.properties
+++ b/WebRoot/messages/ZmMsg_hu.properties
@@ -4157,6 +4157,7 @@ spreadSheet_func_if = 2 \u00e9rt\u00e9k k\u00f6z\u00fcl az egyiket adja vissza a
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_in.properties
+++ b/WebRoot/messages/ZmMsg_in.properties
@@ -4160,6 +4160,7 @@ spreadSheet_func_if = Menghasilkan salah satu dari 2 nilai, tergantung syaratnya
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_it.properties
+++ b/WebRoot/messages/ZmMsg_it.properties
@@ -3978,6 +3978,7 @@ spreadSheet_func_if = Restituisce uno dei due valori specificati, in base alla c
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_iw.properties
+++ b/WebRoot/messages/ZmMsg_iw.properties
@@ -4155,7 +4155,8 @@ spreadSheet_func_if = \u05de\u05d7\u05d6\u05d9\u05e8 \u05d0\u05d7\u05d3 \u05de\u
 # column widths for columns in various list views
 
 # mail list views
-COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE = 85
+COLUMN_WIDTH_DATE_TIME = 150
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_ja.properties
+++ b/WebRoot/messages/ZmMsg_ja.properties
@@ -4048,7 +4048,8 @@ spreadSheet_func_if = \u6761\u4ef6\u306b\u5fdc\u3058\u30662\u3064\u306e\u5024\u3
 # column widths for columns in various list views
 
 # mail list views
-COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE = 80
+COLUMN_WIDTH_DATE_TIME = 145
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_ko.properties
+++ b/WebRoot/messages/ZmMsg_ko.properties
@@ -4088,7 +4088,8 @@ spreadSheet_func_if = \uc870\uac74\uc5d0 \ub530\ub77c \ub450 \uac1c\uc758 \uac12
 # column widths for columns in various list views
 
 # mail list views
-COLUMN_WIDTH_DATE = 120
+COLUMN_WIDTH_DATE = 80
+COLUMN_WIDTH_DATE_TIME = 140
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_lo.properties
+++ b/WebRoot/messages/ZmMsg_lo.properties
@@ -4156,6 +4156,7 @@ spreadSheet_func_if = \u0e9b\u0ec8\u0ebd\u0e99\u200b\u0edc\u0eb6\u0ec8\u0e87\u20
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_ms.properties
+++ b/WebRoot/messages/ZmMsg_ms.properties
@@ -4156,7 +4156,8 @@ spreadSheet_func_if = Kembalikan satu daripada 2 nilai bergantung pada syaratnya
 # column widths for columns in various list views
 
 # mail list views
-COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE = 90
+COLUMN_WIDTH_DATE_TIME = 145
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_nl.properties
+++ b/WebRoot/messages/ZmMsg_nl.properties
@@ -3966,6 +3966,7 @@ spreadSheet_func_if = Geeft \u00e9\u00e9n van twee waarden afhankelijk van de co
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 55
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_no.properties
+++ b/WebRoot/messages/ZmMsg_no.properties
@@ -4178,6 +4178,7 @@ spreadSheet_func_if = Returnerer en av to verdier avhengig av betingelsen
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_pl.properties
+++ b/WebRoot/messages/ZmMsg_pl.properties
@@ -4125,6 +4125,7 @@ spreadSheet_func_if = Zwraca jedn\u0105 z dw\u00f3ch warto\u015bci w zale\u017cn
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_pt.properties
+++ b/WebRoot/messages/ZmMsg_pt.properties
@@ -4165,6 +4165,7 @@ spreadSheet_func_if = Devolve um de dois valores, dependendo da condi\u00e7\u00e
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_pt_BR.properties
+++ b/WebRoot/messages/ZmMsg_pt_BR.properties
@@ -3967,6 +3967,7 @@ spreadSheet_func_if = Retorna um de 2 valores dependendo da condi\u00e7\u00e3o
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_ro.properties
+++ b/WebRoot/messages/ZmMsg_ro.properties
@@ -4157,6 +4157,7 @@ spreadSheet_func_if = \u00centoarce una din 2 valori, \u00een func\u0163ie de co
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_ru.properties
+++ b/WebRoot/messages/ZmMsg_ru.properties
@@ -3967,6 +3967,7 @@ spreadSheet_func_if = \u0412\u043e\u0437\u0432\u0440\u0430\u0449\u0430\u0435\u04
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 55
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 195

--- a/WebRoot/messages/ZmMsg_sl.properties
+++ b/WebRoot/messages/ZmMsg_sl.properties
@@ -4156,6 +4156,7 @@ spreadSheet_func_if = Vrne eno od dveh vrednosti glede na pogoj
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_sv.properties
+++ b/WebRoot/messages/ZmMsg_sv.properties
@@ -3967,6 +3967,7 @@ spreadSheet_func_if = Returnerar ett av tv\u00e5 v\u00e4rden beroende p\u00e5 an
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 125
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_th.properties
+++ b/WebRoot/messages/ZmMsg_th.properties
@@ -4156,6 +4156,7 @@ spreadSheet_func_if = \u0e43\u0e2b\u0e49\u0e04\u0e48\u0e32\u0e2b\u0e19\u0e36\u0e
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 135
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_tr.properties
+++ b/WebRoot/messages/ZmMsg_tr.properties
@@ -4147,6 +4147,7 @@ spreadSheet_func_if = Ko\u015fula ba\u011fl\u0131 olarak, iki de\u011ferden biri
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 55
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_uk.properties
+++ b/WebRoot/messages/ZmMsg_uk.properties
@@ -4155,6 +4155,7 @@ spreadSheet_func_if = \u041f\u043e\u0432\u0435\u0440\u043d\u0435\u043d\u043d\u04
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 110
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_zh_CN.properties
+++ b/WebRoot/messages/ZmMsg_zh_CN.properties
@@ -4132,6 +4132,7 @@ spreadSheet_func_if = \u5f97\u51fa 2 \u4e2a\u6570\u503c\u4e2d\u7684\u4e00\u4e2a\
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 140
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_zh_HK.properties
+++ b/WebRoot/messages/ZmMsg_zh_HK.properties
@@ -4040,7 +4040,8 @@ spreadSheet_func_if = \u5f97\u51fa 2 \u500b\u6578\u503c\u4e2d\u7684\u4e00\u500b\
 # column widths for columns in various list views
 
 # mail list views
-COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE = 105
+COLUMN_WIDTH_DATE_TIME = 170
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/messages/ZmMsg_zh_TW.properties
+++ b/WebRoot/messages/ZmMsg_zh_TW.properties
@@ -4149,6 +4149,7 @@ spreadSheet_func_if = \u4f9d\u64da\u689d\u4ef6\u50b3\u56de\u5169\u500b\u503c\u76
 
 # mail list views
 COLUMN_WIDTH_DATE = 75
+COLUMN_WIDTH_DATE_TIME = 140
 COLUMN_WIDTH_FOLDER = 47
 # 'from' column in conv list view
 COLUMN_WIDTH_FROM_CLV = 160

--- a/WebRoot/skins/_base/base3/skin.css
+++ b/WebRoot/skins/_base/base3/skin.css
@@ -605,7 +605,7 @@ SELECT						{	@FieldBorder@	}
 .TopRow .ImgNodeExpanded			{ padding:0px; }
 .ZmMsgListColTag 					{ padding:0px 2px 0px 3px; vertical-align:middle; }
 .BottomRow .ZmMsgListColTag 		{ margin-right:3px; }
-.ZmMsgListDate						{ position:absolute; right:0px; text-align:right; width:75px; width:6.8rem;}
+.ZmMsgListDate						{ position:absolute; right:0px; text-align:right; }
 .ZmMsgListColSelection, .ZmMsgListColFlag, .ZmMsgListColTag, .ZmMsgListColAccount,
 .ZmMsgListColStatus, .ZmMsgListColMute, .ZmMsgListColRead, .ZmMsgListColAttachment, .ZmMsgListColExpand
 {

--- a/WebRoot/templates/prefs/Pages.template
+++ b/WebRoot/templates/prefs/Pages.template
@@ -223,7 +223,12 @@ and the container element is replaced with that control.
 
 						<tr>
 							<td class='ZOptionsLabel'></td>
-							<td class='ZOptionsField'><div id='${id}_OPEN_MAIL_IN_NEW_WIN' tabindex=0></div></tZmd>
+							<td class='ZOptionsField'><div id='${id}_OPEN_MAIL_IN_NEW_WIN' tabindex=0></div></td>
+						</tr>
+
+						<tr>
+							<td class='ZOptionsLabel'></td>
+							<td class='ZOptionsField'><div id='${id}_DISPLAY_TIME_IN_MAIL_LIST' tabindex=0></div></td>
 						</tr>
 
 						<tr>


### PR DESCRIPTION
[Adding feature]
- If zimbraPrefDisplayTimeInMailList is TRUE, web client displays not only date but also time of a message received yesterday or before in email list.
- Adding a setting in Preferences -> Mail tab

[Related]
- Jira ticket id: NICPS-30
- Pull requests:
https://github.com/Zimbra/zm-ajax/pull/46
-- https://github.com/Zimbra/zm-mailbox/pull/528