### PR TITLE
ZBUG-848: fixed to add all selected contacts to To/Cc/Bcc field

### DIFF
--- a/WebRoot/WEB-INF/tags/mobile/moContactAction.tag
+++ b/WebRoot/WEB-INF/tags/mobile/moContactAction.tag
@@ -156,11 +156,11 @@
     </c:when>
     <c:when test="${zm:actionSet(param, 'composeTo') || zm:actionSet(param, 'composeCC') || zm:actionSet(param, 'composeBCC')
                             || (zm:actionSet(param,'moreActions') && (anAction == 'composeTo' || anAction == 'composeCC' || anAction == 'composeBCC'))}">
+        <c:set var="emailIds" value="" />
         <c:forEach var="id" items="${ids}">
             <zm:getContact var="contact" id="${id}"/>
             <c:choose>
                 <c:when test="${contact.isGroup}">
-                    <c:set var="emailIds" value="" />
                     <c:forEach var="member" items="${contact.groupMembers}">
                         <c:if test="${not empty emailIds}"><c:set var="grpsep" value=", " /></c:if>
                         <c:set var="memberContact" value="${zm:groupMemberById(contact, member)}"/>
@@ -204,7 +204,11 @@
                     <c:if test="${empty homeEmail and not empty workEmail}">
                          <c:set var="toEmail" value="${workEmail}${not empty toEmail ? ',' : ''}${not empty toEmail ? toEmail : ''}"/>
                     </c:if>
-                    <c:set var="emailIds" value="${toEmail}" />
+                    <c:set var="mailsep" value="" />
+                    <c:if test="${not empty emailIds}">
+                        <c:set var="mailsep" value=", " />
+                    </c:if>
+                    <c:set var="emailIds" value="${emailIds}${mailsep}${toEmail}" />
                 </c:otherwise>
             </c:choose>
         </c:forEach>


### PR DESCRIPTION
Problem: Only one of selected contacts is added to To/Cc/Bcc field even when two or more contacts are selected and To/Cc/Bcc action is executed on Mobile HTML client.

Root cause:
Selected contacts were not listed but only one of selected contacts was specified as a parameter in redirect url.

Fix:
Join selected contacts' email addresses with "comma+whitespace" and set it to redirect url.