### PR TITLE
NICPS-517: Add check for file content type while uploading in the briefcase.

### DIFF
--- a/WebRoot/js/zimbraMail/share/ZmUploadManager.js
+++ b/WebRoot/js/zimbraMail/share/ZmUploadManager.js
@@ -423,7 +423,8 @@ function(errors, maxSize, lineBreak) {
     var errorMsg = [ZmMsg.uploadFailed];
     if (errorSummary.invalidExtension) {
         var extensions = this._formatUploadErrorList(this._extensions);
-        errorMsg.push("* " + AjxMessageFormat.format(ZmMsg.errorNotAllowedFile, [ extensions ]));
+        errorFilenames = this._formatUploadErrorList(errorSummary.invalidExtension);
+        errorMsg.push("* " + AjxMessageFormat.format(ZmMsg.errorNotAllowedFile, [ errorFilenames, extensions ]));
     }
 	var msgFormat, errorFilenames;
     if (errorSummary.invalidFilename) {

--- a/WebRoot/js/zimbraMail/share/ZmUploadManager.js
+++ b/WebRoot/js/zimbraMail/share/ZmUploadManager.js
@@ -395,7 +395,7 @@ function(filename, extensions) {
     if (!extensions) return true;
     var ext = filename.replace(/^.*\./,"").toUpperCase();
     for (var i = 0; i < extensions.length; i++) {
-        if (extensions[i] == ext) {
+        if (extensions[i].toUpperCase() == ext) {
             return true;
         }
     }

--- a/WebRoot/js/zimbraMail/share/ZmUploadManager.js
+++ b/WebRoot/js/zimbraMail/share/ZmUploadManager.js
@@ -376,8 +376,6 @@ function(file, extensions, cb) {
                 file.verifiedTypeList = ["ZLIB"];
             }
             // result = true;
-            console.log(file.name, file.verifiedTypeList, signature);
-            console.log("Extensions:-->", extensions);
             for (var i = 0; i < extensions.length; i++) {
             if ( file.verifiedTypeList &&  file.verifiedTypeList.indexOf(extensions[i].toUpperCase()) !== -1) {
                 return cb(true);

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmUploadDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmUploadDialog.js
@@ -367,7 +367,7 @@ ZmUploadDialog.prototype._upload = function(){
                             setLinkTitleText();
                         }
 
-                        if ((i + 1) === elements.length) {
+                        if ((i + 1) === fileElements.length) {
                             postUpload();
                         }
                     }).bind(this))

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmUploadDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmUploadDialog.js
@@ -254,7 +254,7 @@ ZmUploadDialog.prototype.setFileExtensions = function(){
 ZmUploadDialog.prototype._upload = function(){
     var form         	= this._uploadForm;
     var uploadFiles  	= [];
-    var errors       	= {};
+    var errors       	= [];
     this._linkText   	= {};
     var aCtxt        	= ZmAppCtxt.handleWindowOpener();
     var maxSize      	=  aCtxt.get(ZmSetting.DOCUMENT_SIZE_LIMIT);
@@ -272,10 +272,8 @@ ZmUploadDialog.prototype._upload = function(){
         if ((element.name != ZmUploadDialog.UPLOAD_FIELD_NAME) || !element.value)  continue;
 
         this._msgInfo.innerHTML = "";
-		var errors = [];
         if(this._supportsHTML5){
             var files = element.files;
-			var errors = [];
             for (var j = 0; j < files.length; j++){
                 file = files[j];
                 fileObj.push(file);


### PR DESCRIPTION
NICPS-517: Add check for file content type while uploading the file in the briefcase.

**Issue**: While uploading the files in the briefcase, the extensions were being checked against the allowed file extension. But, the actual file content was not getting checked. If a user manipulates the file extension, then security can be bypassed easily.  Refer NICPS-378 for more info on extension check.  There was a bug with existing functionality of extension checking which allows all the files to be uploaded while uploading multiple files and providing a valid file as the last file.

**Solution**: To check the file type regardless of the extension, we need to check the file signature and match it with the different file signatures of various file types. This requires the browser's FileReader API. 

Steps for getting the file signature ( also called magic number )     

Take the first 4 bytes of the file using the slice method
Create a new FileReader instance
Use the FileReader to read the sliced 4 bytes
Create a typed array from the buffer using getUint32
Convert every byte in hexadecimal
What we get now is the file signature(magic number)
Now this magic number needs to be compared to magic numbers of different file types. If there is a match, we can identify the file type.

This solution has one caveat as file signature are not always unique for every file type.
For example, we have unique file signatures for PDF, GIF, etc. but file types like DOCX, PPTX. XLSX, ZIP, etc share the same file signature. It means that we wouldn't be able to differentiate between PPTX and ZIP files using this solution.

For now,  What we can do is to put a check for the commonly used file types. If there is a match, we can further check that file type with the allowed file extensions