### PR TITLE
ZBUG-1656:- Email content for webex invite is shown with unexpected blank zones.

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/ZmMailMsgView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailMsgView.js
@@ -1128,7 +1128,11 @@ function(params) {
 		// assign the right class name to the iframe body
 		idoc.body.className = this._getBodyClass() + (params.isTextMsg ? " MsgBody-text" : " MsgBody-html");
 
+		var docOffsetWidth = idoc.body.offsetWidth;
+
 		idoc.body.style.height = "auto"; //see bug 56899 - if the body has height such as 100% or 94%, it causes a problem in FF in calcualting the iframe height. Make sure the height is clear.
+		idoc.body.style.width = (docOffsetWidth - 20) + "px";
+		idoc.body.style.position = "absolute";
 
 		ifw.getIframe().onload = this._onloadIframe.bind(this, ifw);
 


### PR DESCRIPTION
Added style properties to iframe doc to fix scrollbar height issue.