### PR TITLE
ZBUG-1220: Workaround for Zimbra Skin Broken

### DIFF
--- a/WebRoot/messages/ZmMsg_en_US.properties
+++ b/WebRoot/messages/ZmMsg_en_US.properties
@@ -1,0 +1,16 @@
+# 
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Web Client
+# Copyright (C) 2020 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+# 


### PR DESCRIPTION
**Problem:**
Zimbra Skin Broken.

**Workaround:**
Created an empty `ZmMsg_en_US.properties` file which will be used for overriding the keys from `ZmMsg.properties` file.
`ZmMsg.properties` is getting overriden with the use of this method when we place this file in the message directory of the skin. So, the workaround as of now is that it is expecting a ZmMsg_en_US.properties file in the message directory of the skin from where it reads the overriden keys and the default value is read from the original `ZmMsg.properties` file.