### PR TITLE
ZCS-11065: changed to fetch appointments if they have not been cached

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
@@ -4054,6 +4054,12 @@ ZmCalViewController.prototype._refreshAction =
 function(dontClearCache) {
 	DBG.println(AjxDebug.DBG1, "ZmCalViewController: _refreshAction: " + dontClearCache);
 	var forceMaintenance = false;
+
+	if (dontClearCache) {
+		var reminderParams = this._app.getReminderController().getRefreshParams();
+		var mergeKey = this.apptCache._getCachedMergedKey(reminderParams);
+		dontClearCache = Boolean(this.apptCache._cachedMergedApptVectors[mergeKey]);
+	}
 	// reset cache
 	if (!dontClearCache) {
 		this.apptCache.clearCache();


### PR DESCRIPTION
**Problem:**
* Appointments disappear when the appointments are not cached and view is refreshed.

(example of the trigger of refresh)
* change folder color

(cases that the issue happens)
(A) login, go to Calendar immediately and change folder color immediately (before SearchRequest/BatchRequest is called)
(B) enable Calendar app only, login and change folder color immediately 

**Root cause:**
When `ZmCalViewController.prototype._refreshAction` is called with `dontClearCache true`, `this.apptCache.clearCache();` is not called. In this case, appointments are removed from the view and (re)loaded from cache. However, there is a case that appointments shown in the view are not stored in cache. As a result, no item is shown in the view at refresh.

**Fix:**
Add a logic to check if there is a cache (i.e. check if appointments shown in the view are stored in cache) and force `clearCache` if no cache exists.