### PR TITLE
ZBUG-1037 : Fixing inline image issue with base64 encoding.

### DIFF
--- a/WebRoot/js/zimbraMail/mail/controller/ZmComposeController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmComposeController.js
@@ -2400,7 +2400,7 @@ function (imgArray, length, callback) {
         var img = imgArray[i];
         if (img) {
             var imgSrc = img.src;
-            if (imgSrc && imgSrc.indexOf("data:") !== -1) {
+            if (imgSrc && imgSrc.indexOf("data:") !== -1 && imgSrc.indexOf(";base64,") === -1) {
                 var blob = AjxUtil.dataURItoBlob(imgSrc);
                 if (blob) {
                     //setting data-zim-uri attribute for image replacement in callback
@@ -2524,7 +2524,7 @@ ZmComposeController.prototype._uploadImage = function(blob, callback, errorCallb
 
 ZmComposeController.prototype._handleUploadImage = function(callback, id, response){
     this._dataURIImagesLength--;
-    var uploadedImageArray = this._uploadedImageArray;
+    var uploadedImageArray = this._uploadedImageArray || [];
     if( response && id ){
         response[0]["id"] = id;
         uploadedImageArray.push(response[0]);


### PR DESCRIPTION
Tinymce itself replaces blob images into base64 content automatically, and
those base64 kind of inline images gets uploaded on server as normal attachments.
We just prevent such images to be uploaded on server at all as those are already
added as base64 into the content itself.