### PR TITLE
ZCS-4387 Upgrade jquery in webclient

### DIFF
--- a/WebRoot/WEB-INF/tags/rest/restDocumentView.tag
+++ b/WebRoot/WEB-INF/tags/rest/restDocumentView.tag
@@ -45,9 +45,9 @@ response.setHeader("Pragma", "no-cache");
 <c:set var="isDevMode" value="${not empty requestScope.mode and requestScope.mode eq 'mjsf'}" scope="request"/>
 <c:set var="isSkinDebugMode" value="${not empty requestScope.mode} and ${requestScope.mode eq 'skindebug'}" scope="request"/>
 
-<c:set var="packages" value="Ajax,Startup1_1,Startup1_2,Startup2,Docs" scope="request"/>
+<c:set var="packages" value="JQuery,Ajax,Startup1_1,Startup1_2,Startup2,Docs" scope="request"/>
 <c:if test="${not empty param.packages}">
-    <c:set var="packages" value="Ajax,Startup1_1,Startup1_2,Startup2,Docs,${param.packages}" scope="request"/>
+    <c:set var="packages" value="JQuery,Ajax,Startup1_1,Startup1_2,Startup2,Docs,${param.packages}" scope="request"/>
 </c:if>
 <c:set var="pnames" value="${fn:split(packages,',')}" scope="request"/>
 

--- a/WebRoot/WEB-INF/tags/rest/restSlideView.tag
+++ b/WebRoot/WEB-INF/tags/rest/restSlideView.tag
@@ -39,9 +39,9 @@
 <c:set var="isDevMode" value="${not empty requestScope.mode and requestScope.mode eq 'mjsf'}" scope="request"/>
 <c:set var="isSkinDebugMode" value="${not empty requestScope.mode} and ${requestScope.mode eq 'skindebug'}" scope="request"/>
 
-<c:set var="packages" value="Startup1_1,Startup1_2,Startup2,Slides" scope="request"/>
+<c:set var="packages" value="JQuery,Startup1_1,Startup1_2,Startup2,Slides" scope="request"/>
 <c:if test="${not empty param.packages}">
-    <c:set var="packages" value="Startup1_1,Startup1_2,Startup2,Slides,${param.packages}" scope="request"/>
+    <c:set var="packages" value="JQuery,Startup1_1,Startup1_2,Startup2,Slides,${param.packages}" scope="request"/>
 </c:if>
 <c:set var="pnames" value="${fn:split(packages,',')}" scope="request"/>
 

--- a/WebRoot/WEB-INF/tags/rest/restSpreadsheetView.tag
+++ b/WebRoot/WEB-INF/tags/rest/restSpreadsheetView.tag
@@ -36,9 +36,9 @@
 <c:set var="isDevMode" value="${not empty requestScope.mode and requestScope.mode eq 'mjsf'}" scope="request"/>
 <c:set var="isSkinDebugMode" value="${not empty requestScope.mode} and ${requestScope.mode eq 'skindebug'}" scope="request"/>
 
-<c:set var="packages" value="Ajax,Startup1_1,Startup1_2,Spreadsheet" scope="request"/>
+<c:set var="packages" value="JQuery,Ajax,Startup1_1,Startup1_2,Spreadsheet" scope="request"/>
 <c:if test="${not empty param.packages}">
-    <c:set var="packages" value="Ajax,Startup1_1,Startup1_2,Spreadsheet,${param.packages}" scope="request"/>
+    <c:set var="packages" value="JQuery,Ajax,Startup1_1,Startup1_2,Spreadsheet,${param.packages}" scope="request"/>
 </c:if>
 <c:set var="pnames" value="${fn:split(packages,',')}" scope="request"/>
 

--- a/WebRoot/js/zimbraMail/package/NewWindow_1.js
+++ b/WebRoot/js/zimbraMail/package/NewWindow_1.js
@@ -109,6 +109,5 @@ AjxPackage.require("ajax.dwt.widgets.DwtPropertySheet");
 AjxPackage.require("ajax.dwt.widgets.DwtPropertyPage");
 AjxPackage.require("ajax.dwt.widgets.DwtTabView");
 AjxPackage.require("ajax.dwt.widgets.DwtTimeSelect");
