### PR TITLE
ZCS-8441 : Upgrading yui version to 2.9.0 and Jquery to 3.4.1

### DIFF
--- a/WebRoot/WEB-INF/tags/autoComplete.tag
+++ b/WebRoot/WEB-INF/tags/autoComplete.tag
@@ -23,11 +23,11 @@
 
 <c:set var="yahooDomEvent" value="true" scope="request"/>
 
-<script type="text/javascript" src="<c:url value='/yui/2.7.0/yahoo-dom-event/yahoo-dom-event.js'/>"></script>
-<script type="text/javascript" src="<c:url value='/yui/2.7.0/connection/connection-min.js'/>"></script>
-<script type="text/javascript" src="<c:url value='/yui/2.7.0/datasource/datasource-min.js'/>"></script>
-<script type="text/javascript" src="<c:url value='/yui/2.7.0/json/json-min.js'/>"></script>
-<script type="text/javascript" src="<c:url value='/yui/2.7.0/autocomplete/autocomplete-debug.js'/>"></script>
+<script type="text/javascript" src="<c:url value='/yui/2.9.0-alfresco-20141223/yahoo-dom-event/yahoo-dom-event.js'/>"></script>
+<script type="text/javascript" src="<c:url value='/yui/2.9.0-alfresco-20141223/connection/connection-min.js'/>"></script>
+<script type="text/javascript" src="<c:url value='/yui/2.9.0-alfresco-20141223/datasource/datasource-min.js'/>"></script>
+<script type="text/javascript" src="<c:url value='/yui/2.9.0-alfresco-20141223/json/json-min.js'/>"></script>
+<script type="text/javascript" src="<c:url value='/yui/2.9.0-alfresco-20141223/autocomplete/autocomplete-debug.js'/>"></script>
 
 <script type="text/javascript">
     <!--

--- a/WebRoot/WEB-INF/tags/compose/yuiInclude.tag
+++ b/WebRoot/WEB-INF/tags/compose/yuiInclude.tag
@@ -22,7 +22,7 @@
 <%@ taglib prefix="app" uri="com.zimbra.htmlclient" %>
 
  
-<link rel="stylesheet" type="text/css" href="../yui/2.7.0/assets/skins/sam/skin.css" />
+<link rel="stylesheet" type="text/css" href="../yui/2.9.0-alfresco-20141223/assets/skins/sam/skin.css" />
 <style type="text/css" media="screen">
     .yui-skin-sam .yui-toolbar-container .yui-toolbar-spellcheck span.yui-toolbar-icon {
         background-image: url( ../yui/spellcheck/img/ImgSpellCheck.gif );
@@ -44,13 +44,13 @@
     }
 </style>
 
-<script type="text/javascript" src="../yui/2.7.0/yahoo-dom-event/yahoo-dom-event.js"></script>
-<script type="text/javascript" src="../yui/2.7.0/animation/animation-min.js"></script>
-<script type="text/javascript" src="../yui/2.7.0/element/element-min.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/yahoo-dom-event/yahoo-dom-event.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/animation/animation-min.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/element/element-min.js"></script>
 <!-- Needed for Menus, Buttons and Overlays used in the Toolbar -->
-<script type="text/javascript" src="../yui/2.7.0/container/container_core-min.js"></script>
-<script type="text/javascript" src="../yui/2.7.0/menu/menu-min.js"></script>
-<script type="text/javascript" src="../yui/2.7.0/button/button-min.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/container/container_core-min.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/menu/menu-min.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/button/button-min.js"></script>
 <!-- Source file for Rich Text Editor-->
-<script type="text/javascript" src="../yui/2.7.0/editor/editor-min.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/editor/editor-min.js"></script>
 <app:spellcheck/>

--- a/WebRoot/WEB-INF/tags/conv/convColumnView.tag
+++ b/WebRoot/WEB-INF/tags/conv/convColumnView.tag
@@ -23,11 +23,11 @@
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 
 <!-- Dependencies -->
-<script type="text/javascript" src="../yui/2.7.0/yahoo-dom-event/yahoo-dom-event.js"></script>
-<script type="text/javascript" src="../yui/2.7.0/animation/animation-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/yahoo-dom-event/yahoo-dom-event.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/animation/animation-debug.js"></script>
 
 <!-- Drag and Drop source file -->
