### PR TITLE
ZBUG-723: added styles to show cancel button on toolbar

### DIFF
--- a/WebRoot/css/iphone.css
+++ b/WebRoot/css/iphone.css
@@ -698,6 +698,15 @@ h1, h2, h3, h4, h5, h6 {
     -moz-border-radius: 5px;
     vertical-align:middle;
 }
+
+#fbbar .zo_button1 {
+    display: inline-block;
+}
+
+#fbbar .zo_button1 .ImgCancel {
+    display: block;
+}
+
 /* TODO: Is this still used? And have we lost any formatting going to ImgEdit class?
 .Edit{
     background-color: #EEE;


### PR DESCRIPTION
[Problem]
Blank button appears when a checkbox of a message/conversation/contact is checked on Mobile HTML client.

[Root cause]
ImgCancel class was set in HTML code but style was not set.

[Fix]
Add styles to the button and the class.