### PR TITLE
ZCS-211 login CSRF protection: ZWC login form does not use a csrf token [CWE-352]

### DIFF
--- a/WebRoot/public/hostedlogin.jsp
+++ b/WebRoot/public/hostedlogin.jsp
@@ -2,6 +2,7 @@
 <%@ page import="java.util.*,javax.naming.*,com.zimbra.client.ZAuthResult" %>
 <%@ page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
 <%@ page session="false" %>
+<%@ page import="java.util.UUID" %>
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
@@ -16,7 +17,7 @@
 <fmt:setBundle basename="/messages/ZMsg" var="zmsg" scope="request"/>
 
 <%-- query params to ignore when constructing form port url or redirect url --%>
-<c:set var="ignoredQueryParams" value="loginOp,loginNewPassword,loginConfirmNewPassword,loginErrorCode,username,password,zrememberme,zlastserver,client,customerDomain"/>
+<c:set var="ignoredQueryParams" value="loginOp,loginNewPassword,loginConfirmNewPassword,loginErrorCode,username,password,zrememberme,zlastserver,client,customerDomain,login_csrf"/>
 <c:set var="prefsToFetch" value="zimbraPrefSkin,zimbraPrefClientType,zimbraPrefLocale,zimbraPrefMailItemsPerPage,zimbraPrefGroupMailBy,zimbraPrefAdvancedClientEnforceMinDisplay"/>
 <c:set var="attrsToFetch" value="zimbraFeatureMailEnabled,zimbraFeatureCalendarEnabled,zimbraFeatureContactsEnabled,zimbraFeatureIMEnabled,zimbraFeatureOptionsEnabled,zimbraFeaturePortalEnabled,zimbraFeatureTasksEnabled,zimbraFeatureVoiceEnabled,zimbraFeatureBriefcasesEnabled,zimbraFeatureMailUpsellEnabled,zimbraFeatureContactsUpsellEnabled,zimbraFeatureCalendarUpsellEnabled,zimbraFeatureVoiceUpsellEnabled,zimbraFeatureConversationsEnabled"/>
 
@@ -50,12 +51,31 @@
 			    	<c:set var="fullUserName" value="${param.username}"/>
 			    </c:otherwise>
 		    </c:choose>
-		    <c:choose>
-	        	<c:when test="${!empty cookie.ZM_TEST}">
-		            <zm:login username="${fullUserName}" password="${param.password}" varRedirectUrl="postLoginUrl" varAuthResult="authResult"
-		                      newpassword="${param.loginNewPassword}" rememberme="${param.zrememberme == '1'}"
-		                      prefs="${prefsToFetch}" attrs="${attrsToFetch}"
-							  requestedSkin="${param.skin}"/>
+			<c:choose>
+				<c:when test="${!empty cookie.ZM_TEST}">
+					<!-- CSRF check for login page -->
+					<c:choose>
+						<c:when test="${(not empty param.login_csrf) && (param.login_csrf eq cookie.ZM_LOGIN_CSRF.value)}">
+							<zm:login username="${fullUserName}" password="${param.password}" varRedirectUrl="postLoginUrl"
+								varAuthResult="authResult" newpassword="${param.loginNewPassword}" rememberme="${param.zrememberme == '1'}"
+								prefs="${prefsToFetch}" attrs="${attrsToFetch}"
+								requestedSkin="${param.skin}"/>
+
+							<%
+								// Delete cookie
+								Cookie csrfCookie = new Cookie("ZM_LOGIN_CSRF", "");
+								csrfCookie.setMaxAge(0);
+								response.addCookie(csrfCookie);
+
+								pageContext.setAttribute("login_csrf", "");
+							%>
+						</c:when>
+						<c:otherwise>
+							<!-- on failure of csrf show error to user -->
+							<c:set var="errorCode" value="unknownError"/>
+							<fmt:message var="errorMessage" key="unknownError"/>
+						</c:otherwise>
+					</c:choose>
 		            <%-- continue on at not empty authResult test --%>
 		    	</c:when>
 		        <c:otherwise>
@@ -68,15 +88,24 @@
 	        <%-- try and use existing cookie if possible --%>
 	        <c:set var="authtoken" value="${not empty param.zauthtoken ? param.zauthtoken : cookie.ZM_AUTH_TOKEN.value}"/>
 	        <c:if test="${not empty authtoken}">
