### PR TITLE
Fix German "to" field

### DIFF
--- a/WebRoot/messages/ZtMsg_de.properties
+++ b/WebRoot/messages/ZtMsg_de.properties
@@ -175,7 +175,7 @@ addContact = Zu Kontakten hinzuf\u00fcgen
 # Message header
 from = von
 obo = im Namen von
-to = bis
+to = an
 showDetails = Details
 hideDetails = Details ausblenden
 


### PR DESCRIPTION
The old "bis" means until as in "nine to five". The new "an" implies a recipient as in "message to somebody".