### PR TITLE
ZCS-5266: Errors shown on UI should be language independent

### DIFF
--- a/WebRoot/messages/ZmMsg.properties
+++ b/WebRoot/messages/ZmMsg.properties
@@ -4535,6 +4535,17 @@ passwordRecoveryResetSuccessDescription = You have successfully reset your passw
 passwordRecoveryResetSuccessFinish = Finish
 passwordRecoveryPassword = Confirm Password
 passwordRecoveryComplete = Your reset password setup is already done.
+# Password Recovery errors
+service.RECOVERY_EMAIL_SAME_AS_PRIMARY_OR_ALIAS = Recovery address should not be same as primary/alias email address.
+service.CODE_ALREADY_SENT = Verification code already sent to this recovery email.
+service.MAX_ATTEMPTS_REACHED = Re-send code request has reached maximum limit.
+service.MAX_ATTEMPTS_REACHED_SUSPEND_FEATURE = Max re-send attempts reached, feature is suspended.
+service.CODE_NOT_FOUND = Verification code for recovery email address not found on server.
+service.CODE_MISMATCH = Verification failed for the code sent to your recovery email address.
+service.CODE_EXPIRED = The recovery email address verification code is expired.
+service.CONTACT_ADMIN = Something went wrong. Please contact your administrator.
+service.FEATURE_RESET_PASSWORD_SUSPENDED = Password reset feature is suspended.
+service.FEATURE_RESET_PASSWORD_DISABLED = Password reset feature is disabled.
 
 # oAuth Web Views
 signIn = Sign in with your Zimbra account


### PR DESCRIPTION
**Problem:** Errors shown on UI should be language independent

**Fix:** Create error codes and pass them instead of passing plain string message for error condition.

**Testing Done:**
1. Corrected and ran unit tests for SetRecoverAccountTest and RecoverAccountTest.
2. Manually tested responses on SOAPUI.

**Testing to be done by QA:**
1. Correct required automation.
2. Test and verify errors received in responses.

**Linked PR:**
https://github.com/Zimbra/zm-mailbox/pull/662