### PR TITLE
ZBUG-724 : Fix spacing issue for search bar text

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -2159,7 +2159,7 @@ function(view) {
 				if (appCtxt.get(ZmSetting.SHOW_SEARCH_STRING) && stb) {
 					var value = currentSearch ? currentSearch.query : app.currentQuery;
 					value = appName === ZmApp.SEARCH ? "" : value;
-					stb.setSearchFieldValue(value + " " || "");
+					stb.setSearchFieldValue(value ? value + " " : "");
 				}
 			}
 


### PR DESCRIPTION
ZBUG-724 : Fix spacing issue for search bar text.
Earlier, "undefined" was shown in the search field when Calendar or Preferences tab is clicked.
It was due to the concatenation of undefined variable and a space character.