### PR TITLE
snickers: NICPS-138: remove "mailto:" at Copy action

### DIFF
--- a/WebRoot/js/zimbraMail/share/controller/ZmBaseController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmBaseController.js
@@ -1342,7 +1342,13 @@ ZmBaseController.prototype._getBubbleActionMenuOps = function() {
 
 // Copies address text from the active bubble to the clipboard.
 ZmBaseController.prototype._clipCopy = function(clip) {
-	clip.setText(this._actionEv.address + AjxEmailAddress.SEPARATOR);
+	if ((this._actionEv.item && this._actionEv.item.isAddressBubble) || this._actionEv.address instanceof AjxEmailAddress) {
+		clip.setText(this._actionEv.address + AjxEmailAddress.SEPARATOR);
+	} else if (this._actionEv.address) {
+		clip.setText(AjxStringUtil.parseMailtoLink(this._actionEv.address).to + AjxEmailAddress.SEPARATOR);
+	} else {
+		clip.setText(AjxEmailAddress.SEPARATOR);
+	}
 };
 
 ZmBaseController.prototype._clipCopyComplete = function(clip) {


### PR DESCRIPTION
Problem : "mailto:user@domain" is copied when user right-clik an email link and click "Copy"

Fix : changed to copy "user@domain" only

Testing done : testing done by developer
Checked fields:
- Email: message preview pane
  - Conversation/Message view
  - Text/HTML mail
- Contact: Email field
- Task: subject, location, content

Note:
Copy action on address bubble copies display name and email address.
Example: `"Last First" <user@domain>`
- from/to/cc header shown in message preview pane
- recipient in To/Cc/Bcc field in Compose page

Testing to be done by QA : testing needed to be done by QA in PS team