### PR TITLE
Avoid TypeError in ZmComposeView.prototype.enableInputs

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
@@ -1439,9 +1439,9 @@ ZmComposeView.prototype.enableInputs =
 function(bEnable) {
     DBG.println('draft', 'ZmComposeView.enableInputs for ' + this._view + ': ' + bEnable);
     this._recipients.enableInputs(bEnable);
-    if (typeof(this._subjectField) !== 'undefined') {
+    try {
        this._subjectField.disabled = this._bodyField.disabled = !bEnable;
-    }
+    } catch (err){}
 };
 
 /**


### PR DESCRIPTION
Using typeof does not avoid the error. @silentsakky perhaps you can merge it.