### PR TITLE
PREAPPS-5930 : Log into Classic UI in case of IE11.

### DIFF
--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -82,7 +82,9 @@
     }
 %>
 <c:set var="modernSupported" value="<%=modernSupported%>" />
-
+<c:if test="${ua.isModernIE}">
+	<c:set var="modernSupported" value="false" />
+</c:if>
 <c:catch var="loginException">
 	<c:choose>
 		<c:when test="${(not empty param.loginNewPassword or not empty param.loginConfirmNewPassword) and (param.loginNewPassword ne param.loginConfirmNewPassword)}">


### PR DESCRIPTION
When IE-11 browser is detected, user should be logged into Classic UI.
On login page, do not show Modern UI in dropdown. It will be Classic and Default.