### PR TITLE
ZBUG-1005 fix

### DIFF
--- a/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
+++ b/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
@@ -1367,17 +1367,8 @@ function(callback, toastMessage, result) {
 		this._origMsg.folderId = ZmFolder.ID_TRASH;
 	}
 
-	// allow or disallow move logic:
-	var allowMove;
-	if ((this.acceptFolderId != appCtxt.get(ZmSetting.CAL_DEFAULT_ID)) ||
-		(appCtxt.multiAccounts &&
-			!this.getAccount().isMain &&
-			this.acceptFolderId == appCtxt.get(ZmSetting.CAL_DEFAULT_ID)))
-	{
-		allowMove = true;
-	}
-
-	if (this.acceptFolderId && allowMove && resp.apptId != null) {
+	if (this.acceptFolderId && resp.apptId != null) {
+	
 		this.moveApptItem(resp.apptId, this.acceptFolderId);
 	}
 


### PR DESCRIPTION
Incoming appointment requests via mailview are not applied to the calendar that is listed as default instead the appointments are added to the primary Calendar. Since 8.8.11. See also: https://github.com/Zimbra/zm-web-client/commit/c170de15380e5bf820cfe6341d32e625664cd8c0#diff-8cd4bb295cdcc2bf53e92ae8ae98827dR1372

method: ZmMailMsg.prototype._handleResponseSendInviteReply

To understand what is happening, if Zimbra gets an Calendar invite in the mailbox, and the user clicks accept,
a SendInviteReplyRequest is fired to Zimbra, this takes care of the reply to the sender and a bunch of other things.

Then based on an if statement in _handleResponseSendInviteReply, the appointment is moved to the correct
calendar using an ItemActionRequest. So the Invite always goes to /Calendar first (which is poor behavior, but anyway)

I found that this if statement fails:

 // allow or disallow move logic:
 var allowMove;
 if ((this.acceptFolderId != appCtxt.get(ZmSetting.CAL_DEFAULT_ID)) ||
 (appCtxt.multiAccounts &&
 !this.getAccount().isMain &&
 this.acceptFolderId == appCtxt.get(ZmSetting.CAL_DEFAULT_ID)))
 {
 allowMove = true;
 }
 if (this.acceptFolderId && allowMove && resp.apptId != null) {
 this.moveApptItem(resp.apptId, this.acceptFolderId);
 }

My guess is that this.acceptFolderId should not have been the same as appCtxt.get(ZmSetting.CAL_DEFAULT_ID
but for some reason it sometimes is and then the bug happens. Digging through the code, I cannot see where this.acceptFolderId is initialized, it is probably an anonymous argument, that is either missing or in the wrong place. All the other stuff in the allowMove logic seems to be legacy code from family mailbox era. But I may be wrong there.

This commit removes the whole allowMove logic. And that seems to work well in our testing.