-<script type="text/javascript" src="../yui/2.7.0/dragdrop/dragdrop-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/dragdrop/dragdrop-debug.js"></script>
 
 <app:handleError>
 	<zm:getMailbox var="mailbox"/>

--- a/WebRoot/WEB-INF/tags/conv/convListView.tag
+++ b/WebRoot/WEB-INF/tags/conv/convListView.tag
@@ -23,11 +23,11 @@
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 
 <!-- Dependencies -->
-<script type="text/javascript" src="../yui/2.7.0/yahoo-dom-event/yahoo-dom-event.js"></script>
-<script type="text/javascript" src="../yui/2.7.0/animation/animation-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/yahoo-dom-event/yahoo-dom-event.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/animation/animation-debug.js"></script>
 
 <!-- Drag and Drop source file -->
-<script type="text/javascript" src="../yui/2.7.0/dragdrop/dragdrop-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/dragdrop/dragdrop-debug.js"></script>
 
 <app:handleError>
     <zm:getMailbox var="mailbox"/>

--- a/WebRoot/WEB-INF/tags/conv/convRowView.tag
+++ b/WebRoot/WEB-INF/tags/conv/convRowView.tag
@@ -23,11 +23,11 @@
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 
 <!-- Dependencies -->
-<script type="text/javascript" src="../yui/2.7.0/yahoo-dom-event/yahoo-dom-event.js"></script>
-<script type="text/javascript" src="../yui/2.7.0/animation/animation-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/yahoo-dom-event/yahoo-dom-event.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/animation/animation-debug.js"></script>
 
 <!-- Drag and Drop source file -->
-<script type="text/javascript" src="../yui/2.7.0/dragdrop/dragdrop-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/dragdrop/dragdrop-debug.js"></script>
 
 <app:handleError>
 	<zm:getMailbox var="mailbox"/>

--- a/WebRoot/WEB-INF/tags/head.tag
+++ b/WebRoot/WEB-INF/tags/head.tag
@@ -87,7 +87,7 @@
         }
 
     </script>
-	<script type="text/javascript" src="../yui/2.7.0/yahoo-dom-event/yahoo-dom-event.js"></script>
+	<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/yahoo-dom-event/yahoo-dom-event.js"></script>
     <c:if test="${param.selected eq 'signatures'}">
         <app:yuiInclude/>
     </c:if>

--- a/WebRoot/WEB-INF/tags/keyboard.tag
+++ b/WebRoot/WEB-INF/tags/keyboard.tag
@@ -153,7 +153,7 @@
 
 <c:if test="${not requestScope.yahooDomEvent}">
     <script type="text/javascript"
-            src="<c:url value='/yui/2.7.0/yahoo-dom-event/yahoo-dom-event.js'/>"></script>
+            src="<c:url value='/yui/2.9.0-alfresco-20141223/yahoo-dom-event/yahoo-dom-event.js'/>"></script>
 </c:if>
 
 ${sessionScope.keyboardCache[cache]}

--- a/WebRoot/WEB-INF/tags/message/messageColumnView.tag
+++ b/WebRoot/WEB-INF/tags/message/messageColumnView.tag
@@ -23,11 +23,11 @@
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 
 <!-- Dependencies -->
-<script type="text/javascript" src="../yui/2.7.0/yahoo-dom-event/yahoo-dom-event.js"></script>
-<script type="text/javascript" src="../yui/2.7.0/animation/animation-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/yahoo-dom-event/yahoo-dom-event.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/animation/animation-debug.js"></script>
 
 <!-- Drag and Drop source file -->
-<script type="text/javascript" src="../yui/2.7.0/dragdrop/dragdrop-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/dragdrop/dragdrop-debug.js"></script>
 
 <app:handleError>
 	<zm:getMailbox var="mailbox"/>

--- a/WebRoot/WEB-INF/tags/message/messageListView.tag
+++ b/WebRoot/WEB-INF/tags/message/messageListView.tag
@@ -23,11 +23,11 @@
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 
 <!-- Dependencies -->
-<script type="text/javascript" src="../yui/2.7.0/yahoo-dom-event/yahoo-dom-event.js"></script>
-<script type="text/javascript" src="../yui/2.7.0/animation/animation-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/yahoo-dom-event/yahoo-dom-event.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/animation/animation-debug.js"></script>
 
 <!-- Drag and Drop source file -->
