### PR TITLE
ZBUG-732: fixed to check if an email adress is not empty in Add Filter dialog

### DIFF
--- a/WebRoot/js/zimbraMail/prefs/view/ZmFilterRuleDialog.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmFilterRuleDialog.js
@@ -1430,7 +1430,9 @@ function(rowId) {
 	}
 	else if (testType == ZmFilterRule.TEST_ADDRESS && subject) {
 		subjectMod = ZmFilterRule.C_ADDRESS_VALUE[subject];
-		value += ";" + valueMod;   //addressTest has value=email part=all|domain|localpart
+		if (value != "") {
+			value += ";" + valueMod;   //addressTest has value=email part=all|domain|localpart
+		}
 	}
 	else if (testType == ZmFilterRule.TEST_SIZE && valueMod && valueMod != "B") {
 		value += valueMod;
@@ -1441,7 +1443,9 @@ function(rowId) {
 		value = ZmMimeTable.MSG_READ_RECEIPT;
 	}
 	else if (testType == ZmFilterRule.TEST_ADDRESS) {
-		value += ";" + valueMod;   //addressTest has value=email part=all|domain|localpart
+		if (value != "") {
+			value += ";" + valueMod;   //addressTest has value=email part=all|domain|localpart
+		}
 	}
 	else if (testType == ZmFilterRule.TEST_CONVERSATIONS && value == ZmFilterRule.IMPORTANCE) {
 		value = valueMod;  //importanceTest


### PR DESCRIPTION
[Problem]
Filter can be saved even when an email address field of From/To/Cc/Bcc is empty in Add Filter dialog.

[Root cause]
Empty check did not exist for a rule of TEST_ADDRESS type.

[Fix]
Added empty checks.
