### PR TITLE
ZCS-4023 Fix tinymce upgrade related bugs

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalItemEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalItemEditView.js
@@ -249,8 +249,7 @@ ZmCalItemEditView.prototype.setComposeMode =
 function(composeMode) {
 	this._composeMode = composeMode || this._composeMode;
 
-	if(this._notesHtmlEditor) {
-		this._notesHtmlModeFirstTime = !this._notesHtmlEditor.isHtmlModeInited();
+	if(this._notesHtmlEditor && this._notesHtmlEditor._editorInitialized) {
 		this._notesHtmlEditor.setMode(this._composeMode, true);
 		this.resize();
 	}


### PR DESCRIPTION
- Call setMode on htmleditor only when editor is initialized, before calling it will have no effect