-<script type="text/javascript" src="../yui/2.7.0/dragdrop/dragdrop-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/dragdrop/dragdrop-debug.js"></script>
 
 <app:handleError>
 	<zm:getMailbox var="mailbox"/>

--- a/WebRoot/WEB-INF/tags/message/messageRowView.tag
+++ b/WebRoot/WEB-INF/tags/message/messageRowView.tag
@@ -23,11 +23,11 @@
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 
 <!-- Dependencies -->
-<script type="text/javascript" src="../yui/2.7.0/yahoo-dom-event/yahoo-dom-event.js"></script>
-<script type="text/javascript" src="../yui/2.7.0/animation/animation-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/yahoo-dom-event/yahoo-dom-event.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/animation/animation-debug.js"></script>
 
 <!-- Drag and Drop source file -->
-<script type="text/javascript" src="../yui/2.7.0/dragdrop/dragdrop-debug.js"></script>
+<script type="text/javascript" src="../yui/2.9.0-alfresco-20141223/dragdrop/dragdrop-debug.js"></script>
 
 <app:handleError>
 	<zm:getMailbox var="mailbox"/>

--- a/WebRoot/WEB-INF/tags/rest/restSpreadsheetView.tag
+++ b/WebRoot/WEB-INF/tags/rest/restSpreadsheetView.tag
@@ -121,7 +121,7 @@
     </c:if>
 
     <!-- YUI Library for Charts -->
-    <c:set var="yuiPath" value="${pageContext.request.contextPath}/yui/2.7.0" />
+    <c:set var="yuiPath" value="${pageContext.request.contextPath}/yui/2.9.0-alfresco-20141223" />
     <link rel="stylesheet" type="text/css" href="${yuiPath}/assets/skins/sam/skin.css" />
     <!-- Dependencies -->
 	<script type="text/javascript" src="${yuiPath}/yahoo-dom-event/yahoo-dom-event.js"></script>

--- a/build.xml
+++ b/build.xml
@@ -87,7 +87,7 @@
 
     <property name="modernizr.version" value="2.8.3"/>
     <property name="yui.version" value="2.9.0-alfresco-20141223"/>
-    <property name="jquery.version" value="3.3.1-1"/>
+    <property name="jquery.version" value="3.4.1"/>
 
     <!-- TINY_MCE INTEGRATION -->
     <property name="tinymce.version" value="4.7.9"/>

--- a/build.xml
+++ b/build.xml
@@ -86,7 +86,7 @@
     <property name="3rdparty.dir" value="${build.js.dir}/ajax/3rdparty" />
 
     <property name="modernizr.version" value="2.8.3"/>
-    <property name="yui.version" value="2.7.0"/>
+    <property name="yui.version" value="2.9.0-alfresco-20141223"/>
     <property name="jquery.version" value="3.3.1-1"/>
 
     <!-- TINY_MCE INTEGRATION -->
@@ -137,7 +137,7 @@
     <target name='client' depends='common'>
         <property name='deploy.app' value='zimbra'/>
         <property name='skins.dir' value='${web.dir}/skins'/>
-        <property name='web.includes' value='${common.web.includes},h/**,m/**,portals/**,sounds/**,test/**,yui/2.7.0/**,qunit/**'/>
+        <property name='web.includes' value='${common.web.includes},h/**,m/**,portals/**,sounds/**,test/**,yui/2.9.0-alfresco-20141223/**,qunit/**'/>
         <property name='web.excludes' value='${common.web.excludes}'/>
         <property name='jsp.includes' value='${common.jsp.includes}'/>
         <property name='jsp.excludes' value='${common.jsp.excludes},admin.jsp'/>


### PR DESCRIPTION
ZCS-8441 : upgrading yui version from 2.7.0 to 2.9.0-alfresco-20141223 to avoid vulnerabilities where it has been downloaded from
https://mvnrepository.com/artifact/com.yahoo.platform.yui/yui/2.9.0-alfresco-20141223 where this is the latest amongst 2.9.0.
default 2.9.0 doesnot has any zip


- Upgrading jquery version to 3.4.1