### PR TITLE
Zbug-1280 showing spellcheck button only when spellcheck service is enabled

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
+++ b/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
@@ -1177,7 +1177,8 @@ ZmAppCtxt.AVAILABLE_DICTIONARY_LOCALES = ["ar", "da", "de", "de_AT", "de_CH", "d
  */
 ZmAppCtxt.prototype.isSpellCheckerAvailable = function () {
 
-	if (!appCtxt.get(ZmSetting.SPELL_CHECK_ENABLED)) {
+	var isSpellCheckServiceEnabled = appCtxt.get(ZmSetting.SPELL_CHECK_ENABLED) && !appCtxt.get(ZmSetting.OFFLINE_ENABLED) && (!AjxEnv.isSafari || AjxEnv.isSafari3up || AjxEnv.isChrome);
+	if (!isSpellCheckServiceEnabled) {
 		return false;
 	}
 

--- a/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
@@ -583,7 +583,7 @@ function(attId, isDraft, dummyMsg, forceBail, contactId) {
 	}
 
 	// Mandatory Spell Check
-	if ((!isDraft || forceBail) && appCtxt.get(ZmSetting.SPELL_CHECK_ENABLED) && 
+	if ((!isDraft || forceBail) && appCtxt.isSpellCheckerAvailable() && 
 		appCtxt.get(ZmSetting.MAIL_MANDATORY_SPELLCHECK) && !this._spellCheckOkay) {
 		if (this._htmlEditor.checkMisspelledWords(this._spellCheckShield.bind(this), null, this._spellCheckErrorShield.bind(this))) {
 			return;

--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -356,6 +356,7 @@ ZmSettings.prototype.setUserSettings = function(params) {
         ZmSetting.USERNAME,                 info.name,
 		ZmSetting.EMAIL_VALIDATION_REGEX, 	info.zimbraMailAddressValidationRegex,
 		ZmSetting.HAB_ROOT,                 (info.habRoots && info.habRoots.hab ? info.habRoots.hab : false),
+		ZmSetting.SPELL_CHECK_ENABLED, 		info.isSpellCheckEnabled,
 		ZmSetting.DISABLE_SENSITIVE_ZIMLETS_IN_MIXED_MODE, 	(info.domainSettings && info.domainSettings.zimbraZimletDataSensitiveInMixedModeDisabled ? info.domainSettings.zimbraZimletDataSensitiveInMixedModeDisabled : "FALSE")
     ];
     for (var i = 0; i < settings.length; i += 2) {
@@ -1010,7 +1011,7 @@ function() {
 	this.registerSetting("SEARCH_ENABLED",					{type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:true});
 	this.registerSetting("SHORTCUT_LIST_ENABLED",			{type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:true});
 	this.registerSetting("OFFLINE_ENABLED",					{type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:appCtxt.isOffline});
-	this.registerSetting("SPELL_CHECK_ENABLED",				{type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:!appCtxt.isOffline && (!AjxEnv.isSafari || AjxEnv.isSafari3up || AjxEnv.isChrome)});
+	this.registerSetting("SPELL_CHECK_ENABLED",				{type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN});
 	this.registerSetting("SPELL_CHECK_ADD_WORD_ENABLED",	{type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:!AjxEnv.isSafari || AjxEnv.isSafari3up || AjxEnv.isChrome});
 
 	//SETTINGS SET AT DOMAIN LEVEL

--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -356,7 +356,7 @@ ZmSettings.prototype.setUserSettings = function(params) {
         ZmSetting.USERNAME,                 info.name,
 		ZmSetting.EMAIL_VALIDATION_REGEX, 	info.zimbraMailAddressValidationRegex,
 		ZmSetting.HAB_ROOT,                 (info.habRoots && info.habRoots.hab ? info.habRoots.hab : false),
-		ZmSetting.SPELL_CHECK_ENABLED, 		info.isSpellCheckEnabled,
+		ZmSetting.SPELL_CHECK_ENABLED, 		info.isSpellCheckAvailable,
 		ZmSetting.DISABLE_SENSITIVE_ZIMLETS_IN_MIXED_MODE, 	(info.domainSettings && info.domainSettings.zimbraZimletDataSensitiveInMixedModeDisabled ? info.domainSettings.zimbraZimletDataSensitiveInMixedModeDisabled : "FALSE")
     ];
     for (var i = 0; i < settings.length; i += 2) {


### PR DESCRIPTION
Backend PR: https://github.com/Zimbra/zm-mailbox/pull/1213
Jira ticket: https://jira.corp.synacor.com/browse/ZBUG-1280

Displaying the spell button on compose view only when zimbraSpellCheckURL returns atleast one url on the primary server. This also disables the mandatory spell check button since there is no active service to check the spelling.