### PR TITLE
ZBUG-1945: load sharing folders in Contacts

### DIFF
--- a/WebRoot/js/zimbraMail/abook/model/ZmContactList.js
+++ b/WebRoot/js/zimbraMail/abook/model/ZmContactList.js
@@ -160,8 +160,37 @@ function(callback, errorCallback, accountName) {
 	DBG.println(AjxDebug.DBG1, "loading contacts from " + params.restUri);
 	appCtxt.getAppController().sendRequest(params);
 
+	// wait for Contacts package to be loaded
+	AjxDispatcher.addPackageLoadFunction("Contacts", new AjxCallback(this, this._loadSharingFolders));
+
 	ZmContactList.addDlFolder();
 	
+};
+
+ZmContactList.prototype._loadSharingFolders =
+function() {
+	DBG.println(AjxDebug.DBG1, "loading sharing folders in Contacts");
+	var root = appCtxt.getById(ZmOrganizer.ID_ROOT);
+	var sharingFolder = [];
+	appCtxt.getSharingFolders(root, ZmOrganizer.ADDRBOOK, sharingFolder);
+	if (sharingFolder.length) {
+		var query = "";
+		for (var i = 0; i < sharingFolder.length; i++) {
+			query += sharingFolder[i].createQuery() + " or ";
+		}
+		query = query.replace(/\sor\s$/, '');
+		var sc = appCtxt.getSearchController();
+		sc.setDefaultSearchType(ZmItem.CONTACT);
+		var params = {
+			query: query,
+			searchFor: ZmItem.CONTACT,
+			fetch: true,
+			sortBy: ZmSearch.NAME_ASC,
+			callback: null,
+			noRender: true
+		};
+		sc.search(params);
+	}
 };
 
 /**

--- a/WebRoot/js/zimbraMail/abook/model/ZmContactList.js
+++ b/WebRoot/js/zimbraMail/abook/model/ZmContactList.js
@@ -169,14 +169,14 @@ function(callback, errorCallback, accountName) {
 
 ZmContactList.prototype._loadSharedFolders =
 function() {
-	DBG.println(AjxDebug.DBG1, "loading sharing folders in Contacts");
+	DBG.println(AjxDebug.DBG1, "loading shared folders in Contacts");
 	var root = appCtxt.getById(ZmOrganizer.ID_ROOT);
-	var sharingFolder = [];
-	appCtxt.getSharedFolders(root, ZmOrganizer.ADDRBOOK, sharingFolder);
-	if (sharingFolder.length) {
+	var sharedFolder = [];
+	appCtxt.getSharedFolders(root, ZmOrganizer.ADDRBOOK, sharedFolder);
+	if (sharedFolder.length) {
 		var query = "";
-		for (var i = 0; i < sharingFolder.length; i++) {
-			query += sharingFolder[i].createQuery() + " or ";
+		for (var i = 0; i < sharedFolder.length; i++) {
+			query += sharedFolder[i].createQuery() + " or ";
 		}
 		query = query.replace(/\sor\s$/, '');
 		var sc = appCtxt.getSearchController();

--- a/WebRoot/js/zimbraMail/abook/model/ZmContactList.js
+++ b/WebRoot/js/zimbraMail/abook/model/ZmContactList.js
@@ -161,18 +161,18 @@ function(callback, errorCallback, accountName) {
 	appCtxt.getAppController().sendRequest(params);
 
 	// wait for Contacts package to be loaded
-	AjxDispatcher.addPackageLoadFunction("Contacts", new AjxCallback(this, this._loadSharingFolders));
+	AjxDispatcher.addPackageLoadFunction("Contacts", new AjxCallback(this, this._loadSharedFolders));
 
 	ZmContactList.addDlFolder();
 	
 };
 
-ZmContactList.prototype._loadSharingFolders =
+ZmContactList.prototype._loadSharedFolders =
 function() {
 	DBG.println(AjxDebug.DBG1, "loading sharing folders in Contacts");
 	var root = appCtxt.getById(ZmOrganizer.ID_ROOT);
 	var sharingFolder = [];
-	appCtxt.getSharingFolders(root, ZmOrganizer.ADDRBOOK, sharingFolder);
+	appCtxt.getSharedFolders(root, ZmOrganizer.ADDRBOOK, sharingFolder);
 	if (sharingFolder.length) {
 		var query = "";
 		for (var i = 0; i < sharingFolder.length; i++) {

--- a/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
+++ b/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
@@ -2330,11 +2330,11 @@ ZmAppCtxt.prototype.showError = function(params) {
 };
 
 /**
- * Get sharing folders
+ * Get shared folders
  *
  * @param {Object} folder     current node
  * @param {string} type       folder type
- * @param {Array}  result     an array of sharing folders
+ * @param {Array}  result     an array of shared folders
  */
 ZmAppCtxt.prototype.getSharedFolders =
 function(folder, type, result) {
@@ -2345,7 +2345,7 @@ function(folder, type, result) {
     for (var i = 0; i < children.length; i++) {
         appCtxt.getSharedFolders(children[i], type, result);
     }
-    // a sharing folder has an owner
+    // a shared folder has an owner
     if (folder.owner && folder.type == type && !folder.noSuchFolder) {
         result.push(folder);
     }

--- a/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
+++ b/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
@@ -2336,14 +2336,14 @@ ZmAppCtxt.prototype.showError = function(params) {
  * @param {string} type       folder type
  * @param {Array}  result     an array of sharing folders
  */
-ZmAppCtxt.prototype.getSharingFolders =
+ZmAppCtxt.prototype.getSharedFolders =
 function(folder, type, result) {
     if (!folder || !folder instanceof ZmFolder || !type || !Array.isArray(result)) {
         return;
     }
     var children = folder.children && folder.children.getArray();
     for (var i = 0; i < children.length; i++) {
-        appCtxt.getSharingFolders(children[i], type, result);
+        appCtxt.getSharedFolders(children[i], type, result);
     }
     // a sharing folder has an owner
     if (folder.owner && folder.type == type && !folder.noSuchFolder) {

--- a/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
+++ b/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
@@ -2328,3 +2328,25 @@ ZmAppCtxt.prototype.showError = function(params) {
     dlg.setMessage(errMsg, params.details, params.style || DwtMessageDialog.WARNING_STYLE, params.title);
     dlg.popup(null, params.noReport !== false);
 };
+
+/**
+ * Get sharing folders
+ *
+ * @param {Object} folder     current node
+ * @param {string} type       folder type
+ * @param {Array}  result     an array of sharing folders
+ */
+ZmAppCtxt.prototype.getSharingFolders =
+function(folder, type, result) {
+    if (!folder || !folder instanceof ZmFolder || !type || !Array.isArray(result)) {
+        return;
+    }
+    var children = folder.children && folder.children.getArray();
+    for (var i = 0; i < children.length; i++) {
+        appCtxt.getSharingFolders(children[i], type, result);
+    }
+    // a sharing folder has an owner
+    if (folder.owner && folder.type == type && !folder.noSuchFolder) {
+        result.push(folder);
+    }
+};


### PR DESCRIPTION
**Problem:**
Display Name or Image of a contact in a sharing contact folder is not used in Mail app until the folder is clicked.

Steps to reproduce:
1. on user A,
   * create a contact which has an email (e.g. userC@dev.zimbra.com), display name and an image file.
   * share a contact folder which contains the contact with user B.
2. on user B,
   * accept the share. The contact can be read.
   * receive an email from userC@dev.zimbra.com
3. on user B,
   * relogin and click the message
   * the display name or the image of the contact in the sharing folder is not shown in message preview.
4. on user B,
   * relogin, go to Contacts and click the sharing folder
   * go to Mail and click the message
   * the display name and the image of the contact in the sharing folder are shown in message preview.

Expected behavior:
* display name and an image of a contact in a sharing folder are used in Mail app at step 3, without clicking a sharing folder.

**Root cause:**
Contacts in local folders are loaded in `ZmContactList.prototype.load` by accessing REST API `https://SERVER/home/EMAIL/Contacts?fmt=cf&t=2&all=all`. The API does not return any data in sharing folders. Changing the API affects server performance and error handling at least.
Sharing folders needs to be fetched by sending SearchRequest.

**Changes:**
* define `ZmAppCtxt.prototype.getSharingFolders` to find sharing folders. It is called recursively.
* define `ZmContactList.prototype._loadSharingFolders` to call SearchRequest which fetches the sharing folders.
* `ZmContactList.prototype._loadSharingFolders` needs to be called after `Contacts_all.js` is loaded. Otherwise, no folder in Contacts is returned by `appCtxt.getById(ZmOrganizer.ID_ROOT)`. `AjxDispatcher.addPackageLoadFunction` in `ZmContactList.prototype.load` achieves it.

**Restriction:**
* A message list of Inbox is fetched at the first stage (response to https://SERVER/ access) and rendered before the above SearchRequest is executed. If a message from userC@dev.zimbra.com is listed, display name of the contact is not shown in the message list. The display name is applied when Inbox is clicked (= refreshed).