### PR TITLE
ZCS-10910: fixed end date time of all day appointment in conflict check

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/controller/ZmApptComposeController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmApptComposeController.js
@@ -749,7 +749,7 @@ function(appt, numRecurrence, callback, showAll, displayConflictDialog,
 	}
 
 
-    appt._addDateTimeToRequest(request, comp);
+    appt._addDateTimeToRequest(request, comp, true);
 
     //preserve the EXDATE (exclude recur) information
     if(recurInfo) {
@@ -830,7 +830,11 @@ function(appt, originalStartDate, numRecurrence) {
     var endDate;
     var range = recurrence.repeatCustomCount * numRecurrence;
     if (recurrence.repeatType == ZmRecurrence.NONE) {
-        endDate = appt.endDate;
+        if (appt.allDayEvent === "1") {
+            endDate = new Date(appt.endDate.getTime() + 24 * 60 * 60 * 1000);
+        } else {
+            endDate = appt.endDate;
+        }
     } else if (recurrence.repeatType == ZmRecurrence.DAILY) {
         endDate = AjxDateUtil.roll(startDate, AjxDateUtil.DAY, range);
     } else if (recurrence.repeatType == ZmRecurrence.WEEKLY) {

--- a/WebRoot/js/zimbraMail/calendar/model/ZmCalItem.js
+++ b/WebRoot/js/zimbraMail/calendar/model/ZmCalItem.js
@@ -2413,7 +2413,7 @@ function(xprop, xparams) {
  * @private
  */
 ZmCalItem.prototype._addDateTimeToRequest =
-function(request, comp) {
+function(request, comp, extractAllDay) {
 	// always(?) set all day
     comp.allDay = this.allDayEvent + "";
 	// timezone
@@ -2432,7 +2432,7 @@ function(request, comp) {
 	// start date
 	if (this.startDate) {
         s = comp.s = {};
-		if (!this.isAllDayEvent()) {
+		if (!this.isAllDayEvent() || extractAllDay) {
 			sd = AjxDateUtil.getServerDateTime(this.startDate, this.startsInUTC);
 
 			// set timezone if not utc date/time
@@ -2462,7 +2462,12 @@ function(request, comp) {
 				e.tz = tz;
             }
             e.d = ed;
-
+		} else if (extractAllDay) {
+			var ed = new Date(this.endDate.getTime() + 24 * 60 * 60 * 1000);
+			e.d = AjxDateUtil.getServerDateTime(ed, this.endsInUTC);
+			if (!this.endsInUTC && tz && tz.length) {
+				e.tz = tz;
+			}
 		} else {
 			e.d = AjxDateUtil.getServerDate(this.endDate);
 		}


### PR DESCRIPTION
**Problem:**
Conflicting Resources dialog is not shown on all day appointment even when GetFreeBusyRequest/Response detects a conflict.

**Root cause:**
End date time is calculated as 00:00:00 of the day in conflict check process at send/save action.
For example, start date and end date of all day appointment is set to 24/Sep/2021, both start and end time is set to "24/Sep 2021 00:00:00" in CheckRecurConflictsRequest.  End date time needs to be "25/Sep/2021 00:00:00" to detect a conflict on 24/Sep.

**Change:**
* Add one day (24 hours) to end time for conflict check (CheckRecurConflictsRequest) when all day checkbox is checked.
* Add timezone of start and end time to CheckRecurConflictsRequest.