-	            <zm:login authtoken="${authtoken}" authtokenInUrl="${not empty param.zauthtoken}"
-	                      varRedirectUrl="postLoginUrl" varAuthResult="authResult"
-	                      rememberme="${param.zrememberme == '1'}"
-                          prefs="${prefsToFetch}" attrs="${attrsToFetch}"
-						  requestedSkin="${param.skin}"/>
-	            <%-- continue on at not empty authResult test --%>
-	        </c:if>
-	    </c:otherwise>
-    </c:choose>
+				<zm:login authtoken="${authtoken}" authtokenInUrl="${not empty param.zauthtoken}"
+					varRedirectUrl="postLoginUrl" varAuthResult="authResult"
+					rememberme="${param.zrememberme == '1'}"
+					prefs="${prefsToFetch}" attrs="${attrsToFetch}"
+					requestedSkin="${param.skin}"/>
+
+				<%
+					// Delete cookie
+					Cookie csrfCookie = new Cookie("ZM_LOGIN_CSRF", "");
+					csrfCookie.setMaxAge(0);
+					response.addCookie(csrfCookie);
+
+					pageContext.setAttribute("login_csrf", "");
+				%>
+				<%-- continue on at not empty authResult test --%>
+			</c:if>
+		</c:otherwise>
+	</c:choose>
 </c:catch>
 <zm:getDomainInfo var="domainInfo" by="virtualHostname" value="${zm:getServerName(pageContext)}"/>
 <c:set var="mailServiceURL" value="${protocolMode}:\/\/${domainInfo.attrs.zimbraPublicServiceHostname}"/>
