### PR TITLE
ZBUG-856: fixed to address All and None in Actions on Mobile HTML client

### DIFF
--- a/WebRoot/WEB-INF/tags/mobile/moJS-iPad.tag
+++ b/WebRoot/WEB-INF/tags/mobile/moJS-iPad.tag
@@ -368,7 +368,8 @@ var getFormValues = function(obj) {
     }
     for (i = 0, sel = obj.getElementsByTagName("SELECT"), len = sel.length; i < len; i++) {
         control = sel[i];//obj.getElementsByTagName("SELECT")[i];
-        getstr += control.name + "=" + control.options[control.selectedIndex].value + "&";
+        if (control.options[control.selectedIndex].value != "" && control.options[control.selectedIndex].value != "selectAll" && control.options[control.selectedIndex].value != "selectNone" && getstr.indexOf(control.name) == -1)
+            getstr += control.name + "=" + control.options[control.selectedIndex].value + "&";
     }
     for (i = 0; i < obj.getElementsByTagName("TEXTAREA").length; i++) {
         control = obj.getElementsByTagName("TEXTAREA")[i];

--- a/WebRoot/WEB-INF/tags/mobile/moJS.tag
+++ b/WebRoot/WEB-INF/tags/mobile/moJS.tag
@@ -464,7 +464,8 @@ var getFormValues = function(obj) {
     }
     for (i = 0, sel = obj.getElementsByTagName("SELECT"), len = sel.length; i < len; i++) {
         control = sel[i];//obj.getElementsByTagName("SELECT")[i];
-        getstr += control.name + "=" + control.options[control.selectedIndex].value + "&";
+        if (control.options[control.selectedIndex].value != "" && control.options[control.selectedIndex].value != "selectAll" && control.options[control.selectedIndex].value != "selectNone" && getstr.indexOf(control.name) == -1)
+            getstr += control.name + "=" + control.options[control.selectedIndex].value + "&";
     }
     for (i = 0; i < obj.getElementsByTagName("TEXTAREA").length; i++) {
         control = obj.getElementsByTagName("TEXTAREA")[i];


### PR DESCRIPTION
**Problem:**
When All in Actions is clicked, any action doesn't work on Mobile HTML client.

**Root cause:**
"anAction" parameter was passed two times in a request.
e.g.
anAction: selectAll
anAction: actionFlag

**Fix:**
Send one "anAction" in a request.
