### PR TITLE
ZCS-10004: Ability to set shared (write-able) calendar as a default calendar

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/ZmCalendarApp.js
+++ b/WebRoot/js/zimbraMail/calendar/ZmCalendarApp.js
@@ -1555,15 +1555,13 @@ function() {
 			continue;
 		}
 
-		var id = cal.link ? cal.getRemoteId() : cal.id;
-
 		var image = appCtxt.multiAccounts ? acct.getIcon() : cal.getIconWithColor();
 		var name = AjxStringUtil.htmlDecode(appCtxt.multiAccounts
 			? ([cal.getName(), " (", acct.getDisplayName(), ")"].join(""))
 			: cal.getName());
 
 		displayOptions.push(name);
-		options.push(id);
+		options.push(cal.id);
 		images.push(image);
 	}
 


### PR DESCRIPTION
**Issue:** Error while setting a shared calendar as a default calendar

**Reason:** Shared id was being sent, whereas the API expected the default id (integer value).

**Fix:** Default id is now sent for all calendars.