### PR TITLE
ZBUG-725: fixed to add an email address of a member of a contact group to TO field in compose

### DIFF
--- a/WebRoot/WEB-INF/tags/mobile/moContactEmail.tag
+++ b/WebRoot/WEB-INF/tags/mobile/moContactEmail.tag
@@ -1,0 +1,30 @@
+<%--
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Web Client
+ * Copyright (C) 2009, 2010, 2013, 2014, 2016 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+--%>
+<%@ tag body-content="empty" %>
+
+<%@ attribute name="email" rtexprvalue="true" required="true" %>
+<%@ attribute name="label" rtexprvalue="true" required="false" %>
+
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="fmt" uri="com.zimbra.i18n" %>
+
+<c:if test="${!empty email}">
+        <fmt:message key="${label}" var="elabel"/>
+        <c:set var="escapedEmail">${fn:escapeXml(email)}</c:set>
+        <tr><c:if test="${!empty label}"><td class="contactLabel">${fn:escapeXml(elabel)}:</td></c:if><td class="contactOutput"><a href="/m/zmain?st=newmail&to=${escapedEmail}">${escapedEmail}</a></td></tr>
+</c:if>

--- a/WebRoot/WEB-INF/tags/mobile/moContactView.tag
+++ b/WebRoot/WEB-INF/tags/mobile/moContactView.tag
@@ -121,7 +121,7 @@
                                     <app:contactJobInfo contact="${memberContact}" />
                                 </td>
                                 <td width="20" class="contactOutput">
-                                    <app:contactEmail email="${memberContact.email}"/>
+                                    <mo:contactEmail email="${memberContact.email}"/>
                                 </td>
                                 <c:set var="memberContactAttrs" value="${memberContact.attrs}"/>
                                 <td width="20" class="contactOutput" nowrap="nowrap"><c:if test="${zm:anySet(memberContact,'mobilePhone')}">${fn:escapeXml(memberContactAttrs['mobilePhone'])}</c:if></td>

--- a/WebRoot/WEB-INF/tlds/mobile.tld
+++ b/WebRoot/WEB-INF/tlds/mobile.tld
@@ -31,6 +31,11 @@
     </tag-file>
 
     <tag-file>
+       <name>contactEmail</name>
+        <path>/WEB-INF/tags/mobile/moContactEmail.tag</path>
+    </tag-file>
+
+    <tag-file>
        <name>folderForm</name>
         <path>/WEB-INF/tags/mobile/moFolderForm.tag</path>
     </tag-file>


### PR DESCRIPTION
[Problem]
Compose page of Standard HTML client is shown when a member of a contact group is clicked on Mobile HTML client.

[Root cause]
<app:contactEmail> was set in moContactView.tag. It called /WEB-INF/tags/contact/contactEmail.tag, which was used for Standard HTML client.

[Fix]
Add moContactEmail.tag and modify moContactView.tag to call it.