### PR TITLE
snickers: NICPS-31: changed to remove "mailto:" from email link

### DIFF
--- a/WebRoot/js/zimbraMail/mail/controller/ZmMailListController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmMailListController.js
@@ -1682,7 +1682,9 @@ ZmMailListController.prototype._filterListener =
 function(isAddress, rule) {
 
 	if (isAddress) {
-		this._handleResponseFilterListener(rule, this._actionEv.address);
+		var address = this._actionEv.address.isAjxEmailAddress ? this._actionEv.address : new AjxEmailAddress(this._actionEv.address);
+		address.setAddress(AjxStringUtil.parseMailtoLink(address.getAddress()).to);
+		this._handleResponseFilterListener(rule, address);
 	}
 	else {
 		this._getLoadedMsg(null, this._handleResponseFilterListener.bind(this, rule));

--- a/WebRoot/js/zimbraMail/share/controller/ZmBaseController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmBaseController.js
@@ -1383,9 +1383,11 @@ ZmBaseController.prototype._loadContactForMenu = function(menu, address, ev, imI
 		return;
 	}
 
+	email = AjxStringUtil.parseMailtoLink(email).to;
 	// first check if contact is cached, and no server call is needed
 	var contact = contactsApp.getContactByEmail(email);
 	if (contact) {
+		address.setAddress(AjxStringUtil.parseMailtoLink(address.getAddress()).to);
 		this._handleResponseGetContact(menu, address, ev, imItem, contact);
 		return;
 	}

--- a/WebRoot/js/zimbraMail/share/controller/ZmBaseController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmBaseController.js
@@ -1579,7 +1579,7 @@ ZmBaseController.prototype._handleLoadContactListener = function() {
 		}
 	} else {
 		var contact = cc._createNewContact(this._actionEv);
-		contact.attr.email = AjxStringUtil.parseMailtoLink(contact.attr.email).to;
+		contact.setAttr(ZmContact.F_email, AjxStringUtil.parseMailtoLink(contact.getAttr(ZmContact.F_email)).to);
 		cc.show(contact, true);
 	}
 	if (appCtxt.isChildWindow) {

--- a/WebRoot/js/zimbraMail/share/controller/ZmBaseController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmBaseController.js
@@ -1515,7 +1515,8 @@ ZmBaseController.prototype._searchListener = function(addrType, isToolbar, ev) {
 	}
 
 	if (name) {
-        var ac = window.parentAppCtxt || window.appCtxt;
+		name = AjxStringUtil.parseMailtoLink(name).to;
+		var ac = window.parentAppCtxt || window.appCtxt;
 		var srchCtlr = ac.getSearchController();
 		if (addrType === AjxEmailAddress.FROM) {
 			srchCtlr.fromSearch(name);
@@ -1537,6 +1538,7 @@ ZmBaseController.prototype._composeListener = function(ev, addr) {
 		email = addr && addr.toString();
 
 	if (email) {
+		email = AjxStringUtil.parseMailtoLink(email).to;
 		AjxDispatcher.run("Compose", {
 			action:         ZmOperation.NEW_MESSAGE,
 			inNewWindow:    this._app._inNewWindow(ev),
@@ -1577,6 +1579,7 @@ ZmBaseController.prototype._handleLoadContactListener = function() {
 		}
 	} else {
 		var contact = cc._createNewContact(this._actionEv);
+		contact.attr.email = AjxStringUtil.parseMailtoLink(contact.attr.email).to;
 		cc.show(contact, true);
 	}
 	if (appCtxt.isChildWindow) {


### PR DESCRIPTION
Problem: if email link begins with "mailto:" in message view, "mailto:" is treated as a part of an email address at actions as below.
- Find Emails -> Received From Sender: search query is "from:mailto:user@domain". The search does not work. 
- Find Emails -> Sent To Sender: search query is "tocc:mailto:user@domain". The search does not work.
- New Email: "mailto:user@domain" is added to To field in compose page
- Add To Contacts: "mailto:user@domain" is added to Email field in New Contact page

Fix: added AjxStringUtil.parseMailtoLink to remove "mailto:"

Testing done : testing done by developer. Tested the actions via the following path.
- Right-click a sender in From field of message list on message/conversation view
- Right-click a sender/recipient in message header on preview/main/separate window
- Double-click a sender/recipient in message header on preview/main/separate window
- Right-click an email link without "mailto:" in message body on preview/main/separate window
- Click an email link without "mailto:" in message body on preview/main/separate window
- Right-click an email link with "mailto:" in message body view on preview/main/separate window
- Click an email link with "mailto:" in message body view on preview/main/separate window
- Right-click a contact in contact list

Testing to be done by QA : testing needed to be done by QA in PS team

Note: "mailto:" is not removed at the following actions:
- Copy: "mailto:user@domain" is copied to clipboard
- Add To Filter: "mailto:user@domain" is added to From in Add Filter dialog