@@ -135,6 +164,14 @@ if (application.getInitParameter("offlineMode") != null)  {
 	Cookie testCookie = new Cookie("ZM_TEST", "true");
 	testCookie.setSecure(com.zimbra.cs.taglib.ZJspSession.secureAuthTokenCookie(request));
 	response.addCookie(testCookie);
+
+	String csrfToken = UUID.randomUUID().toString();
+	Cookie csrfCookie = new Cookie("ZM_LOGIN_CSRF", csrfToken);
+	csrfCookie.setSecure(com.zimbra.cs.taglib.ZJspSession.secureAuthTokenCookie(request));
+	csrfCookie.setHttpOnly(true);
+	response.addCookie(csrfCookie);
+
+	pageContext.setAttribute("login_csrf", csrfToken);
 %>
 
 
@@ -218,6 +255,8 @@ if (application.getInitParameter("offlineMode") != null)  {
                             <div id="ZLoginFormPanel">
                                 <form method="post" name="loginForm" action="${formActionUrl}">
                                     <input type="hidden" name="loginOp" value="login"/>
+                                    <input type="hidden" name="login_csrf" value="${login_csrf}"/>
+
                                     <table width="100%" cellpadding="4">
                                         <tr>
                                             <td class="zLoginLabelContainer"><label for="username"><fmt:message key="username"/>:</label></td>

--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -1,6 +1,7 @@
 <%@ page buffer="8kb" autoFlush="true" %>
 <%@ page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
 <%@ page session="false" %>
+<%@ page import="java.util.UUID" %>
 <%@ page import="com.zimbra.cs.taglib.ZJspSession"%>
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
@@ -16,7 +17,7 @@
 <fmt:setBundle basename="/messages/ZMsg" var="zmsg" scope="request"/>
 
 <%-- query params to ignore when constructing form port url or redirect url --%>
-<c:set var="ignoredQueryParams" value=",loginOp,loginNewPassword,totpcode,loginConfirmNewPassword,loginErrorCode,username,email,password,zrememberme,ztrusteddevice,zlastserver,client,"/>
+<c:set var="ignoredQueryParams" value=",loginOp,loginNewPassword,totpcode,loginConfirmNewPassword,loginErrorCode,username,email,password,zrememberme,ztrusteddevice,zlastserver,client,login_csrf,"/>
 
 <%-- get useragent --%>
 <zm:getUserAgent var="ua" session="false"/>
@@ -110,11 +111,29 @@
 		<c:when test="${(param.loginOp eq 'login') && !(empty fullUserName) && !(empty param.password) && (pageContext.request.method eq 'POST')}">
 			<c:choose>
 				<c:when test="${!empty cookie.ZM_TEST}">
-                    <zm:login username="${fullUserName}" password="${param.password}" varRedirectUrl="postLoginUrl"
-							varAuthResult="authResult"
-							newpassword="${param.loginNewPassword}" rememberme="${param.zrememberme == '1'}"
-                            trustedDeviceToken="${cookie.ZM_TRUST_TOKEN.value}"
-							requestedSkin="${param.skin}" importData="true" csrfTokenSecured="true"/>
+					<!-- CSRF check for login page -->
+					<c:choose>
+						<c:when test="${(not empty param.login_csrf) && (param.login_csrf eq cookie.ZM_LOGIN_CSRF.value)}">
+							<zm:login username="${fullUserName}" password="${param.password}" varRedirectUrl="postLoginUrl"
+								varAuthResult="authResult" newpassword="${param.loginNewPassword}" rememberme="${param.zrememberme == '1'}"
+								trustedDeviceToken="${cookie.ZM_TRUST_TOKEN.value}"
+								requestedSkin="${param.skin}" importData="true" csrfTokenSecured="true"/>
+
+							<%
+								// Delete cookie
+								Cookie csrfCookie = new Cookie("ZM_LOGIN_CSRF", "");
+								csrfCookie.setMaxAge(0);
+								response.addCookie(csrfCookie);
+
+								pageContext.setAttribute("login_csrf", "");
+							%>
+						</c:when>
+						<c:otherwise>
+							<!-- on failure of csrf show error to user -->
+							<c:set var="errorCode" value="unknownError"/>
+							<fmt:message var="errorMessage" key="unknownError"/>
+						</c:otherwise>
+					</c:choose>
 					<%-- continue on at not empty authResult test --%>
 				</c:when>
 				<c:otherwise>
@@ -127,11 +146,21 @@
             <%-- try and use existing cookie if possible --%>
 			<c:set var="authtoken" value="${not empty param.zauthtoken ? param.zauthtoken : cookie.ZM_AUTH_TOKEN.value}"/>
 			<c:if test="${not empty authtoken}">
-				<zm:login authtoken="${authtoken}" authtokenInUrl="${not empty param.zauthtoken}" twoFactorCode="${not empty param.totpcode ? param.totpcode : ''}"
-						varRedirectUrl="postLoginUrl" varAuthResult="authResult"
-						rememberme="${param.zrememberme == '1'}" trustedDevice="${param.ztrusteddevice == 1}"
-						requestedSkin="${param.skin}" adminPreAuth="${param.adminPreAuth == '1'}"
-                        importData="true" csrfTokenSecured="true"/>
+				<zm:login authtoken="${authtoken}" authtokenInUrl="${not empty param.zauthtoken}"
+					twoFactorCode="${not empty param.totpcode ? param.totpcode : ''}"
+					varRedirectUrl="postLoginUrl" varAuthResult="authResult"
+					rememberme="${param.zrememberme == '1'}" trustedDevice="${param.ztrusteddevice == 1}"
+					requestedSkin="${param.skin}" adminPreAuth="${param.adminPreAuth == '1'}"
+					importData="true" csrfTokenSecured="true"/>
+
+				<%
+					// Delete cookie
+					Cookie csrfCookie = new Cookie("ZM_LOGIN_CSRF", "");
+					csrfCookie.setMaxAge(0);
+					response.addCookie(csrfCookie);
+
+					pageContext.setAttribute("login_csrf", "");
+				%>
 				<%-- continue on at not empty authResult test --%>
 			</c:if>
 		</c:otherwise>
@@ -365,6 +394,15 @@ if (application.getInitParameter("offlineMode") != null) {
 	Cookie testCookie = new Cookie("ZM_TEST", "true");
 	testCookie.setSecure(com.zimbra.cs.taglib.ZJspSession.secureAuthTokenCookie(request));
 	response.addCookie(testCookie);
+
+	String csrfToken = UUID.randomUUID().toString();
+	Cookie csrfCookie = new Cookie("ZM_LOGIN_CSRF", csrfToken);
+	csrfCookie.setSecure(com.zimbra.cs.taglib.ZJspSession.secureAuthTokenCookie(request));
+	csrfCookie.setHttpOnly(true);
+	response.addCookie(csrfCookie);
+
+	pageContext.setAttribute("login_csrf", csrfToken);
+
 	//Add the no-cache headers to ensure that the login page is never served from cache
 	response.addHeader("Vary", "User-Agent");
 	response.setHeader("Expires", "-1");
@@ -459,6 +497,7 @@ if (application.getInitParameter("offlineMode") != null) {
 					<c:otherwise>
 								<form method="post" name="loginForm" action="${formActionUrl}" accept-charset="UTF-8">
 								<input type="hidden" name="loginOp" value="login"/>
+								<input type="hidden" name="login_csrf" value="${login_csrf}"/>
 
 								<c:if test="${totpAuthRequired || errorCode eq 'account.TWO_FACTOR_AUTH_FAILED'}">
 									<!-- if user has selected remember me in login page and we are showing totp screen to user, then we need to maintain value of that flag as after successfull two factor authentication we will have to rewrite ZM_AUTH_TOKEN with correct expires headers -->


### PR DESCRIPTION
- add csrf token protection in login page, this token is non persistant
- first a unique random string is generated which is put into cookie as ZM_LOGIN_CSRF and also stored as hidden form input field as login_csrf
- when submitting login request we compare both the values if both values match then only go ahead with auth request otherwise show error to user and break login process