### PR TITLE
ZCS-4023 Fix tinymce upgrade related bugs

### DIFF
--- a/WebRoot/WEB-INF/tags/compose/htmlCompose.tag
+++ b/WebRoot/WEB-INF/tags/compose/htmlCompose.tag
@@ -153,6 +153,7 @@ var myEditor;
             toolbar_items_size: 'small',
             toolbar : toolbarbuttons.join(' '),
             font_formats : fonts.join(";"),
+            fontsize_formats : "<fmt:message bundle='${AjxMsg}' key="fontSizes"/>" || '',
             statusbar : false,
             menubar : false,
             convert_urls : false,

--- a/WebRoot/WEB-INF/tags/options/optSignatures.tag
+++ b/WebRoot/WEB-INF/tags/options/optSignatures.tag
@@ -298,6 +298,7 @@
             toolbar_items_size: 'small',
             toolbar : toolbarbuttons.join(' '),
             font_formats : fonts.join(";"),
+            fontsize_formats : "<fmt:message bundle='${AjxMsg}' key="fontSizes"/>" || '',
             statusbar : false,
             menubar : false,
             convert_urls : false,


### PR DESCRIPTION
- Add custom font size support to html client, webclient is already using this
- Remove code in ZmHtmlEditor.js which was used to solve issue related to font format selection was setting wrong value in combobox, this was happening because we were having single quotes in font_formats config of TinyMCE which is now fixed properly
- If user has default compose mode as html and when user tried to open plain text task, code was loading html mode first but before it finishes we were setting mode as plain text which was creating issues, now we are making sure that html editor is always initialized with correct compose mode