### PR TITLE
ZBUG-1853: removed Linux-specific BusyOverlay and VeilOverlay

### DIFF
--- a/WebRoot/css/common.css
+++ b/WebRoot/css/common.css
@@ -422,20 +422,10 @@ TD.vSpace {
 	@BusyCursor@
 	background-color:transparent;	/* ??? */
 }
-/* As of 07/22/05 Linux (or rather X) has a nasty issue that causes a huge perf problem with opacity.*/
-
-.BusyOverlay-linux TABLE, .VeilOverlay-linux TABLE {
-	@BusyCursor@
-	background-color:transparent;
-}
 
 .VeilOverlay TABLE {
 	@DisabledCursor@
 	@VeilColor@
-}
-
-.VeilOverlay-linux TABLE {
-	@LoginScreen@
 }
 
 .CurtainOverlay TABLE {


### PR DESCRIPTION
**Problem:**
On Linux, when a dialog like Move Message is shown, the background does not become transparent but blue background appears. The background should become transparent in the same way as on Windows and Mac.

**Root cause:**
Styles of BusyOverlay and VeilOverlay were different between Linux and others. According to the comment in `common.css`, it was due to performance problem with opacity style.
No performance issue was observed with opacity style. Linux-specific style is no longer necessary.

**Changes:**
Change to use `BusyOverlay` and `VeilOverlay` classes regardless of client OS.
* Remove `BusyOverlay-linux` and `VeilOverlay-linux` classes on https://github.com/Zimbra/zm-ajax/pull/95
* Remove the style for the classes.