### PR TITLE
ZBUG-1551:- Web client allow editing raw HTML in email causing blank emails in Outlook

### DIFF
--- a/WebRoot/js/zimbraMail/share/view/htmlEditor/ZmHtmlEditor.js
+++ b/WebRoot/js/zimbraMail/share/view/htmlEditor/ZmHtmlEditor.js
@@ -375,7 +375,21 @@ ZmHtmlEditor.prototype._setContentStyles = function(ed) {
 		parentNode = styles[i].parentNode;
 		if (parentNode.tagName.toLowerCase() != 'body') {
 			parentNode.removeChild(styles[i]);
-			body.insertBefore(styles[i], body.childNodes[0]);
+
+			// while replying we were adding the incoming css styles to the first element present 
+			// in the body which was <br/> tag which causes issue after performing multiple backspace
+			// now we are searching for the data-marker of replying message i.e  '__QUOTED_TEXT__'
+			// and inserting css div style before the '__QUOTED_TEXT__' data marker.
+			for(var j=0; j < body.childElementCount; j++){
+				if(body.children[j].hasAttribute('data-marker')) {
+					const dataMarker = body.children[j].getAttribute('data-marker');
+
+					if(dataMarker === '__' + ZmComposeView.BC_QUOTED_TEXT + '__'){
+						body.insertBefore(styles[i], body.childNodes[j]);
+						return
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Before**:- while replying we were adding the incoming css styles to the first element present 
in the body which was <br/> tag which causes issue after performing multiple backspace

**Now**:-  we are searching for the data-marker of replying message i.e  '__QUOTED_TEXT__'
and inserting css div style before the '__QUOTED_TEXT__' data marker.