### PR TITLE
ZBUG-851: fixed tabIndex in Add/Edit Filter dialog

### DIFF
--- a/WebRoot/js/zimbraMail/prefs/view/ZmFilterRuleDialog.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmFilterRuleDialog.js
@@ -218,26 +218,31 @@ function() {
 	// get basic controls
 	var MAX_VALUE = 100000;
 	var tabIndexes = {};
-	var ids = [ this._nameInputId, this._activeCheckboxId, this._stopCheckboxId ];
+	var el, tabIndex;
+	var ids = [this._activeCheckboxId, this._nameInputId];
 	for (var i = 0; i < ids.length; i++) {
-		var el = Dwt.byId(ids[i]);
-		var tabIndex = el.getAttribute("tabindex") || MAX_VALUE - 5 - i;
+		el = Dwt.byId(ids[i]);
+		tabIndex = MAX_VALUE - 6 - i;
 		tabIndexes[tabIndex] = el;
 	}
 
 	// add other controls
-	var el = Dwt.byId(this._conditionId);
-	var tabIndex = el.getAttribute("tabindex") || MAX_VALUE - 4;
+	el = Dwt.byId(this._conditionId);
+	tabIndex = MAX_VALUE - 5;
 	tabIndexes[tabIndex] = this._conditionSelect;
 
 	// add tabgroups that will hold the conditions and actions
-	var el = Dwt.byId(this._conditionsTableId);
-	var tabIndex = el.getAttribute("tabindex") || MAX_VALUE - 3;
+	el = Dwt.byId(this._conditionsTableId);
+	tabIndex = MAX_VALUE - 4;
 	tabIndexes[tabIndex] = this._conditionsTabGroup;
 
-	var el = Dwt.byId(this._actionsTableId);
-	var tabIndex = el.getAttribute("tabindex") || MAX_VALUE - 2;
+	el = Dwt.byId(this._actionsTableId);
+	tabIndex = MAX_VALUE - 3;
 	tabIndexes[tabIndex] = this._actionsTabGroup;
+
+	el = Dwt.byId(this._stopCheckboxId);
+	tabIndex = MAX_VALUE -2;
+	tabIndexes[tabIndex] = el;
 
 	// add dialog buttons
 	tabIndexes[MAX_VALUE - 1] = this.getButton(DwtDialog.OK_BUTTON);


### PR DESCRIPTION
**Problem:**
Focus doesn't move to next field in Create/Edit Filter dialog by pressing Tab key.

**Root cause:**
`el.getAttribute("tabindex")` always returned "0". Then tabIndexes array was not set as expected.

**Fix:**
Remove `el.getAttribute("tabindex")` and set tabIndex incrementally.
Change the tabIndex order of Name field, Active checkbox and Stop checkbox.