### PR TITLE
ZCS-7729: fixed rest url of shared folder in briefcase

### DIFF
--- a/WebRoot/js/zimbraMail/share/model/ZmOrganizer.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmOrganizer.js
@@ -839,11 +839,21 @@ function(noRemote) {
  */
 ZmOrganizer.prototype.getOwnerRestUrl =
 function(){
-  var restUrl=this.restUrl;
-  var path = AjxStringUtil.urlEncode(this.oname).replace("#","%23");
+	var node = this;
+	var restUrl;
+	var path = "";
 
-  // return REST URL as seen by the GetInfoResponse
-  return ([restUrl, "/", path].join(""));
+	while (node && !node.restUrl) {
+		path = node.name + "/" + path;
+		node = node.parent;
+	}
+	restUrl = node.restUrl;
+	path = node.oname + "/" + path;
+
+	path = AjxStringUtil.urlEncode(path).replace("#", "%23").replace(new RegExp("/$"), "");
+
+	// return REST URL as seen by the GetInfoResponse
+	return ([restUrl, "/", path].join(""));
 };
 
 ZmOrganizer.prototype._generateRestUrl =


### PR DESCRIPTION
**Problem:**
When user tries to download files in a sub folder of shared folder at a time, the page is reloaded unexpectedly. User needs to download files one by one.

**Root cause:**
Rest URL was set in a root folder of a shared folder, but it was not set in a sub folder. Then Ajax client accessed a wrong URL.
Request URL on a root folder: `https://SERVER/home/EMAIL/parent/parent?fmt=zip&list=ITEM_ID`
Request URL on a sub folder: `https://SERVER/?fmt=zip&list=ITEM_ID`

**Fix:**
Fixed `ZmOrganizer#getOwnerRestUrl` to find parent's `restURL` recursively and set a correct `path`.

**Affected area:**
`ZmOrganizer#getOwnerRestUrl` is called only when downloading files in a shared folder on Briefcase.