### PR TITLE
ZBUG-669: changed to hide Show Conversation when zimbraFeatureConversationsEnabled is FALSE

### DIFF
--- a/WebRoot/js/zimbraMail/mail/ZmMailApp.js
+++ b/WebRoot/js/zimbraMail/mail/ZmMailApp.js
@@ -916,7 +916,7 @@ function() {
 	ZmOperation.registerOp(ZmId.OP_SEND_MENU, {textKey:"send", tooltipKey:"sendTooltip", image:"Send"}, ZmSetting.SAVE_DRAFT_ENABLED);
 	ZmOperation.registerOp(ZmId.OP_SEND_LATER, {textKey:"sendLater", tooltipKey:"sendLaterTooltip", image:"SendLater"}, ZmSetting.SAVE_DRAFT_ENABLED);
 	ZmOperation.registerOp(ZmId.OP_SHOW_BCC, {textKey:"showBcc"});
-	ZmOperation.registerOp(ZmId.OP_SHOW_CONV, {textKey:"showConv", image:"Conversation"});
+	ZmOperation.registerOp(ZmId.OP_SHOW_CONV, {textKey:"showConv", image:"Conversation"}, ZmSetting.CONVERSATIONS_ENABLED);
 	ZmOperation.registerOp(ZmId.OP_SHOW_ORIG, {textKey:"showOrig", image:"Message"});
 	ZmOperation.registerOp(ZmId.OP_SPAM, {textKey:"junkLabel", tooltipKey:"junkTooltip", image:"JunkMail", shortcut:ZmKeyMap.SPAM, textPrecedence:70}, ZmSetting.SPAM_ENABLED);
 	ZmOperation.registerOp(ZmId.OP_USE_PREFIX, {textKey:"usePrefix"});


### PR DESCRIPTION
[Problem]
Show Conversation menu item is shown even when zimbraFeatureConversationsEnabled is FALSE.

[Root cause]
SHOW_CONV operation was always enabled in ZmMailApp.js.

[Fix]
Add ZmSetting.CONVERSATIONS_ENABLED as a condition to enable/disable the operation.