### PR TITLE
ZBUG-724: set empty string if search query is null or undefined

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -2151,7 +2151,7 @@ function(view) {
 				var stb = appCtxt.getSearchController().getSearchToolbar();
 				if (appCtxt.get(ZmSetting.SHOW_SEARCH_STRING) && stb) {
 					var value = currentSearch ? currentSearch.query : app.currentQuery;
-					value = appName === ZmApp.SEARCH ? "" : value;
+					value = appName === ZmApp.SEARCH ? "" : (value || "");
 					stb.setSearchFieldValue(value + " " || "");
 				}
 			}


### PR DESCRIPTION
[Problem]
"undefined" is shown in a search field when Calendar or Preferences tab is clicked if zimbraPrefShowSearchString is TRUE.

[Root cause]
Search query was set in the field without null/undefined check.

[Fix]
Set an empty string if a search query is null or undefined.