### PR TITLE
ZCS-10908: fixed script errors raised when Contacts is disabled

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
@@ -1070,7 +1070,9 @@ function(calItem, mode) {
         //enable forward field/picker if its not propose time view
         this._setAddresses(this._forwardToField, this._isProposeTime ? calItem.getOrganizer() : "");
         this._forwardToField.setEnabled(!this._isProposeTime);
-        this._forwardPicker.setEnabled(!this._isProposeTime);
+        if (this._forwardPicker) {
+            this._forwardPicker.setEnabled(!this._isProposeTime);
+        }
 
         for (var t = 0; t < this._attTypes.length; t++) {
 		    var type = this._attTypes[t];
@@ -1698,6 +1700,9 @@ function(ev) {
     this._forwardToField.setEnabled(false);
 	if (!this._contactPicker) {
 		AjxDispatcher.require("ContactsCore");
+		if (!appCtxt.getApp(ZmApp.CONTACTS)) {
+			appCtxt.getAppController()._createApp(ZmApp.CONTACTS);
+		}
 		var buttonInfo = [
 			{ id: AjxEmailAddress.TO,	label: ZmMsg.toLabel }
 		];
@@ -1722,6 +1727,9 @@ function(addrType, ev) {
     var contactPicker = this._attendeePicker[addrType];
 	if (!contactPicker) {
 		AjxDispatcher.require("ContactsCore");
+		if (!appCtxt.getApp(ZmApp.CONTACTS)) {
+			appCtxt.getAppController()._createApp(ZmApp.CONTACTS);
+		}
 		var buttonInfo = [
 			{ id: AjxEmailAddress.TO,	label: ZmMsg.toLabel }
 		];

--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
@@ -1404,6 +1404,8 @@ function(idTag, attType, params) {
 	var inputId = this.parent._htmlElId + idTag + "_input";
 	var cellId = this._htmlElId + idTag;
 	var input;
+	var contactsEnabled = appCtxt.get(ZmSetting.CONTACTS_ENABLED);
+
 	if (!params.noAddrBubbles) {
 		var aifParams = {
 			label:					params.label,
@@ -1415,6 +1417,9 @@ function(idTag, attType, params) {
 			strictMode:				params.strictMode
 		}
 		var input = this._attInputField[attType] = new ZmAddressInputField(aifParams);
+		if (!contactsEnabled && input._input) {
+			input._input.supportsAutoComplete = false;
+		}
 		input.reparentHtmlElement(cellId);
 	} else {
 		var params = {

--- a/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
+++ b/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
@@ -259,8 +259,8 @@ function(type, used, addAsContact, dontUpdateUsed) {
 				var contact = addr;
 				if (addAsContact) {
 					var cl = AjxDispatcher.run("GetContacts");
-					contact = cl.getContactByEmail(email);
-					if (contact == null) {
+					contact = cl && cl.getContactByEmail(email);
+					if (contact == null || !cl) {
 						contact = new ZmContact(null);
 						contact.initFromEmail(addr);
 					}

--- a/WebRoot/js/zimbraMail/share/controller/ZmBaseController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmBaseController.js
@@ -1330,7 +1330,9 @@ ZmBaseController.prototype._getBubbleActionMenuOps = function() {
 	}
 	ops.push(ZmOperation.SEARCH_MENU);
 	ops.push(ZmOperation.NEW_MESSAGE);
-	ops.push(ZmOperation.CONTACT);
+	if (appCtxt.get(ZmSetting.CONTACTS_ENABLED)) {
+		ops.push(ZmOperation.CONTACT);
+	}
 	ops.push(ZmOperation.GO_TO_URL);
 
 	if (appCtxt.get(ZmSetting.FILTERS_ENABLED) && this._filterListener) {
@@ -1384,7 +1386,7 @@ ZmBaseController.prototype._loadContactForMenu = function(menu, address, ev, imI
 	}
 
 	// first check if contact is cached, and no server call is needed
-	var contact = contactsApp.getContactByEmail(email);
+	var contact = contactsApp && contactsApp.getContactByEmail(email);
 	if (contact) {
 		this._handleResponseGetContact(menu, address, ev, imItem, contact);
 		return;
@@ -1404,7 +1406,7 @@ ZmBaseController.prototype._loadContactForMenu = function(menu, address, ev, imI
 	}
 	menu.popup(0, ev.docX || ev.item.getXW(), ev.docY || ev.item.getYH());
 	var respCallback = this._handleResponseGetContact.bind(this, menu, address, ev, imItem);
-	contactsApp.getContactByEmail(email, respCallback);
+	contactsApp && contactsApp.getContactByEmail(email, respCallback);
 };
 
 ZmBaseController.prototype._handleResponseGetContact = function(menu, address, ev, imItem, contact) {

--- a/WebRoot/js/zimbraMail/share/view/ZmAddressInputField.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmAddressInputField.js
@@ -771,8 +771,9 @@ function(ev) {
 	this._resetOperations();
 
 	var email = bubble.email;
-	var contactsApp = appCtxt.getApp(ZmApp.CONTACTS);
-	if (email && contactsApp) {
+	var contactsEnabled = appCtxt.get(ZmSetting.CONTACTS_ENABLED);
+	if (email && contactsEnabled) {
+		var contactsApp = appCtxt.getApp(ZmApp.CONTACTS);
 		// first check if contact is cached, and no server call is needed
 		var contact = contactsApp.getContactByEmail(email);
 		if (contact) {
@@ -785,10 +786,14 @@ function(ev) {
 	}
 	else {
 		var actionMenu = this.getActionMenu();
-		actionMenu.getOp(ZmOperation.CONTACT).setVisible(false);
-		actionMenu.getOp(ZmOperation.EXPAND).setVisible(false);
+		if (actionMenu.getOp(ZmOperation.CONTACT)) {
+			actionMenu.getOp(ZmOperation.CONTACT).setVisible(false);
+			this._setContactText(null);
+		}
+		if (actionMenu.getOp(ZmOperation.EXPAND)) {
+			actionMenu.getOp(ZmOperation.EXPAND).setVisible(false);
+		}
 
-		this._setContactText(null);
 		menu.popup(0, ev.docX || bubble.getXW(), ev.docY || bubble.getYH());
 	}
 
@@ -893,9 +898,10 @@ function() {
 		ops.push(ZmOperation.COPY);
 	};
 	ops.push(ZmOperation.EDIT);
-	ops.push(ZmOperation.EXPAND);
-	ops.push(ZmOperation.CONTACT);
-	
+	if (appCtxt.get(ZmSetting.CONTACTS_ENABLED)) {
+		ops.push(ZmOperation.EXPAND);
+		ops.push(ZmOperation.CONTACT);
+	}
 	return ops;
 };
 


### PR DESCRIPTION
**Problem:**
When Contacts feature is disabled (i.e. zimbraFeatureContactsEnabled FALSE), a script error dialog is shown in the following cases:
(A) go to New/Edit Appointment page, add a location and right-click the address bubble of the location
(B) show a message and right-click an address bubble of a sender or a recipient
(C) go to New Appointment page and click Attendees or Optional button. (Note: no error is thrown when you go to Compose page and then go to New Appointment page.)
(D) right-click an appointment, click Forward and click To button
(E) disable GAL feature (i.e. zimbraFeatureGalEnabled FALSE) and go to New Appointment page
(F) right-click a message and click Create Appointment. See also https://github.com/Zimbra/zm-zimlets/pull/50

**Changes:**
(A) fixed `ZmAddressInputField.js`
* menu for `ZmOperation.CONTACT` and `ZmOperation.EXPAND` are added only when Contacts feature is enabled. 
   * "Add to Contacts" or "Edit Contact" menu do not need to be shown when Contacts feature is disabled
   * When Contacts feature is disabled, Expand menu (to show members of distribution list) does not work by design. It does not need to be shown .
* `appCtxt.get(ZmSetting.CONTACTS_ENABLED)` is used rather than `appCtxt.getApp(ZmApp.CONTACTS)` to check if Contacts feature is enabled at lines 774-775. Contacts app is loaded internally (i.e. `appCtxt.getApp(ZmApp.CONTACTS)` becomes true) when Compose page is accessed.

(B) fixed `ZmBaseController.js`
* menu for `ZmOperation.CONTACT` is added only when Contacts feature is enabled.
* null/undefined check is added

(C) fixed `ZmApptEditView.js`, lines 1730-1732
* An error was thrown because `ZmItem.RESULTS_LIST['CONTACT']` was not defined. It was defined when Contacts app was loaded. (Reference: `ZmSearchResult.prototype._getResultsList`, `ZmSearchResult.prototype.set` and `ZmContactsApp.prototype._registerItems`)
* Contacts app is loaded when Attendees or Optional button is clicked.

(D) fixed `ZmApptEditView.js`, lines 1703-1705
* same cause as (C)
* Contacts app is loaded when To button is clicked.

(E) fixed `ZmApptEditView.js`, lines 1073-1075
* `this._forwardPicker` is not set when both Contacts and GAL features are disabled. (Reference: `ZmApptEditView.prototype._createContactPicke` and `ZmApptEditView.prototype._createWidgets`)

(F) fixed `ZmMailMsg.js`
* An error was thrown because `AjxDispatcher.run("GetContacts")` is undefined.
* null/undefined check is added.

**Additional Problem:**
When Contacts feature is disabled, input area is very narrow in the following fields:
* right-click an appointment -> Forward -> To field
* New Appointment -> Attendees, Optional and Location fields

**Root Cause:**
When autocomplete is available, the width of the input field constructed by ZmAddressInputField is adjusted automatically every time a character is entered. On the other hand, when it is unavailable, the width is not changed. Then a field looks narrow. The autocomplete feature is disabled when Contacts feature is disabled.
(Reference)
```
ZmApptEditView.prototype._createWidgets =
function(width) {
	if (appCtxt.get(ZmSetting.CONTACTS_ENABLED)) {
		this._initAutocomplete();
	}
```
(Comparison) the width of To/Cc field in compose page is set to 100% when autocomplete is unavailable.

**Change:**
`supportsAutoComplete` is set to false on the input fields when Contacts feature is disabled. Then the width of the fields keeps 100%. (Reference:`ZmAddressInputField.prototype._resizeInput`)