### PR TITLE
ZBUG-1100: Contact Group name is not updated in the contact list after renamed or deleted

### DIFF
--- a/WebRoot/js/zimbraMail/abook/controller/ZmContactController.js
+++ b/WebRoot/js/zimbraMail/abook/controller/ZmContactController.js
@@ -283,6 +283,8 @@ function() {
 ZmContactController.prototype._setViewContents =
 function() {
 	var cv = this._contactView;
+	// We need to extract current i.e editing contact list and keep in this object while setting edit view, Because contact list of editing contact group can get changed from cache while changing contact lists in edit view.
+	this.editingContactList = this._contact.list;
 	cv.set(this._contact, this._contactDirty);
 	if (this._contactDirty) {
 		delete this._contactDirty;
@@ -360,6 +362,9 @@ ZmContactController.prototype._saveListener = function(ev, bIsPopCallback) {
 	view.enableInputs(false);
 
 	var contact = view.getContact();
+	if(this.editingContactList) {
+		contact.list = this.editingContactList;
+	}
 	if (mods && AjxUtil.arraySize(mods) > 0) {
 
 		// bug fix #22041 - when moving betw. shared/local folders, dont modify

--- a/WebRoot/js/zimbraMail/abook/model/ZmContact.js
+++ b/WebRoot/js/zimbraMail/abook/model/ZmContact.js
@@ -427,7 +427,7 @@ function(node, args) {
 		}
 		AjxUtil.hashUpdate(contact.attr, node._attrs);	// merge new attrs just in case we don't have them
 		contact.list = args.list || new ZmContactList(null);
-		contact._list = {};
+		contact._list = contact._list || {}; // We need to add new contact list in contact._list array which contains lists in which contact is present.
 		contact._list[contact.list.id] = true;
 	}
 	//S/MIME: If user certificate is present, include it into contact's object


### PR DESCRIPTION
Fixed issue i.e Contact Group name is not updated in the contact list after renamed or deleted.