### PR TITLE
ZCS-9595:- Status of expanded/collapsed of a folder is not saved when zimbraFeatureOptionsEnabled is FALSE

### DIFF
--- a/WebRoot/js/zimbraMail/share/model/ZmMetaData.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmMetaData.js
@@ -105,8 +105,13 @@ function(section, data, batchCommand, callback, errorCallback, sensitive) {
 		if (AjxUtil.isObject(d)) {
 			d = ZmSetting.serialize(d, ZmSetting.D_HASH);
 		}
-		var a = soapDoc.set("a", d, metaNode);
-		a.setAttribute("n", i);
+
+		// If we want to remove any data from SetMailboxMetadataRequest then don't send it as part of request,
+		// server will automatically remove it
+		if (d !== null && d !== "") {
+			var a = soapDoc.set("a", d, metaNode);
+			a.setAttribute("n", i);
+		}
 	}
 
 	if (batchCommand) {

--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -1203,11 +1203,14 @@ ZmSettings.prototype._showConfirmDialog = function(text, callback, style) {
 
 ZmSettings.prototype._implicitChangeListener =
 function(ev) {
-	if (!appCtxt.get(ZmSetting.OPTIONS_ENABLED)) {
+	var id = ev.source.id;
+	var sourceType = ev.source.type;
+
+	// Allow to perform implicit settings save (e.g folder expand) if the source type is META even when zimbraFeatureOptionsEnabled is false.
+	if (!appCtxt.get(ZmSetting.OPTIONS_ENABLED) && ZmSetting.T_METADATA !== sourceType) {
 		return;
 	}
 	if (ev.type != ZmEvent.S_SETTING) { return; }
-	var id = ev.source.id;
 	var setting = this.getSetting(id);
 	if (id == ZmSetting.FOLDERS_EXPANDED && window.duringExpandAll) {
 		if (!window.afterExpandAllCallback) {


### PR DESCRIPTION
Removed OPTIONS_ENABLED check when use is doing implicit settings.