### PR TITLE
ZBUG-861: fixed the expression of ics link

### DIFF
--- a/WebRoot/WEB-INF/tags/rest/restCalendarViewBottomToolbar.tag
+++ b/WebRoot/WEB-INF/tags/rest/restCalendarViewBottomToolbar.tag
@@ -30,7 +30,7 @@
     <tr>
         <td align="left" class="TbBt">
             <c:if test="${not empty requestScope.zimbra_target_item_name}">
-                <a href="/home/${zm:cook(${requestScope.zimbra_target_account_name})}${zm:cook(${requestScope.zimbra_target_item_path})}.ics">
+                <a href="/home/${zm:cook(requestScope.zimbra_target_account_name)}${zm:cook(requestScope.zimbra_target_item_path)}.ics">
                     <app:img src="startup/ImgCalendarApp.png" alt="ics"/><span style='padding-left:5px'>${zm:cook(requestScope.zimbra_target_item_name)}.ics</span></a>
             </c:if>
         </td>


### PR DESCRIPTION
**Problem:**
- ics link is not shown in calendar in separate window.
- javax.el.ELException is written in mailbox.log

**Root cause:**
Nested `$` caused the exception. Then the link was not created.
`${zm:cook(${requestScope.zimbra_target_account_name})}`

**Fixed:**
Remove nested `$`.