### PR TITLE
ZBUG-2236: Show delivered From if no good contact fullname

### DIFF
--- a/WebRoot/js/zimbraMail/mail/model/ZmMailItem.js
+++ b/WebRoot/js/zimbraMail/mail/model/ZmMailItem.js
@@ -176,6 +176,11 @@ function(node) {
 			contact = contactList && contactList.getContactByEmail(node.a),
 			fullName = contact && contact.getFullNameForDisplay(false);
 
+		// unless it's just the start of the email address (ZBUG-2236)
+		if (node.p != null && node.a != null && node.a.startsWith(fullName + "@")) {
+			fullName = node.p; // Update contacts with prettier name?
+		}
+
 		var addr = new AjxEmailAddress(node.a, type, fullName || node.p, node.d, node.isGroup, node.isGroup && node.exp);
 		var ac = window.parentAppCtxt || window.appCtxt;
 		ac.setIsExpandableDL(node.a, addr.canExpand);

--- a/WebRoot/js/zimbraMail/mail/model/ZmMailItem.js
+++ b/WebRoot/js/zimbraMail/mail/model/ZmMailItem.js
@@ -177,7 +177,7 @@ function(node) {
 			fullName = contact && contact.getFullNameForDisplay(false);
 
 		// unless it's just the start of the email address (ZBUG-2236)
-		if (node.p != null && node.a != null && node.a.startsWith(fullName + "@")) {
+		if (node.p && node.a && node.a.startsWith(fullName + "@")) {
 			fullName = node.p; // Update contacts with prettier name?
 		}
 

--- a/WebRoot/js/zimbraMail/mail/model/ZmMailItem.js
+++ b/WebRoot/js/zimbraMail/mail/model/ZmMailItem.js
@@ -178,7 +178,7 @@ function(node) {
 
 		// unless it's just the start of the email address (ZBUG-2236)
 		if (node.p && node.a && node.a.startsWith(fullName + "@")) {
-			fullName = node.p; // Update contacts with prettier name?
+			fullName = node.p;
 		}
 
 		var addr = new AjxEmailAddress(node.a, type, fullName || node.p, node.d, node.isGroup, node.isGroup && node.exp);


### PR DESCRIPTION
**Problem:** If a contact exists, its display name is always used for an address, even if the delivered name is more descriptive, e.g. contact says "user1" and the original message had "User One <user1@example.com>".

**Solution:** Use the more descriptive name for To/From displays.

**Fix:** Fixed ZmMailItem.prototype._parseParticipantNode to use the passed From if the contact is only the user part of the email address.

**Testing:** Deploy zm-web-client branch, follow instructions in [ZBUG-2236](https://jira.corp.synacor.com/browse/ZBUG-2236), verify that delivered fullname is used in final step for viewing and replying.