### PR TITLE
ZCS-10916: added condition to check weekly repeat

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptRecurDialog.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptRecurDialog.js
@@ -1695,7 +1695,7 @@ function(ev) {
 
 ZmApptRecurDialog.prototype._selectChangeListener = 
 function(ev) {
-    if(ev.item && ev.item instanceof DwtMenuItem){
+    if(ev.item && ev.item instanceof DwtMenuItem && this.getSelectedRepeatValue() == ZmRecurrence.WEEKLY){
        this._weeklyDefaultRadio.checked = true;
        this._weeklySelectButton.setText(ev.item.getText());
        this._weeklySelectButton._selected = ev.item.getData("index");


### PR DESCRIPTION
**Problem:**
Invalid date is set in the following case:
1. New Appointment -> Custom in repeat setting
2. select a day of week in Monthly repeat
3. change to Weekly repeat and click OK
4. NaN/NaN/0NaN is set in Start and End date

**Root cause:**
In `ZmApptRecurDialog.prototype._selectChangeListener`, a clicked item is checked if it is DwtMenuItem. The processes in the `if` statement is for weekly repeat setting. However, other drop down menu options in Monthly or Yearly repeat are also instances of DwtMenuItem.

**Change:**
Adding a condition to check if the current setting is for weekly repeat.