### PR TITLE
ZBUG-1344: fixing to add inline image by copy & paste

### DIFF
--- a/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
+++ b/WebRoot/js/zimbraMail/mail/model/ZmMailMsg.js
@@ -1662,7 +1662,7 @@ function(request, isDraft, accountName, requestReadReceipt, sendTime) {
 							} else {
 								var id = inlineAtts[j].mid
 									|| (isDraft || this.isDraft)
-									? (oboDraftMsgId || this.id || this.origId)
+									? (inlineAtts[j].mid || oboDraftMsgId || this.id || this.origId)
 									: (this.origId || this.id);
 
 								if (!id && this._origMsg) {

--- a/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
@@ -493,15 +493,27 @@ function(msg, handleInlineDocs){
 					msg.addInlineAttachmentId(cid, mid, part, true);
 					handled = true;
 				} else {
+					var mid = null;
 					ci = "<" + cid + ">";
 					inlineAtt = msg.findInlineAtt(ci);
 					if (!inlineAtt && this._msg) {
 						inlineAtt = this._msg.findInlineAtt(ci);
 					}
-						if (inlineAtt) {
+					// handle a pasted image
+					if (!inlineAtt && images[i].src) {
+						// See ZmMailMsg.getUrlForPart
+						var escapedUri = appCtxt.get(ZmSetting.CSFE_MSG_FETCHER_URI).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+						var re = new RegExp('^' + escapedUri + '&loc=' + AjxEnv.DEFAULT_LOCALE + '&id=(\\d+).*&part=([\\d|\\.]+)$');
+						var attrInfo = images[i].src.match(re);
+						if (attrInfo && attrInfo.length == 3) {
+							mid = attrInfo[1];
+							inlineAtt = { part: attrInfo[2] };
+						}
+					}
+					if (inlineAtt) {
 						var id = [cid, inlineAtt.part].join("_");
 						if (!attached[id]) {
-							msg.addInlineAttachmentId(cid, null, inlineAtt.part);
+							msg.addInlineAttachmentId(cid, mid, inlineAtt.part, (mid != null));
 							handled = true;
 							attached[id] = true;
 						}


### PR DESCRIPTION
**Problem:**
When an inline image is added to compose by copy & paste, it is shown in the compose but it is not shown in a delivered message.

(Steps)
1. show a message with an inline image
2. copy the inline image to clipboard
3. open Compose page in html format
4. paste the image
5. send the message
6. show a delivered message. The image is not shown.

**Root cause:**
When an inline image is added by copy & paste, an entire img tag is pasted like this:
`<img pnsrc="cid:afa3239d0c35e74e739eec3bc11e87da3faa8a3c@zimbra" data-mce-src="cid:afa3239d0c35e74e739eec3bc11e87da3faa8a3c@zimbra" src="https://SERVER/service/home/~/?auth=co&loc=ja&id=608&part=2.2" style="xxx">`

`src` specifies a mime part whose Content-ID is "cid:afa3239d0c35e74e739eec3bc11e87da3faa8a3c@zimbra" in multipart/related (named 2.2) on a message whose id is 608 in this case.
When a composing message is saved or sent, the file needs to be specified as an attachment file. Otherwise, a content cannot be found and then a mime part for the file is not added during mime message creation on a server.

**Changes:**
* parse a url in `src` attribute and set message id and part number to `ZmMailMsg._inlineAtts`
* fetch a message id (mid) from the `_inlineAtts` if it exists and use it in SendMsgRequest and SaveDraftRequest in priority.