### PR TITLE
bugfix/ZCS-5595 Add logic to show hide forgot password link

### DIFF
--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -587,12 +587,15 @@ if (application.getInitParameter("offlineMode") != null) {
                                 <input type="submit" class="ZLoginButton DwtButton" value="<fmt:message key="login"/>" />
                                 </td>
                                 </tr>
+				<c:set var="resetPasswordFeatureStatus" value="${domainInfo.attrs.zimbraFeatureResetPasswordStatus}"/>
+				<c:if test="${resetPasswordFeatureStatus eq 'enabled'}">
                                     <tr>
                                         <td>&nbsp;</td>
                                         <td class="submitTD">
                                             <a href="#" onclick="forgotPassword();" id="ZLoginForgotPassword" aria-controls="ZLoginForgotPassword" aria-expanded="false"><fmt:message key="forgotPassword"/></a>
                                         </td>
                                     </tr>
+                                </c:if>
                             </c:otherwise>
                         </c:choose>
                         <c:if test="${empty param.virtualacctdomain}">

--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -587,8 +587,8 @@ if (application.getInitParameter("offlineMode") != null) {
                                 <input type="submit" class="ZLoginButton DwtButton" value="<fmt:message key="login"/>" />
                                 </td>
                                 </tr>
-				<c:set var="resetPasswordFeatureStatus" value="${domainInfo.attrs.zimbraFeatureResetPasswordStatus}"/>
-				<c:if test="${resetPasswordFeatureStatus eq 'enabled'}">
+			
+				<c:if test="${domainInfo.attrs.zimbraFeatureResetPasswordStatus eq 'enabled'}">	
                                     <tr>
                                         <td>&nbsp;</td>
                                         <td class="submitTD">


### PR DESCRIPTION
Added logic in login.jsp file to show/hide "Forgot Password" link. This checks against the zimbraFeatureResetPasswordStatus which is set with the domainInfo flag.

To test use zmprov to change this attribute on the domain level and then restart mailbox.

zmprov md [DOMAIN] zimbraFeatureResetPasswordStatus disabled
zmmailboxdctl restart
Confirm link doe NOT show.

zmprov md [DOMAIN] zimbraFeatureResetPasswordStatus suspended
zmmailboxdctl restart
Confirm link doe NOT show.

zmprov md [DOMAIN] zimbraFeatureResetPasswordStatus enabled
zmmailboxdctl restart
Confirm link DOES show.