### PR TITLE
ZCS-6680 : When a single calendar is selected new events will be created in the calendar selected instead of the default calendar

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
@@ -1605,7 +1605,7 @@ function(startDate, duration, folderId, mailItem) {
 			newAppt.setFolderId(mailItem.getAccount().getDefaultCalendar().id);
 		}
 		// As per ZCS-223, we will always default to user defined default folder and not based on selections
-		/* else {
+		else {
 			// bug: 27646 case where only one calendar is checked
 			var checkedFolderIds = this.getCheckedCalendarFolderIds();
 			if (checkedFolderIds && checkedFolderIds.length == 1) {
@@ -1623,8 +1623,7 @@ function(startDate, duration, folderId, mailItem) {
 				// calendar app has no notion of "active" app, so always set to default calendar
 				this.defaultAccount = appCtxt.isFamilyMbox ? this.mainAccount : this.visibleAccounts[1];
 				newAppt.setFolderId(calId);
-			}
-		}*/
+		}
 	}
 	newAppt.setPrivacy((appCtxt.get(ZmSetting.CAL_APPT_VISIBILITY) == ZmSetting.CAL_VISIBILITY_PRIV)?"PRI" :"PUB");
 	return newAppt;


### PR DESCRIPTION
When selected a single calendar from the list of calendar from the list of calendar and creating a new event the add dialog selects the calendar that is selected .
If multiple calendar are selected and a new event is been created the add dialog chooses the default calendar.
If none of the calendar is been selected  and a new event is been created the add dialog chooses the default calendar.