### PR TITLE
ZBUG-2282: Reverting ZCS-7512 changes to fix.

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/ZmMailMsgView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailMsgView.js
@@ -987,18 +987,6 @@ function(params) {
 
 	var html = params.html || "";
 	
-	if (html.search(/(<form)(?![^>]+action)(.*?>)/g)) {
-		html = html.replace(/(<form)(?![^>]+action)(.*?>)/ig, function(form) {
-				if (form.match(/target/g)) {
-					form = form.replace(/(<.*)(target=.*)(.*>)/g, '$1action="SAMEHOSTFORMPOST-BLOCKED" target="_blank"$3');
-				}
-				else {
-					form = form.replace(/(<form)(?![^>]+action)(.*?>)/g, '$1 action="SAMEHOSTFORMPOST-BLOCKED" target="_blank"$2');
-				}
-		return form;
-		});
-	}
-
 	if (!params.isTextMsg) {
 		//Microsoft silly smilies
 		html = html.replace(/<span style="font-family:Wingdings">J<\/span>/g, "\u263a"); // :)


### PR DESCRIPTION
Problem:- Classic Web Client: Stored XSS Vulnerability in ZmMailMsgView.js

Cause:- This issue is caused by ZCS-7512. https://github.com/Zimbra/zm-web-client/pull/508/files

When we remove ZCS-7512 code the above issue gets automatically fixed.

The root cause of ZCS-7512 is backend is sending wrong `<form />` tag html when OWASP enabled 