-AjxPackage.require("ajax.3rdparty.jquery.jquery");
 
 AjxPackage.require("zimbraMail.share.view.ZmTagsHelper");

--- a/WebRoot/js/zimbraMail/package/NewWindow_2.js
+++ b/WebRoot/js/zimbraMail/package/NewWindow_2.js
@@ -55,7 +55,6 @@ AjxPackage.require("ajax.dwt.widgets.DwtMessageComposite");
 
 AjxPackage.require("ajax.util.AjxDateUtil");
 AjxPackage.require("ajax.util.AjxPluginDetector");
-AjxPackage.require("ajax.3rdparty.clipboard");
 AjxPackage.require("ajax.util.AjxClipboard");
 AjxPackage.require("ajax.util.AjxSHA1");
 

--- a/WebRoot/js/zimbraMail/package/Startup1_1.js
+++ b/WebRoot/js/zimbraMail/package/Startup1_1.js
@@ -121,8 +121,6 @@ AjxPackage.require("ajax.dwt.widgets.DwtOptionDialog");
 AjxPackage.require("ajax.dwt.widgets.DwtChooser");
 AjxPackage.require("ajax.dwt.widgets.DwtTimeSelect");
 
-AjxPackage.require("ajax.3rdparty.jquery.jquery");
-
 AjxPackage.require("zimbra.csfe.ZmBatchCommand");
 AjxPackage.require("zimbra.csfe.ZmCsfeCommand");
 AjxPackage.require("zimbra.csfe.ZmCsfeException");

--- a/WebRoot/js/zimbraMail/package/Startup2.js
+++ b/WebRoot/js/zimbraMail/package/Startup2.js
@@ -27,7 +27,6 @@ AjxPackage.require("ajax.util.AjxBuffer");
 AjxPackage.require("ajax.xslt.AjxXslt");
 AjxPackage.require("ajax.util.AjxSHA1");
 AjxPackage.require("ajax.util.AjxPluginDetector");
-AjxPackage.require("ajax.3rdparty.clipboard");
 AjxPackage.require("ajax.util.AjxClipboard");
 AjxPackage.require("ajax.dwt.events.DwtDateRangeEvent");
 AjxPackage.require("ajax.dwt.events.DwtIdleTimer");

--- a/WebRoot/public/Docs.jsp
+++ b/WebRoot/public/Docs.jsp
@@ -148,7 +148,7 @@ If not, see <https://www.gnu.org/licenses/>.
     </script>
     <%
 
-        String packages = "Ajax,Startup1_1,Startup1_2,Startup2,Docs";
+        String packages = "JQuery,Ajax,Startup1_1,Startup1_2,Startup2,Docs";
 
         String pprefix = isDevMode && !isCoverage ? "public/jsp" : "js";
         String psuffix = isDevMode && !isCoverage ? ".jsp" : "_all.js";

--- a/WebRoot/public/launchNewWindow.jsp
+++ b/WebRoot/public/launchNewWindow.jsp
@@ -156,7 +156,7 @@
 <jsp:include page="/js/ajax/util/AjxTimezoneData.js" />
 </script>
 <%
-	String packages = "NewWindow_1,NewWindow_2";
+	String packages = "JQuery,NewWindow_1,NewWindow_2";
 
     String extraPackages = request.getParameter("packages");
     if (extraPackages != null) packages += ","+BeanUtils.cook(extraPackages);

--- a/WebRoot/public/launchSidebar.jsp
+++ b/WebRoot/public/launchSidebar.jsp
@@ -141,7 +141,7 @@
 </jsp:include>
 <jsp:include page="Boot.jsp"/>
 <%
