### PR TITLE
ZBUG-2164, ZCS-11153: fixed parameter handling on mailto link

### DIFF
--- a/WebRoot/js/zimbraMail/share/zimlet/handler/ZmEmailObjectHandler.js
+++ b/WebRoot/js/zimbraMail/share/zimlet/handler/ZmEmailObjectHandler.js
@@ -41,9 +41,8 @@ ZmEmailObjectHandler.prototype.toString = function() {
 };
 
 // email regex that recognizes mailto: links as well
-//ZmEmailObjectHandler.RE = /\b(mailto:[ ]*)?([0-9a-zA-Z]+[.&#!$%'*+-\/=?^_`{}|~])*[0-9a-zA-Z_-]+@([-0-9a-zA-Z]+[.])+[a-zA-Z]{2,6}([\w\/_\.]*(\?\S+)?)/gi;
-ZmEmailObjectHandler.RE = /\b(mailto:[ ]*)?([0-9a-zA-Z\u00C0-\u00ff]+[.&#!$%'*+-\/=?^_`{}|~])*[0-9a-zA-Z_-\u00C0-\u00ff]+@([-0-9a-zA-Z]+[.])+[a-zA-Z]{2,6}([\w\/_\.]*(\?\S+)?)/gi;
-
+// Reference: RFC 2234, 3986 and 6068
+ZmEmailObjectHandler.RE = /\b(mailto:[ ]*)?([0-9a-zA-Z\u00C0-\u00ff]+[.&#!$%'*+-\/=?^_`{}|~])*[0-9a-zA-Z_-\u00C0-\u00ff]+@([-0-9a-zA-Z]+[.])+[a-zA-Z]{2,6}([\w\/_\.]*(\?[-0-9a-zA-Z_\.~%!$'\(\)\*\+,;:@=&]+)?)/gi;
 
 ZmEmailObjectHandler.prototype.match = function(content, startIndex, objectMgr) {
 
@@ -83,8 +82,9 @@ ZmEmailObjectHandler.prototype.clicked = function(spanElement, contentObjText, m
 		action:         ZmOperation.NEW_MESSAGE,
 		inNewWindow:    ctlr && ctlr._app && ctlr._app._inNewWindow(ev),
 		toOverride:     parts.to,
-		subjOverride:   parts.subject,
-		extraBodyText:  parts.body
+		subjOverride:   AjxStringUtil.htmlEncode(parts.subject),
+		extraBodyText:  AjxStringUtil.htmlEncode(parts.body),
+		extraBodyTextIsExternal: Boolean(parts.body)
 	};
 
 	AjxDispatcher.run("Compose", params);


### PR DESCRIPTION
**Problems:**
1. When a message body contains mailto string which has angle brackets `<>` like `<mailto:account1@dev.zimbra.com?subject=sample%20message>`, the link includes the last `>`.
(i.e. `mailto:account1@dev.zimbra.com?subject=sample%20message>`)
Then by clicking the link, "sample message>" is set in subject field of new compose page.
2. When the link is clicked, the values of subject and body need to be sanitized before they are added to the fields in new compose page.

**Definition of the format of mailto link:**
It is defined in RFC 6068, 3986 and 2234.
```
(RFC 6068)
      mailtoURI    = "mailto:" [ to ] [ hfields ]
      to           = addr-spec *("," addr-spec )
      hfields      = "?" hfield *( "&" hfield )
      hfield       = hfname "=" hfvalue
      hfname       = *qchar
      hfvalue      = *qchar
      addr-spec    = local-part "@" domain
      local-part   = dot-atom-text / quoted-string
      domain       = dot-atom-text / "[" *dtext-no-obs "]"
      dtext-no-obs = %d33-90 / ; Printable US-ASCII
                     %d94-126  ; characters not including
                               ; "[", "]", or "\"
      qchar        = unreserved / pct-encoded / some-delims
      some-delims  = "!" / "$" / "'" / "(" / ")" / "*"
                   / "+" / "," / ";" / ":" / "@"

(RFC 3986)
      unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
      pct-encoded = "%" HEXDIG HEXDIG

(RFC 2234)
        ALPHA          =  %x41-5A / %x61-7A   ; A-Z / a-z
        DIGIT          =  %x30-39
                               ; 0-9
        HEXDIG         =  DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
```
Focusing on URL parameter(s). The following characters can be used
```
      hfields      = "?" hfield *( "&" hfield )
      hfield       = hfname "=" hfvalue
      hfname       = *qchar
      hfvalue      = *qchar
      qchar        = unreserved / pct-encoded / some-delims
      unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
      pct-encoded = "%" HEXDIG HEXDIG
      some-delims  = "!" / "$" / "'" / "(" / ")" / "*"
                   / "+" / "," / ";" / ":" / "@"
```
References:
* https://datatracker.ietf.org/doc/html/rfc2234
* https://datatracker.ietf.org/doc/html/rfc3986
* https://datatracker.ietf.org/doc/html/rfc6068


**Changes:**
For problem 1, change regex about URL parameter from `(\?\S+)?` to `(\?[-0-9a-zA-Z_\.~%!$'\(\)\*\+,;:@=&]+)?`.
It expresses the first letter `?` and `- 0-9 a-z A-Z _ . ~ % ! $ ' ( ) * + , ; : @ = &`. It does not have `< >`. Then the link becomes `mailto:account1@dev.zimbra.com?subject=sample%20message` in the above case.

For problem 2, sanitize the values using `AjxStringUtil.htmlEncode`. `extraBodyTextIsExternal` is set to true for secure if body exists because a mailto can be written by anyone.


