### PR TITLE
snickers: NICPS-138: removed "mailto:" at New Email action on Contact List

### DIFF
--- a/WebRoot/js/zimbraMail/abook/controller/ZmContactListController.js
+++ b/WebRoot/js/zimbraMail/abook/controller/ZmContactListController.js
@@ -930,7 +930,8 @@ function(ev) {
 			}
 		}
 		else {
-			var addr = new AjxEmailAddress(contact.getEmail(), AjxEmailAddress.TO, contact.getFullName());
+			var email = AjxStringUtil.parseMailtoLink(contact.getEmail()).to;
+			var addr = new AjxEmailAddress(email, AjxEmailAddress.TO, contact.getFullName());
 			emailStr += addr.toString() + AjxEmailAddress.SEPARATOR;
 		}
     }


### PR DESCRIPTION
Problem : "mailto:user@address" is added to To field when a contact email is "mailto:user@domain" and "New Email" is clicked

Fix : remove "mailto:" from email address

Testing done : testing done by developer

Testing to be done by QA : testing needed to be done by QA in PS team

Note: The PR doesn't fix "New Email" on contact group. If an email of a contact in a contact group is "mailto:user@domain", the contact is not added to To field at "New Email" action on the contact group.
The reason not to fix it is, we need to change AjxEmailAddress.parseEmailString or AjxEmailAddress.parse, but affected area is wide. It is risky at this point.

Linked PR :
https://github.com/Zimbra/zm-web-client/pull/234
https://github.com/Zimbra/zm-web-client/pull/256