### PR TITLE
ZBUG-860: fixed date range and altkey of Right arrow button in calendar in separate window

### DIFF
--- a/WebRoot/WEB-INF/tags/rest/restCalendarViewToolbar.tag
+++ b/WebRoot/WEB-INF/tags/rest/restCalendarViewToolbar.tag
@@ -75,7 +75,7 @@
                         ${fn:escapeXml(title)}
                     </td>
                     <td>
-                        <a <c:if test="${keys}">id="NEXT_PAGE"</c:if> href="${fn:escapeXml(nextUrl)}"><app:img alt="ALT_PAGE_NEXT" src="startup/ImgRightArrow.png" border="0"/></a>
+                        <a <c:if test="${keys}">id="NEXT_PAGE"</c:if> href="${fn:escapeXml(nextUrl)}"><app:img altkey="ALT_PAGE_NEXT" src="startup/ImgRightArrow.png" border="0"/></a>
                     </td>
                 </tr>
             </table>

--- a/WebRoot/WEB-INF/tags/rest/restMultiDayView.tag
+++ b/WebRoot/WEB-INF/tags/rest/restMultiDayView.tag
@@ -50,7 +50,14 @@
             <fmt:message var="singleDayFormat" key="CAL_DAY_TB_TITLE_FORMAT"/>
             <fmt:message var="pageTitle" key="CAL_MDAY_TITLE_FORMAT">
                 <fmt:param><fmt:formatDate value="${currentDay.time}" pattern="${singleDayFormat}"/></fmt:param>
-                <fmt:param><fmt:formatDate value="${zm:addDay(currentDay, numdays-1).time}" pattern="${singleDayFormat}"/></fmt:param>
+                <c:choose>
+                    <c:when test="${view eq 'workWeek'}">
+                        <fmt:param><fmt:formatDate value="${zm:addDay(currentDay, 4).time}" pattern="${singleDayFormat}"/></fmt:param>
+                    </c:when>
+                    <c:otherwise>
+                        <fmt:param><fmt:formatDate value="${zm:addDay(currentDay, numdays-1).time}" pattern="${singleDayFormat}"/></fmt:param>
+                    </c:otherwise>
+                </c:choose>
             </fmt:message>
             <c:set var="tbTitle" value="${pageTitle}"/>
         </c:otherwise>


### PR DESCRIPTION
Fixed wrong labels on separate window.
**Problem 1:**
End date shown at the top-right of the page is wrong in calendar WorkWeek view.

**Root cause:**
When WorkWeek view was selected, numdays was 7 (and workDays is Mon-Fri).

    restCalendar.tag
    <c:when test="${view eq 'workWeek'}">
        <rest:multiDayView mailbox="${mailbox}" timezone="${timezone}" date="${dateContext}" view='${view}' numdays="7"/>
    </c:when>

    restMultiDay.tag
    <c:when test="${view eq 'workWeek'}">
        <c:set var="wdays" value="1,2,3,4,5"/>
    </c:when>
    ...
    <c:set var="workDays" value="${zm:getWorkDays(wdays)}"/>

However, date range was calculated with numdays(=7).

    restMultiDayView.tag
    <fmt:message var="pageTitle" key="CAL_MDAY_TITLE_FORMAT">
    ...
        <fmt:param><fmt:formatDate value="${zm:addDay(currentDay, numdays-1).time}" pattern="${singleDayFormat}"/></fmt:param>
    </fmt:message>
    ...
    <rest:calendarViewToolbar timezone="${timezone}" today="${today}" date="${date}" prevDate="${prevDate}"
                              nextDate="${nextDate}" title="${tbTitle}" context="${context}" keys="true"/>

**Fix:**
Change to calculate date range with 5 days when WorkWeek view is selected.

---
**Problem:**
ALT_PAGE_NEXT is shown when a mouse cursor moves over Right arrow button.
(Comparison) "go to previous page" is shown on Left arrow button.

**Root cause:**
A param name was wrong. Then alt attribute was set incorrectly.

**Fix:**
Fix param name in restCalendarViewToolbar.tag.