### PR TITLE
ZBUG-2145: added Catalan to aspell support locale

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
+++ b/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
@@ -1168,7 +1168,7 @@ function() {
  *      (use only the items whose format is "<Primary-tag> *( "_" <Subtag> )")
  * When Aspell is upgraded and more locales are added, please update this list too.
  */
-ZmAppCtxt.AVAILABLE_DICTIONARY_LOCALES = ["ar", "da", "de", "de_AT", "de_CH", "de_DE", "en", "en_CA", "en_GB", "en_US", "es", "fr", "fr_CH", "fr_FR", "hi", "hu", "it", "nl", "pl", "pt_BR", "ru", "sv"];
+ZmAppCtxt.AVAILABLE_DICTIONARY_LOCALES = ["ar", "ca", "da", "de", "de_AT", "de_CH", "de_DE", "en", "en_CA", "en_GB", "en_US", "es", "fr", "fr_CH", "fr_FR", "hi", "hu", "it", "nl", "pl", "pt_BR", "ru", "sv"];
 
 /**
  * Gets the availability of the spell check feature based on the current locale and user's configuration


### PR DESCRIPTION
**Problem:**
Spell check button does not appear in compose page when language setting is Catalan. (zimbraPrefLocale ca)

**Root cause:**
Aspell Catalan dictionary was not included in Zimbra.

**Changes:**
* Add Catalan dictionary on https://github.com/Zimbra/packages/pull/149
* Add `ca` to `ZmAppCtxt.AVAILABLE_DICTIONARY_LOCALES`