### PR TITLE
ZCS-10917: removed check style from day of week in weekly custom repeat

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptRecurDialog.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptRecurDialog.js
@@ -1019,7 +1019,7 @@ function() {
     var satsun = new Array();
     for (var i = 0; i < 7; i++) {
 		//this._weeklySelect.addOption(dayFormatter.format(day), false, i);
-        var mi = new DwtMenuItem({parent:wMenu, style:DwtMenuItem.CHECK_STYLE, radioGroupId:i});
+        var mi = new DwtMenuItem({parent:wMenu, radioGroupId:i});
         mi.setText(dayFormatter.format(day));
         mi.addSelectionListener(selectChangeListener);
         mi.setData("index",i);


### PR DESCRIPTION
**Problem:**
Check mark of day of week in custom weekly repeat setting does not work. An item selected at the last is used. 
Multiple days of a week can be chosen in the 2nd radio button option. Then the check mark is unnecessary.

![checkmark_in_weekly_custom_repeat](https://user-images.githubusercontent.com/32184593/135449805-baef6b4b-d02b-4d45-af46-42f172869b81.png)

**Change:**
`DwtMenuItem.CHECK_STYLE` is removed from the menu item.

![after_the_fix](https://user-images.githubusercontent.com/32184593/135450237-b8f2e8d2-aff3-4b8e-b6a5-f1d8c6148e04.png)