### PR TITLE
PREAPPS-3313 : Login page customizations and Handling 404 error on refresh in zimbrax

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -2763,7 +2763,10 @@ function(ev, relogin) {
 	}
 	if (appCtxt.isWebClientOfflineSupported && (ev || relogin)) {
 		return ZmOffline.handleLogOff(ev, relogin);
-    }
+	}
+	if (localStorage.hasOwnProperty('csrfToken') ==  true ){
+		localStorage.removeItem('csrfToken');
+	}
 
 	ZmZimbraMail._isLogOff = true;
 

--- a/WebRoot/messages/ZmMsg.properties
+++ b/WebRoot/messages/ZmMsg.properties
@@ -669,6 +669,7 @@ clientLoginNotice = <a target="_new" href="https://www.zimbra.com">Zimbra</a> ::
 clientMobile = Mobile
 clientPreferred = Default
 clientStandard = Standard (HTML)
+clientZimbrax = Zimbra X
 clientTouch = Touch
 clientType = Client Type:
 clientUnsupported = Note that your web browser or display does not fully support the Advanced version.  We strongly recommend that you use the Standard client.

--- a/WebRoot/public/error.jsp
+++ b/WebRoot/public/error.jsp
@@ -40,9 +40,15 @@
 
 <%
 	Object errorCode = request.getAttribute("javax.servlet.error.status_code");
+	pageContext.setAttribute("currentUri", request.getAttribute("javax.servlet.error.request_uri"));
 	String errorTitle = errorCode+"Title";
 	String errorMsg = errorCode+"Msg";
 %>
+
+
+<c:if test = "${fn:contains(currentUri, '/zimbrax')}">
+<jsp:forward page="/zimbrax/index.html"/>
+</c:if>
 
 <c:set var="errCode" value="<%=errorCode%>"/>
 <c:set var="errTitle" value="<%=errorTitle%>"/>

--- a/WebRoot/public/error.jsp
+++ b/WebRoot/public/error.jsp
@@ -40,15 +40,9 @@
 
 <%
 	Object errorCode = request.getAttribute("javax.servlet.error.status_code");
-	pageContext.setAttribute("currentUri", request.getAttribute("javax.servlet.error.request_uri"));
 	String errorTitle = errorCode+"Title";
 	String errorMsg = errorCode+"Msg";
 %>
-
-
-<c:if test = "${fn:contains(currentUri, '/zimbrax')}">
-<jsp:forward page="/zimbrax/index.html"/>
-</c:if>
 
 <c:set var="errCode" value="<%=errorCode%>"/>
 <c:set var="errTitle" value="<%=errorTitle%>"/>

--- a/WebRoot/public/launchZCS.jsp
+++ b/WebRoot/public/launchZCS.jsp
@@ -231,7 +231,8 @@
     window.isPerfMetric			= ${isPerfMetric};
 	window.authTokenExpires     = <%= authResult.getExpires()%>;
 	window.csrfToken            = "${csrfToken}";
-    window.appLang              = "${lang}";
+	window.appLang              = "${lang}";
+	localStorage.setItem("csrfToken" , "${csrfToken}");
 </script>
 <noscript>
 <meta http-equiv="Refresh" content="0;url=public/noscript.jsp" >

--- a/WebRoot/public/launchZCS.jsp
+++ b/WebRoot/public/launchZCS.jsp
@@ -232,7 +232,10 @@
 	window.authTokenExpires     = <%= authResult.getExpires()%>;
 	window.csrfToken            = "${csrfToken}";
 	window.appLang              = "${lang}";
-	localStorage.setItem("csrfToken" , "${csrfToken}");
+	if (localStorage.hasOwnProperty('csrfToken') ==  false ){
+		localStorage.setItem("csrfToken" , "${csrfToken}");
+	}
+	
 </script>
 <noscript>
 <meta http-equiv="Refresh" content="0;url=public/noscript.jsp" >

