### PR TITLE
ZCS-10909: reset the status of Show Equipment

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
@@ -489,6 +489,7 @@ function() {
 	if (this._resourcesContainer) {
         this.showResourceField(false);
         this._resourceInputField.clear();
+        this._resourcesShown = false;
 	}
 
 	this._allDayCheckbox.checked = false;


### PR DESCRIPTION
**Problem:**
"Show Equipment" does not work in the following case:
1. open New Appointment tag, click "Show Equipment" and close the tab
2. open another New Appointment and click "Show Equipment". Equipment field does not appear.
3. click "Show Equipment" again. Equipment field appears.

*Change:*
* reset the status of Show/Hide Equipment when a new/edit appointment tab is closed.