### PR TITLE
snickers: NICPS-49: adding "Add Attachment" function on Mobile HTML client

### DIFF
--- a/WebRoot/WEB-INF/tags/mobile/moComposeCheck.tag
+++ b/WebRoot/WEB-INF/tags/mobile/moComposeCheck.tag
@@ -132,6 +132,12 @@
                 <app:status><fmt:message key="draftSavedSuccessfully"/></app:status>
                 <c:set var="needComposeView" value="${true}"/>
             </c:when>
+            <c:when test="${uploader.isLimitExceeded}">
+                <c:set var="statusClass" scope="request" value="StatusCritical"/>
+                <c:set var="uploadError" scope="request" value="${true}"/>
+                <fmt:message var="errorMsg" key="zclient.UPLOAD_SIZE_LIMIT_EXCEEDED"/>
+                <c:set var="statusMessage" scope="request" value="${errorMsg}"/>
+            </c:when>
         </c:choose>
     </c:if>
 </mo:handleError>

--- a/WebRoot/css/ipad.css
+++ b/WebRoot/css/ipad.css
@@ -1600,6 +1600,10 @@ span.aleft > div:first-child, .contactHeader {
     z-index: 9030;
 }
 
+.ZhACAttach {
+    z-index: 9020;
+}
+
 .yui-ac-bcd .left{
 	border-bottom: none !important;
 }

--- a/WebRoot/css/iphone-ext.css
+++ b/WebRoot/css/iphone-ext.css
@@ -461,6 +461,9 @@ input[type="button"], input[type="reset"] {
 .ZhACBCc {
     z-index: 9030;
 }
+.ZhACAttach {
+    z-index: 9020;
+}
 .prev_button, .mid_button, .next_button {
     border: 0px;
     margin: 0px;

--- a/WebRoot/css/iphone-lowbw.css
+++ b/WebRoot/css/iphone-lowbw.css
@@ -331,6 +331,9 @@ input[type="button"], input[type="reset"] {
 .ZhACBCc {
     z-index: 9030;
 }
+.ZhACAttach {
+    z-index: 9020;
+}
 .prev_button, .mid_button, .next_button {
     border: 0px;
     margin: 0px;

--- a/WebRoot/css/iphone.css
+++ b/WebRoot/css/iphone.css
@@ -501,6 +501,9 @@ form {
 .ZhACBCc {
     z-index: 9030;
 }
+.ZhACAttach {
+    z-index: 9020;
+}
 .prev_button, .mid_button, .next_button {
     border: 0px !important;
     margin: 0px !important;

--- a/WebRoot/css/xlite.css
+++ b/WebRoot/css/xlite.css
@@ -320,6 +320,9 @@ hr{
 .ZhACBCc {
     z-index: 9030;
 }
+.ZhACAttach {
+    z-index: 9020;
+}
 
 .Flag:before {
     content:"|>";

--- a/WebRoot/css/zmobile1.css
+++ b/WebRoot/css/zmobile1.css
@@ -198,6 +198,7 @@ a.zo_button_disabled {color:gray;background-color:none;}
 .ZhACTo {z-index:9050;}
 .ZhACCc {z-index:9040;}
 .ZhACBCc {z-index:9030;}
+.ZhACAttach {z-index:9020;}
 
 
 

--- a/WebRoot/m/mocompose
+++ b/WebRoot/m/mocompose
@@ -311,8 +311,9 @@ if(window != parent){
 }
 </c:set>${dbg ? js : zm:yuiCompress(js, 'js')}</script>
 </c:if>
+<script type="text/javascript">AC("toField","toContainer");AC("ccField","ccContainer");AC("bccField","bccContainer");</script>
 <c:if test="${empty param.isinframe and empty requestScope.compAction}">
-	<script type="text/javascript">AC("toField","toContainer");AC("ccField","ccContainer");AC("bccField","bccContainer");
+    <script type="text/javascript">
 //  bug:99598 - workaround for an iOS8 bug, do not auto focus for iOS devices
     if (!/iPad|iPhone|iPod/g.test(navigator.userAgent)) {
         $('${param.op eq 'reply' || param.op eq 'replyAll' ? 'bodyField' : 'toField'}').focus();

--- a/WebRoot/m/mocompose
+++ b/WebRoot/m/mocompose
@@ -169,6 +169,13 @@
             <input class="Textarea" autocorrect="off" autocomplete="OFF" id="bccField" type="text" value="${fn:escapeXml(compose.bcc)}" name="bcc"><br/><div class='ZhACCont' id="bccContainer" style='width:99%;'></div>
         </div>
     </span>
+</div><div class="tr ${classForNextRow}">
+    <span class="label td"><label for="attachFiles"><fmt:message key="attachLabel"/></label></span>
+    <span class="td value">
+        <div class="ZhAC ZhACAttach">
+             <input id="attachFiles" type="file" name="fileUpload" multiple>
+        </div>
+    </span>
 </div></div></div>
 <div class="View"><div class="tbl"><div class="tr cmp_sub_row">
     <span class='label td nb'><label for="subjectField"><fmt:message key="subjectLabel"/> </label></span>
@@ -242,9 +249,9 @@
         url="/service/home/~/?id=${message.id}&part=${part.partName}&auth=co"
         displayName="${part.displayName}"
         contentType="${part.contentType}"
-        checked="${compose.checkedAttachmentNames[part.partName]}"
+        checked="${compose.checkedAttachmentNames[part.partName] != null or (part.isMssage and not empty compose.messageAttachments)}"
         displaySize="${zm:displaySize(pageContext,part.size)}"
-        value="${part.partName}" name="originalAttachment"/>
+        value="${part.partName},${true}" name="originalAttachment"/>
     <c:set var="firstAttachment" value="${false}"/>
 </c:forEach>
 </div></c:if>

--- a/WebRoot/messages/ZhMsg.properties
+++ b/WebRoot/messages/ZhMsg.properties
@@ -302,6 +302,7 @@ assistant = Assistant
 at = @
 atBottomOfMessage = Below included messages
 attachFiles = Attach Files
+attachLabel = Attach:
 attachments = Attachments
 attachmentCount = {0,choice,0#no attachments|1#{0,number,integer} attachment|1<{0,number,integer} attachments}
 attachmentLimitMsg = <b>Note:&nbsp;</b>Attachments may not be larger than {0}


### PR DESCRIPTION
Problem : provide "add attachment" function on Mobile HTML client
Fix : 
1. Add "Attach" button on compose page
2. Add error handling code in case file size exceeds max size limit

Testing done : testing done by developer.
- Win10/Edge, IE11, Firefox, Chrome
- iPhone7/iOS11.2.5/Safari
- XperiaXZ/Android7.0/Chrome

Testing to be done by QA : testing needed to be done by QA in PS team

TODO: I18N support
- Label of attach button
- New key: ZhMsg.properties -> attachLabel

Link: PR on develop branch - https://github.com/Zimbra/zm-web-client/pull/224