--- a/WebRoot/public/launchZCS.jsp
+++ b/WebRoot/public/launchZCS.jsp
@@ -232,10 +232,7 @@
 	window.authTokenExpires     = <%= authResult.getExpires()%>;
 	window.csrfToken            = "${csrfToken}";
 	window.appLang              = "${lang}";
-	if (localStorage.hasOwnProperty('csrfToken') ==  false ){
-		localStorage.setItem("csrfToken" , "${csrfToken}");
-	}
-	
+	localStorage.setItem("csrfToken" , "${csrfToken}");
 </script>
 <noscript>
 <meta http-equiv="Refresh" content="0;url=public/noscript.jsp" >

--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -285,6 +285,9 @@
                                     </c:forEach>
                                 </c:redirect>
                             </c:when>
+                            <c:when test="${client eq 'zimbrax'}">
+                                    <jsp:forward page="/public/zimbrax.jsp"/>
+                            </c:when>
                             <c:when test="${client eq 'touch'}">
                                 <c:redirect url="${param.dev eq '1' ? '/tdebug' : '/t'}">
                                     <c:forEach var="p" items="${paramValues}">
@@ -623,6 +626,7 @@ if (application.getInitParameter("offlineMode") != null) {
                                     <option value="advanced" <c:if test="${client eq 'advanced'}">selected</c:if>> <fmt:message key="clientAdvanced"/></option>
                                     <option value="standard" <c:if test="${client eq 'standard'}">selected</c:if>> <fmt:message key="clientStandard"/></option>
                                     <option value="mobile" <c:if test="${client eq 'mobile'}">selected</c:if>> <fmt:message key="clientMobile"/></option>
+                                    <option value="zimbrax" <c:if test="${client eq 'zimbrax'}">selected</c:if>> <fmt:message key="clientZimbrax"/></option>
                                     <c:if test="${touchLoginPageExists}">
                                         <option value="touch" <c:if test="${client eq 'touch'}">selected</c:if>> <fmt:message key="clientTouch"/></option>
                                     </c:if>

--- a/WebRoot/public/zimbrax.jsp
+++ b/WebRoot/public/zimbrax.jsp
@@ -9,7 +9,7 @@
 <script TYPE="text/javascript">
     localStorage.setItem("csrfToken" , "${csrfToken}");
 	//TODO : we need to remove index.html when jetty configs are in place
-    var url = window.location.origin + "/zimbrax/index.html"
+    var url = window.location.origin + "/zimbrax/"
     window.location.href = url;
 </script>
 

--- a/WebRoot/public/zimbrax.jsp
+++ b/WebRoot/public/zimbrax.jsp
@@ -1,0 +1,14 @@
+<%@ page buffer="8kb" autoFlush="true" %>
+<%@ page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
+<%@ page import="java.util.*,javax.naming.*,com.zimbra.client.ZAuthResult" %>
+<%
+	
+    ZAuthResult authResult = (ZAuthResult) request.getAttribute("authResult");
+    pageContext.setAttribute("csrfToken", authResult.getCsrfToken());
+%>
+<script TYPE="text/javascript">
+    localStorage.setItem("csrfToken" , "${csrfToken}");
+    var url = window.location.origin + "/zimbrax/index.html"
+    window.location.href = url;
+</script>
+

--- a/WebRoot/public/zimbrax.jsp
+++ b/WebRoot/public/zimbrax.jsp
@@ -8,6 +8,7 @@
 %>
 <script TYPE="text/javascript">
     localStorage.setItem("csrfToken" , "${csrfToken}");
+	//TODO : we need to remove index.html when jetty configs are in place
     var url = window.location.origin + "/zimbrax/index.html"
     window.location.href = url;
 </script>


### PR DESCRIPTION
- Verify that "Zimbra X" option is available in drop-down for login page.
- Select "Zimbra X" on login page from drop-down and enter your credentials.
- After login user should get redirected to "Zimbra X" UI instead of legacy.
- On logout user should get redirected to zimbra legacy login page.