### PR TITLE
ZBUG-850: fixed to remote msgDiv when item is checked/unchecked

### DIFF
--- a/WebRoot/WEB-INF/tags/mobile/moJS.tag
+++ b/WebRoot/WEB-INF/tags/mobile/moJS.tag
@@ -856,6 +856,10 @@ var hideDelete = function(id){
 var updateChecked = function(disabled,doItAll){
    var fbbar = $("fbbar");
    if(!dV[dId] && !fbbar) return;
+   var msgDiv = $("msgDiv");
+   if(msgDiv) {
+       msgDiv.remove();
+   }
    var cCount = 0,cbs=$('zForm').getElementsByClassName('chk');
    for(var i=0, len = (cbs !== undefined) ? cbs.length : 0; i < len; i++){
        if(cbs[i].checked){ cCount++;cbs[i].disabled = disabled;}


### PR DESCRIPTION
**Problem:**
Toolbar appears in a wrong place after an action is executed and another message is selected on Mobile HTML client.

**Root cause:**
When an item is checked, style "display: table" is added to the following div and then the toolbar (id='fbbar') appears
`<div id="fbbar" class="tb tbl" style="display: table; transform: translateY(0px);">`
The position of fbbar is "absolute".

    #fbbar {
        position: absolute!important;
        top: 40px!important;
        -webkit-transition: -webkit-transform .2s ease-out;
        z-index: 100!important;
        border-bottom: 2px solid silver;
    }

When an action is executed, the following msgDiv is added and then a result message (like "1 message has been marked read") is shown.
`<div class="container tbl" id="msgDiv" onclick="return toggleElem(this);">`
At this point, the position of folder name area, toolbar and message list move down because msgDiv is inserted between App bar and folder name area.

When another item is checked, fbbar is shown in the same position (=absolute position) but other area has moved down. As a result, fbbar is not shown over the toolbar.

**Fix:**
When another item is checked or a checked item is unchecked, msgDiv is removed. Then fbbar is shown over the toolbar.