### PR TITLE
Revert "NICPS-386: update version to handle zm-patch dependency (#304)"

### DIFF
--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -59,7 +59,7 @@ sub git_timestamp_from_dirs($)
 my %PKG_GRAPH = (
    "zimbra-mbox-webclient-war" => {
       summary    => "Zimbra WebClient War",
-      version    => "2.0.0",
+      version    => "1.0.0",
       revision   => 1,
       hard_deps  => [],
       soft_deps  => [],


### PR DESCRIPTION
This reverts commit 5dd308218e575db3d6f21c1c12af2aee12c4accb.