-    String allPackages = "Startup1_1,Startup1_2";
+    String allPackages = "JQuery,Startup1_1,Startup1_2";
     String[] pnames = allPackages.split(",");
     for (String pname : pnames) {
         String pageurl = "/js/" + pname + "_all.js";

--- a/WebRoot/public/launchZCS.jsp
+++ b/WebRoot/public/launchZCS.jsp
@@ -328,7 +328,7 @@
 <jsp:include page="/js/ajax/util/AjxTimezoneData.js" />
 </script>
 <%
-	String allPackages = "Startup1_1,Startup1_2";
+	String allPackages = "JQuery,Startup1_1,Startup1_2";
     if (extraPackages != null) {
     	if (extraPackages.equals("dev")) {
             extraPackages = "Startup2,MailCore,Mail,ContactsCore,CalendarCore,Calendar,CalendarAppt,Contacts,BriefcaseCore,Briefcase,PreferencesCore,Preferences,TasksCore,Tasks,Extras,Share,Zimlet,ZimletApp,Alert,ImportExport,Voicemail";

--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,6 @@
     <import file="../zm-zcs/ant-global.xml"/>
     <property name="ajax.dir" location="../zm-ajax" />
     <property name="ajax.src.dir" location="${ajax.dir}/src" />
-    <property name="ajax.build.dir" location="${ajax.dir}/build" />
 
     <property name="timezones.dir" location="../zm-timezones" />
     <property name="timezones.build.dir" location="${timezones.dir}/build" />
@@ -34,7 +33,6 @@
 
     <!-- zm-taglib -->
     <property name='taglib.dir' value='${this.zwc.basedir}/../zm-taglib'/>
-    <property name='taglib.build.dir' value='${taglib.dir}/build'/>
 
     <property name="jsdoctoolkit.version" value="2.4.0"/>
     <property name="jsdoctoolkit.dir" location="${build.tmp.dir}/jsdoc_toolkit-${jsdoctoolkit.version}/jsdoc-toolkit" />
@@ -81,6 +79,7 @@
     <property name='nodebug.ext' value='.nodebug'/>
     <property name="jsmin.ext" value='.min'/>
     <property name="compress.ext" value='.zgz'/>
+    <property name='compressoutput.ext' value='.out'/>
     <property name='compresserror.ext' value='.err'/>
 
     <!-- THIRDPARTY INTEGRATION -->
@@ -88,7 +87,7 @@
 
     <property name="modernizr.version" value="2.8.3"/>
     <property name="yui.version" value="2.7.0"/>
-    <property name="jquery.version" value="1.11.0"/>
+    <property name="jquery.version" value="3.3.1-1"/>
 
     <!-- TINY_MCE INTEGRATION -->
     <property name="tinymce.version" value="4.2.6"/>
@@ -125,7 +124,7 @@
         <property name='common.jam.excludes' value='${custom.jam.excludes},'/>
         <property name='common.build.web.includes' value='${custom.build.web.includes},**'/>
         <property name='common.build.web.excludes'
-                  value='${custom.build.web.excludes},js/*${depends.ext},js/*${nodebug.ext},js/*${jsmin.ext},js/*${license.ext}'/>
+                  value='${custom.build.web.excludes},js/*${depends.ext},js/*${nodebug.ext},js/*${jsmin.ext},js/*${license.ext},js/*${compressoutput.ext}'/>
         <property name='common.webinf.includes' value='${custom.webinf.includes},**'/>
         <property name='common.webinf.excludes' value='${custom.webinf.excludes},web.*,lib/**'/>
     </target>
@@ -134,7 +133,7 @@
         <property name='deploy.app' value='zimbra'/>
         <property name='skins.dir' value='${web.dir}/skins'/>
         <property name='web.includes' value='${common.web.includes},h/**,m/**,portals/**,sounds/**,test/**,yui/2.7.0/**,qunit/**'/>
-        <property name='web.excludes' value='${common.web.excludes},js/zimbraAdmin/**'/>
+        <property name='web.excludes' value='${common.web.excludes}'/>
         <property name='jsp.includes' value='${common.jsp.includes}'/>
         <property name='jsp.excludes' value='${common.jsp.excludes},admin.jsp'/>
         <property name='img.includes' value='${common.img.includes}'/>
@@ -142,7 +141,7 @@
         <property name='template.includes' value='${common.template.includes}'/>
         <property name='template.excludes' value='${common.template.excludes},admin/**'/>
         <property name='jam.includes' value='${common.jam.includes}'/>
-        <property name='jam.excludes' value='${common.jam.excludes},**/zimbraAdmin/**'/>
+        <property name='jam.excludes' value='${common.jam.excludes}'/>
         <property name='build.web.includes' value='${common.build.web.includes}'/>
         <property name='build.web.excludes' value='${common.build.web.excludes}'/>
         <property name='webinf.includes' value='${common.webinf.includes}'/>
@@ -232,6 +231,7 @@
 
             <!-- files from build tree -->
             <zipfileset dir='${build.web.dir}' includes='${build.web.includes}' excludes='${build.web.excludes}'/>
+            <!-- zipfileset dir='${build.web.dir}' includes='js/Modernizr_all.js${jsmin.ext}' / -->
 			<zipfileset dir='${build.web.dir}' includes='js/Boot_all.js${jsmin.ext}' />
 
             <!-- primary files from source trees -->
@@ -729,7 +729,6 @@
 		<!-- delete output files if files changed -->
 		<dependset>
 			<srcfileset dir='${srcdir}' includes='*/**' />
-			<srcfileset dir='${ajax.build.dir}' includes='**/img/*.class' />
 			<targetfileset dir='${destdir}' includes='${build.css.file}*.css,${build.css.file}*.js' />
 		</dependset>
 		<!-- merge images, if needed -->
@@ -913,7 +912,6 @@
 
         <packagedependset>
             <srcdependslist dir='.' files='${depends.file}'/>
-            <srcfileset dir='${ajax.build.dir}' includes='**/PackageJammerTask.class'/>
             <targetfilelist dir='.' files='${jam.file}'/>
             <targetfilelist dir='.' files='${jsp.file}'/>
         </packagedependset>
@@ -937,6 +935,10 @@
             </not>
             <then>
                 <condition property='wrap' value='false' else='true'>
+                    <!-- or>
+                        <equals arg1='${arg}' arg2='Boot'/>
+                        <equals arg1='${arg}' arg2='Modernizr'/>
+                    </or -->
                     <equals arg1='${arg}' arg2='Boot'/>
                 </condition>
 
@@ -1018,7 +1020,6 @@ ext = BeanUtils.cook(ext);
 	    <taskdef name="try"
 	             classname="com.zimbra.webClient.build.TryTask"
 	             classpathref="class.path"
-
 	    />
 
         <!-- copying yui jar file in build/tmp directory. -->
@@ -1049,31 +1050,45 @@ ext = BeanUtils.cook(ext);
                             <substitution expression=" "/>
                             <fileset file="@{var}${nodebug.ext}"/>
                         </replaceregexp>
-                        <echo>Minimizing to @{var}${jsmin.ext}</echo>
-	                    <try>
-	                        <block>
-		                        <java jar="${build.tmp.dir}/yuicompressor-2.4.8.jar" fork="true" failonerror="true"
-		                              output="${build.dir}/yui-compress.out">
-                                    <!-- Add error="@{var}${compresserror.ext}" in java task if *.err files need to be generated. -->
-		                            <arg value="--line-break"/>
-		                            <arg value="0"/>
-		                            <arg value="--type"/>
-		                            <arg value="js"/>
-		                            <arg value="-o"/>
-		                            <arg value="@{var}${jsmin.ext}"/>
-		                            <arg value="@{var}${nodebug.ext}"/>
-                                    <arg value="--verbose"/>
-		                        </java>
-	                        </block>
-		                    <catch>
-			                    <antcall target='compress-test-files'>
-				                    <param name='filename' value='@{var}${depends.ext}' />
-			                    </antcall>
-		                    </catch>
-		                    <finally>
-			                    <!-- do nothing -->
-		                    </finally>
-	                    </try>
+                        <if>
+                            <or>
+                                <equals arg1="@{var}" arg2="${build.js.dir}/JQuery_all.js" />
+                                <!-- equals arg1="@{var}" arg2="${build.js.dir}/Modernizr_all.js" / -->
+                                <equals arg1="@{var}" arg2="${build.js.dir}/Clipboard_all.js" />
+                            </or>
+                            <!-- we will not minify thirdparty libraries -->
+                            <then>
+                                <echo>Copying thirdparty library file to @{var}${jsmin.ext}</echo>
+                                <copy tofile="@{var}${jsmin.ext}" file="@{var}"/>
+                            </then>
+                            <else>
+                                <try>
+                                    <block>
+                                        <echo>Minifying file to @{var}${jsmin.ext}</echo>
+                                        <java jar="${build.tmp.dir}/yuicompressor-2.4.8.jar" fork="true" failonerror="true"
+                                              output="@{var}${compressoutput.ext}">
+                                            <!-- Add error="@{var}${compresserror.ext}" in java task if *.err files need to be generated. -->
+                                            <arg value="--line-break"/>
+                                            <arg value="0"/>
+                                            <arg value="--type"/>
+                                            <arg value="js"/>
+                                            <arg value="-o"/>
+                                            <arg value="@{var}${jsmin.ext}"/>
+                                            <arg value="@{var}${nodebug.ext}"/>
+                                            <arg value="--verbose"/>
+                                        </java>
+                                    </block>
+                                    <catch>
+                                        <antcall target='compress-test-files'>
+                                            <param name='filename' value='@{var}${depends.ext}' />
+                                        </antcall>
+                                    </catch>
+                                    <finally>
+                                        <!-- do nothing -->
+                                    </finally>
+                                </try>
+                            </else>
+                        </if>
                         <echo>Prepending Copyright to @{var}${license.ext}</echo>
                         <concat destfile="@{var}${license.ext}" fixlastline="true">
                             <header filtering="no" trimleading="yes">
@@ -1545,7 +1560,14 @@ ext = BeanUtils.cook(ext);
         <unzip src="${build.tmp.dir}/jquery-${jquery.version}.jar" dest="${build.tmp.dir}/jquery" overwrite="true" />
 
         <copy todir="${3rdparty.dir}/jquery">
-            <fileset dir="${build.tmp.dir}/jquery/META-INF/resources/webjars/jquery/${jquery.version}" />
+            <fileset dir="${build.tmp.dir}/jquery/META-INF/resources/webjars/jquery/${jquery.version}" includes="*.js" excludes="webjars-requirejs.js" />
+            <scriptmapper language="javascript">
+                // replace dots with underscores in JS file names, retaining the suffix
+                if (/\.js$/.test(source)) {
+                  source = source.substr(0, source.length - 3).replace(/\./g, '_') + '.js';
+                }
+                self.addMappedName(source);
+            </scriptmapper>
         </copy>
     </target>
 
@@ -1556,7 +1578,14 @@ ext = BeanUtils.cook(ext);
         <unzip src="${build.tmp.dir}/modernizr-${modernizr.version}.jar" dest="${build.tmp.dir}/modernizr" overwrite="true" />
 
         <copy todir="${3rdparty.dir}/modernizr">
-            <fileset dir="${build.tmp.dir}/modernizr/META-INF/resources/webjars/modernizr/${modernizr.version}" />
+            <fileset dir="${build.tmp.dir}/modernizr/META-INF/resources/webjars/modernizr/${modernizr.version}" includes="*.js" />
+            <scriptmapper language="javascript">
+                // replace dots with underscores in JS file names, retaining the suffix
+                if (/\.js$/.test(source)) {
+                  source = source.substr(0, source.length - 3).replace(/\./g, '_') + '.js';
+                }
+                self.addMappedName(source);
+            </scriptmapper>
         </copy>
     </target>
 


### PR DESCRIPTION
- Move jquery and clipboard 3rdparty libs to it's own modules
- Don't minify code of 3rdparty libraries using yuicompressor instead use already minified version that is shipped as part of 3rdparty package
- Modernizr is a special case here, it is not moved to own module as that is tightly coupled with bootstrap classes which creates issues
- Make sure JQuery is loaded before any package, as that was the case earlier also
- Load clipboard module only when it is needed, this was earlier included  as part of startup module
- Upgrade jquery version to 3.3.1-1