### PR TITLE
ZBUG-2423: set correct file name when a file is pasted from clipboard to draft

### DIFF
--- a/WebRoot/js/zimbraMail/share/view/htmlEditor/ZmHtmlEditor.js
+++ b/WebRoot/js/zimbraMail/share/view/htmlEditor/ZmHtmlEditor.js
@@ -882,7 +882,7 @@ ZmHtmlEditor.prototype.onPaste = function(ev) {
 
 	if (item && item.getAsFile) {
 		file = item.getAsFile();
-		name = file && file.fileName;
+		name = file && file.name;
 		type = file && file.type;
 	} else if (item && item.type) {
 		file = item;
@@ -897,7 +897,6 @@ ZmHtmlEditor.prototype.onPaste = function(ev) {
 			"Cache-Control": "no-cache",
 			"X-Requested-With": "XMLHttpRequest",
 			"Content-Type": type,
-			//For paste from clipboard filename is undefined
 			"Content-Disposition": 'attachment; filename="' + (name ? AjxUtil.convertToEntities(name) : ev.timeStamp || new Date().getTime()) + '"'
 		};
 		var url = (appCtxt.get(ZmSetting.CSFE_ATTACHMENT_UPLOAD_URI) +


### PR DESCRIPTION
**Problem:**
When a file is attached (= pasted) from clipboard in Compose page, the file name of the attachment is changed to some numeric string.

**Root cause:**
`ZmHtmlEditor.prototype.onPaste` is called when a file is pasted from clipboard. File data is gotten in the following code:
```
var items = ((ev.clipboardData &&
              (ev.clipboardData.items || ev.clipboardData.files)) ||
             (window.clipboardData && clipboardData.files)),
    item = items && items[0],
    file, name, type,
    view;

if (item && item.getAsFile) {
    file = item.getAsFile();
    name = file && file.fileName;
    type = file && file.type;
} else if (item && item.type) {
    file = item;
    name = file.name;
    type = file.type;
}
```
Object:
```
ev.clipboardData is DataTransfer
ev.clipboardData.items is DataTransferItemList
ev.clipboardData.items[0] is DataTransferItem
ev.clipboardData.items[0].getAsFile() returns File

ev.clipboardData.files is FileList
ev.clipboardData.files[0] is File
```

File has `name` property, but does not have `fileName` property.
https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent/clipboardData
https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer
https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList
https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem
https://developer.mozilla.org/en-US/docs/Web/API/File

Then `name` is set to `undefined` at
```
name = file && file.fileName;
```
As a result, filename is set to `ev.timeStamp || new Date().getTime()`.
```
"Content-Disposition": 'attachment; filename="' + (name ? AjxUtil.convertToEntities(name) : ev.timeStamp || new Date().getTime()) + '"'
```

**Change:**
* get `name` property of a file.
