### PR TITLE
ZBUG-852: changed to set context menu for draft if a conversation has only a draft

### DIFF
--- a/WebRoot/js/zimbraMail/mail/controller/ZmMailListController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmMailListController.js
@@ -898,7 +898,7 @@ function(ev) {
 	var email = address && address.getAddress();
 
 	var item = (items && items.length == 1) ? items[0] : null;
-	if (this.isDraftsFolder() || (item && item.isDraft && item.type != ZmId.ITEM_CONV)) { //note that we never treat a conversation as a draft for actions. See also bug 64494
+	if (this.isDraftsFolder() || (item && item.isDraft && (item.type != ZmId.ITEM_CONV || item.numMsgs == 1))) { //note that we never treat a conversation as a draft for actions. See also bug 64494
 		// show drafts menu
 		this._initializeDraftsActionMenu();
         this._setDraftSearchMenu(address, item, ev);


### PR DESCRIPTION
**Problem:**
Unnecessary sashes are shown in context menu on a draft in Trash in conversation view mode.

**Root Cause**
Action menu buttons for draft was set when the current folder was Drafts or the type of a selected item is conversation. It didn't concider a conversation which had only a draft. Then Action menu buttons for a conversation was set on a draft, but some menu buttons were removed when the item was a draft. As a result, unnecessary sashes remained.

**Fix:**
Add a condition to check if a selected conversation consists of a draft.