### PR TITLE
NICPS-537: Add check for zimbraFileTypeCheckEnabled attribute

### DIFF
--- a/WebRoot/js/zimbraMail/share/ZmUploadManager.js
+++ b/WebRoot/js/zimbraMail/share/ZmUploadManager.js
@@ -307,7 +307,9 @@ ZmUploadManager.prototype.getErrorsAsync = function(file, maxSize, errors, exten
 		valid = false;
 		error.errorCodes.push( ZmUploadManager.ERROR_INVALID_FILENAME );
     }
-    if(valid && window.FileReader){
+    var isFileTypeCheckEnabled = appCtxt.getSettings().getInfoResponse.attrs._attrs.zimbraFileTypeCheckEnabled;
+
+    if(isFileTypeCheckEnabled && valid && window.FileReader){
         return this._checkFileType(file, extensions, function(isFileValid){
             if(!isFileValid){
                 valid = false;


### PR DESCRIPTION
NICPS-537: Add check for zimbraFileTypeCheckEnabled attribute

An attribute named zimbraFileTypeCheckEnabled is added. This boolean attribute is responsible for enabling/disabling of file content type check while uploading a file in the briefcase.