### PR TITLE
ZBUG-727: fixed script error at undo contact deletaion in Search tab

### DIFF
--- a/WebRoot/js/zimbraMail/abook/view/ZmContactSplitView.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmContactSplitView.js
@@ -1116,6 +1116,9 @@ function(ev) {
 	// bug fix #14874 - if moved to trash, show strike-thru
 	var folderId = this._controller.getFolderId();
 	if (!folderId && ev.event == ZmEvent.E_MOVE) {
+		if(!ev._details.items) {
+			ev._details.items = ev.items;
+		}
 		var contact = ev._details.items[0];
 		var folder = appCtxt.getById(contact.folderId);
 		var row = this._getElement(contact, ZmItem.F_ITEM_ROW);


### PR DESCRIPTION
[Problem]
Script error is shown when a contact is deleted and undo is clicked in Search tab.

[Root cause]
When two or more contacts were deleted and undo was executed, ZmItemMoveAction.multipleUndo was called. In the process, ev._details.items were set in ZmItem._doNotify. Then no error occurred in ZmContactSimpleView._changeListener.
On the other hand, when a contact were deleted and undo was executed, ZmItemMoveAction.undo was called. In the process, ev._details.items were not set because ZmItem._doNotify was not called. Then ev._details didn't have items property in ZmContactSimpleView._changeListener. As a result, '0' of undefined was referred.

[Fix]
Add ev._details.items if it is undefined.