### PR TITLE
ZCS-10732 : Do not merge..!!

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
@@ -4190,8 +4190,8 @@ function() {
 		if (needsRefresh) {
             var rt = view.getTimeRange();
 			var params = {
-				start: rt.start,
-				end: rt.end,
+				start: rt.start - (31 * 24 * 60 * 60 * 1000), // Previous month
+				end: rt.end + (31 * 24 * 60 * 60 * 1000) + (31 * 24 * 60 * 60 * 1000), // to next two months
 				fanoutAllDay: view._fanoutAllDay(),
 				callback: (new AjxCallback(this, this._maintGetApptCallback, [work, view])),
 				accountFolderIds: ([].concat(this._checkedAccountCalendarIds)), // pass in a copy, not a reference


### PR DESCRIPTION
Increased time-frame to four months while fetching data for calendar month-view.
This time-frame is being used in ModernUI.
This change will fix this issue only if zimbraCalendarRecurrenceMonthlyMaxMonths is configured with 3.