### PR TITLE
ZBUG-2015 : Fix issue while delete multiple shared account from settings.

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
@@ -3169,8 +3169,10 @@ function(account, resp) {
 };
 
 ZmAccountsPage.prototype._doDeleteCallback = function(organizer) {
+	// Filter the accounts and skip persona if there is any in this particular delete operation
+	var onlyAccounts = AjxUtil.filter(this._deletedAccounts, function(a) { if(a.type !== ZmAccount.TYPE_PERSONA) {return a} });
 	this._deleteResponseReceived.push(organizer);
-	if (this._deletedAccounts.length === this._deleteResponseReceived.length) {
+	if (onlyAccounts.length === this._deleteResponseReceived.length) {
 		this._promptToDeleteFolder(this._deleteResponseReceived);
 	}
 };


### PR DESCRIPTION
We prompt user to remove deleted shared account from folder tree for
each data source. But only the last reponsed folder were getting moved to trash.
The reason was overlappint prompt dialog.
Fix this by handle all of the deleted data sources in one prompt dialog.
Now all the deleted datasources included in one prompt dialog and getting moved to trash.