### PR TITLE
ZBUG-623 : Prevent attachment duplication while saving or sending email.

### DIFF
--- a/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
+++ b/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
@@ -2151,7 +2151,7 @@ function(findHits, includeInlineImages, includeInlineAtts) {
 
 			if (!this.isRealAttachment(attach) ||
 					(attach.contentType.match(/^image/) && attach.contentId && attach.foundInMsgBody && !includeInlineImages) ||
-					(attach.contentDisposition == "inline" && attach.fileName && ZmMimeTable.isRenderable(attach.contentType, true) && !includeInlineAtts)) {
+					(attach.contentDisposition == "inline" && attach.fileName && ZmMimeTable.isRenderable(attach.contentType, !appCtxt.get(ZmSetting.VIEW_AS_HTML)) && !includeInlineAtts)) {
 				continue;
 			}
 


### PR DESCRIPTION
Inline pdf attachments are being converted to actual attachment as we are
considering inline-pdf as non renderable with html editor mode as well.
Fixing this by considering inline-pdf as non-renderable in case of
Text editor only.