### PR TITLE
ZBUG-859: fixed params for calendar in separate window

### DIFF
--- a/WebRoot/WEB-INF/tags/rest/restApptView.tag
+++ b/WebRoot/WEB-INF/tags/rest/restApptView.tag
@@ -57,7 +57,7 @@
                                 <table cellspacing=0 cellpadding=0 class='Tb'>
                                     <tr>
                                         <td nowrap>
-                                            <rest:calendarUrl var="closeurl" />
+                                            <rest:calendarUrl var="closeurl" action=""/>
                                             <a id="OPCLOSE" href="${closeurl}"> <app:img src="common/ImgClose.png"/> <span><fmt:message key="close"/></span></a>
                                         </td>
                                     </tr>

--- a/WebRoot/h/rest
+++ b/WebRoot/h/rest
@@ -6,7 +6,8 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ taglib prefix="fmt" uri="com.zimbra.i18n" %>
-<fmt:setLocale value='${pageContext.request.locale}' scope='request' />
+<c:set var="locale" value="${not empty requestScope.zimbra_target_account_prefLocale ? requestScope.zimbra_target_account_prefLocale : pageContext.request.locale}"/>
+<fmt:setLocale value='${locale}' scope='request' />
 <fmt:setBundle basename="/messages/ZhMsg" scope="request"/>
 
 <fmt:setTimeZone var="timezone" value="${zm:getTimeZone(not empty param.tz ? param.tz : requestScope.zimbra_target_account_prefTimeZoneId)}" scope="request"/>


### PR DESCRIPTION
**Problem 1:**
Language setting is ignored in calendar in separate window on web-split environment.

**Root cause:**
In WebRoot/h/rest, pageContext.request.locale was not sent from mailstore. Then English was always used.

**Fix:**
Use requestScope.zimbra_target_account_prefLocale if it exists.

---
**Problem 2:**
Button/Text links don't work on web-split environment. Most of the links are fixed on https://github.com/Zimbra/zm-mailbox/pull/847, but Close button in appointment view page still doesn't work.

**Root cause:**
action param didn't exist on `rest:calendarUrl` in restApptView.tag. Then incorrect action was added by restCalendarUrl.tag.
`https://websplit.dev.zimbra.com/home/test1@dev.zimbra.com/Calendar.html?view=month&tz=Asia%2FTokyo&date=20190207&action=view`

**Fix:**
Add an empty "action" param. Then the link on Close button doesn't have action view. 
`https://websplit.dev.zimbra.com/home/test1@dev.zimbra.com/Calendar.html?view=month&tz=Asia%2FTokyo&date=20190207`

**Related PR:** https://github.com/Zimbra/zm-mailbox/pull/847