### PR TITLE
ZBUG-821 : Fix missing pdf attachment regression.

### DIFF
--- a/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
+++ b/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
@@ -2151,7 +2151,8 @@ function(findHits, includeInlineImages, includeInlineAtts) {
 
 			if (!this.isRealAttachment(attach) ||
 					(attach.contentType.match(/^image/) && attach.contentId && attach.foundInMsgBody && !includeInlineImages) ||
-					(attach.contentDisposition == "inline" && attach.fileName && ZmMimeTable.isRenderable(attach.contentType, !appCtxt.get(ZmSetting.VIEW_AS_HTML)) && !includeInlineAtts)) {
+					(attach.contentDisposition == "inline" && attach.fileName && ZmMimeTable.isRenderable(attach.contentType, true) && !includeInlineAtts) ||
+					(attach.contentDisposition == "inline" && attach.contentType === "application/pdf" && attach.contentId && attach.foundInMsgBody)) {
 				continue;
 			}
 


### PR DESCRIPTION
Removing code introduced in ZBUG-623 as this issue caused by
those changes.
Fixing ZBUG-821 and ZBUG-623 using a common fix.
We just ignore pdf attachments incase if those were added to
body part as inline attachment.