### PR TITLE
Enforce functional sanitation of "skin" parameter

### DIFF
--- a/WebRoot/WEB-INF/tags/infra/skinAndRedirect.tag
+++ b/WebRoot/WEB-INF/tags/infra/skinAndRedirect.tag
@@ -15,6 +15,7 @@
  * ***** END LICENSE BLOCK *****
 --%>
 <%@ tag import="java.io.*" %>
+<%@ tag import="java.util.regex.Pattern" %>
 <%@ tag import="javax.servlet.*" %>
 <%@ tag import="javax.servlet.jsp.*" %>
 <%@ attribute name="mailbox" rtexprvalue="true" required="false" type="com.zimbra.cs.taglib.bean.ZMailboxBean" %>
@@ -27,6 +28,10 @@
 	<%
 		PageContext pageContext = (PageContext)jspContext;
 		String skin = (String)pageContext.findAttribute("skin");
+
+		if (!Pattern.matches("^[0-9A-Za-z]+$", skin)) {
+		    skin = application.getInitParameter("zimbraDefaultSkin");
+		}
 
 		if (uri == null) {
 			uri = request.getRequestURI();
@@ -41,23 +46,25 @@
 
 		// perform redirect
 		String path = pageContext.getServletContext().getRealPath(uri);
-		File file = new File(path);
-		if (file.exists()) {
-			/***
-			// NOTE: Setting an attribute and passing it into the
-			// NOTE: forwarded request doesn't work. The value is
-			// NOTE: not seen by the other JSP.
-	//		pageContext.setAttribute("originalRequest", request);
-			pageContext.forward(uri);
-			/***/
-			ServletContext servletContext = pageContext.getServletContext();
-			RequestDispatcher dispatcher = servletContext.getRequestDispatcher(uri);
+		if (path != null) {
+			File file = new File(path);
+			if (file.exists()) {
+				/***
+				// NOTE: Setting an attribute and passing it into the
+				// NOTE: forwarded request doesn't work. The value is
+				// NOTE: not seen by the other JSP.
+//				pageContext.setAttribute("originalRequest", request);
+				pageContext.forward(uri);
+				/***/
+				ServletContext servletContext = pageContext.getServletContext();
+				RequestDispatcher dispatcher = servletContext.getRequestDispatcher(uri);
 
-			ServletRequest servletRequest = pageContext.getRequest();
-			ServletResponse servletResponse = pageContext.getResponse();
-			servletRequest.setAttribute("originalRequestURI", request.getRequestURI());
-			dispatcher.forward(servletRequest, servletResponse);
-			/***/
+				ServletRequest servletRequest = pageContext.getRequest();
+				ServletResponse servletResponse = pageContext.getResponse();
+				servletRequest.setAttribute("originalRequestURI", request.getRequestURI());
+				dispatcher.forward(servletRequest, servletResponse);
+				/***/
+			}
 		}
 	%>
 </c:if>

--- a/WebRoot/public/Docs.jsp
+++ b/WebRoot/public/Docs.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 <%@ page import="java.util.Locale" %>
+<%@ page import="java.util.regex.Pattern" %>
 <%@ page import="com.zimbra.cs.taglib.bean.BeanUtils" %>
 <%
     // Prevent IE from ever going into compatibility/quirks mode.
@@ -68,7 +69,8 @@ If not, see <https://www.gnu.org/licenses/>.
     String skin = application.getInitParameter("zimbraDefaultSkin");
     Cookie[] cookies = request.getCookies();
     String requestSkin = request.getParameter("skin");
-    if (requestSkin != null) {
+    if (requestSkin == null ||
+        !Pattern.matches("^[0-9A-Za-z]+$", requestSkin)) {
         skin = requestSkin;
     } else if (cookies != null) {
         for (Cookie cookie : cookies) {

--- a/WebRoot/public/Resources.jsp
+++ b/WebRoot/public/Resources.jsp
@@ -1,4 +1,5 @@
 <%@ page session="false" %>
+<%@ page import="java.util.regex.Pattern" %>
 <%@ page import="com.zimbra.cs.taglib.bean.BeanUtils" %>
 <!--
 ***** BEGIN LICENSE BLOCK *****
@@ -56,10 +57,9 @@ If not, see <https://www.gnu.org/licenses/>.
     }
 
 	String skin = request.getParameter("skin");
-	if (skin == null) {
+	if (skin == null || !Pattern.matches("^[0-9A-Za-z]+$", skin)) {
 		skin = application.getInitParameter("zimbraDefaultSkin");
 	}
-	skin = skin.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll("\"", "&quot;");
 
 	String resources = (String)request.getAttribute("res");
 	if (resources == null) {

--- a/WebRoot/public/error.jsp
+++ b/WebRoot/public/error.jsp
@@ -17,6 +17,7 @@
 <%@ page buffer="8kb" autoFlush="true" %>
 <%@ page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
 <%@ page session="false" %>
+<%@ page import="java.util.regex.Pattern" %>
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
@@ -25,8 +26,17 @@
 <app:skinAndRedirect />
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <fmt:setLocale value='${pageContext.request.locale}' scope='request' />
+
+<%
+        String skin = request.getParameter("skin");
+        boolean skinOK = (skin != null &&
+                          Pattern.matches("^[0-9A-Za-z]+$", skin));
+%>
+
+<c:if test="${skinOK}">
 <fmt:setBundle basename="/messages/ZhMsg" scope="request"/>
 <fmt:setBundle basename="/messages/ZmMsg" var="zmmsg" scope="request"/>
+</c:if>
 
 <%
 	Object errorCode = request.getAttribute("javax.servlet.error.status_code");

--- a/WebRoot/public/proto/index.jsp
+++ b/WebRoot/public/proto/index.jsp
@@ -1,4 +1,5 @@
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
+<%@ page import="java.util.regex.Pattern" %>
 <!--
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Web Client
@@ -28,7 +29,8 @@
 	String controller = request.getParameter("controller");
 	String template = request.getParameter("template");
 	String skin = request.getParameter("skin");
-	if (skin == null) skin = application.getInitParameter("zimbraDefaultSkin");
+	if (skin == null || !Pattern.matches("^[0-9A-Za-z]+$", skin))
+		skin = application.getInitParameter("zimbraDefaultSkin");
 
     pageContext.setAttribute("template", template);
     pageContext.setAttribute("controller", controller);


### PR DESCRIPTION
Many attempts to exploit zimbra "skin" directory traversal bug (see https://www.exploit-db.com/exploits/30085 or its rewritten version https://github.com/nulsec/zimbra-0day/blob/master/zimbra.txt) produce the tremendous amount of exceptions in zmmailboxd.out.

This commit chain closes https://bugzilla.zimbra.com/show_bug.cgi?id=109156 by enforcing functional
sanitation of "skin" parameter. As "skin" parameter is one alphanumeric word. the proposed patches revert to Zimbra's "defaultSkin" option if supplied value is not the case.