### PR TITLE
Fixes dialog overflow outside browser window

### DIFF
--- a/WebRoot/js/zimbraMail/prefs/view/ZmFilterRuleDialog.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmFilterRuleDialog.js
@@ -363,12 +363,12 @@ function(data, test, isCondition, rowId) {
 				html[i++] = "<td><table>";
 				html[i++] = "<tr><td>" + ZmMsg.actionNotifyReadOnlyMsg + "</td></tr>";
 				html[i++] = "<tr><td>" + ZmMsg.emailLabel + " " + email + " | " + subject + " | " + ZmMsg.maxBodySize + ": " + maxBodySize + "</td><tr>";
-				html[i++] = "<tr><td>" + ZmMsg.body + ": " + content + "</td></tr></table></td>";
+				html[i++] = "<tr><td style='max-width:100px'>" + ZmMsg.body + ": " + content + "</td></tr></table></td>";
 			}
 			else if (actionId == ZmFilterRule.A_REPLY && data) {
 				var content = AjxUtil.isArray(data.content) ? data.content[0]._content : "";
 				html[i++] = "<td><table><tr><td>" + ZmMsg.actionReplyReadOnlyMsg + "</td></tr>";
-				html[i++] = "<tr><td>" + ZmMsg.body + ": " + content + "</td></tr></table></td>";
+				html[i++] = "<tr><td style='max-width:100px'>" + ZmMsg.body + ": " + content + "</td></tr></table></td>";
 			}
 			this.setButtonEnabled(DwtDialog.OK_BUTTON, false);
 		}


### PR DESCRIPTION
A little know feature in Zimbra is that one can set filters that automate email replies. But this can only be done in the CLI.

/opt/zimbra/bin/zmmailbox -z -m myaccount@example.com afrl "Filter_name" active any address "to,cc,from" all is "otheraccount@example.com" reply "Auto reply message" stop

The filter is now shown read-only to the user, however if a longer reply message is set, the filter dialog goes outside the browser window like so:

![without-patch](https://user-images.githubusercontent.com/4353213/56582821-731afa80-65d8-11e9-9060-4c30c4a533af.png)

This PR patches it to be like so:
![with-patch](https://user-images.githubusercontent.com/4353213/56582822-731afa80-65d8-11e9-9c81-c0a02688001a.png)

Also, without patch the UI can still be used by dragging around the filter dialog, which makes the dialog  resize correctly eventually. But most users would not expect that.
