### PR TITLE
ZBUG-853: fixed width of textarea in edit contact group page

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -1972,6 +1972,10 @@ INPUT[type="text"].search_input-expanded:focus {
 	width:100%;
 }
 
+.groupMembers.groupMembersInput {
+	width:98%;
+}
+
 /* ??? -> ZmFieldLabelRight */
 .ZmTaskEditView .editLabel {
 	@Label-right@

--- a/WebRoot/templates/abook/Contacts.template
+++ b/WebRoot/templates/abook/Contacts.template
@@ -818,7 +818,7 @@
 							</tr>
 							<tr>
 								<td>
-									<textarea class='groupMembers' id='${id}_addNewField'></textarea>
+									<textarea class='groupMembers groupMembersInput' id='${id}_addNewField'></textarea>
 								</td>
 							</tr>
 						</table>


### PR DESCRIPTION
**Problem:**
In edit contact group page, the right part of textarea "Or enter addresses below (comma separated)" is out of the window.

**Fixed:**
Add a classname to the textarea and set the style `width:98%;` .