### PR TITLE
ZCS-6897 : Fixing HAB in detached window.

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -1961,7 +1961,8 @@ function() {
 	ZmOrganizer.registerOrg(ZmOrganizer.HAB,
 							{
 								treeController:	"ZmHabTreeController",
-								labelKey:			"hab"
+								labelKey:			"hab",
+								childWindow:		true
 							});
 	
 	// Technically, we don't need to do this because the drop listeners for dragged organizers typically do their

--- a/WebRoot/js/zimbraMail/package/ContactsCore.js
+++ b/WebRoot/js/zimbraMail/package/ContactsCore.js
@@ -36,3 +36,4 @@ AjxPackage.require("zimbraMail.abook.model.ZmContact");
 AjxPackage.require("zimbraMail.abook.model.ZmContactList");
 AjxPackage.require("zimbraMail.abook.view.ZmContactsHelper");
 AjxPackage.require("zimbraMail.abook.view.ZmContactPicker");
+AjxPackage.require("zimbraMail.abook.controller.ZmHabTreeController");

--- a/WebRoot/js/zimbraMail/package/Startup1_2.js
+++ b/WebRoot/js/zimbraMail/package/Startup1_2.js
@@ -106,7 +106,6 @@ AjxPackage.require("zimbraMail.mail.ZmMailApp");
 AjxPackage.require("zimbraMail.calendar.ZmCalendarApp");
 AjxPackage.require("zimbraMail.tasks.ZmTasksApp");
 AjxPackage.require("zimbraMail.abook.ZmContactsApp");
-AjxPackage.require("zimbraMail.abook.controller.ZmHabTreeController");
 AjxPackage.require("zimbraMail.briefcase.ZmBriefcaseApp");
 AjxPackage.require("zimbraMail.voicemail.ZmVoiceApp");
 //AjxPackage.require("zimbraMail.chat.ZmChatApp");


### PR DESCRIPTION
HAB was missing in detached window because the hab-controller
related code is not there in Contacts-core package for detached
window.
Moved the controller file to Contacts-core package.
Additionally, Registered HAB tree is for child-window organiser.