### PR TITLE
ZCS-11122: Protect against XSS while rendering list view in /h/calendar

### DIFF
--- a/WebRoot/WEB-INF/tags/calendar/monthView.tag
+++ b/WebRoot/WEB-INF/tags/calendar/monthView.tag
@@ -124,7 +124,7 @@
                                 </c:when>
                                 <c:otherwise>
                                     <app:calendarUrl var="monthZoomUrl" view="month" zoom="${true}" timezone="${timezone}" rawdate="${currentDay}"/>
-                                    <td width="11%" onclick='javascript:dayClick(event, "${monthZoomUrl}");' class='ZhCalMonthDay${currentDay.timeInMillis eq date.timeInMillis ? 'Selected':''}'>
+                                    <td width="11%" onclick='javascript:dayClick(event, "${fn:escapeXml(monthZoomUrl)}");' class='ZhCalMonthDay${currentDay.timeInMillis eq date.timeInMillis ? 'Selected':''}'>
                                             <table width="100%" cellspacing="2" >
                                                 <tr>
                                                     <c:set var="T" value="${zm:isSameDate(currentDay, today) ? 'T' : ''}"/>

--- a/WebRoot/WEB-INF/tags/calendar/multiDay.tag
+++ b/WebRoot/WEB-INF/tags/calendar/multiDay.tag
@@ -291,7 +291,7 @@
                             <td valign=top class='ZhCalDayHour' nowrap width="1%" rowspan="4" style='border-left:none;color:blue;'>
                                 <fmt:formatDate var="dateDf" value="${row.date}" pattern="yyyyMMdd'T'HHmmss" timeZone="${timezone}"/>
                                 <app:calendarUrl var="newAppt" timezone="${timezone}" date="${dateDf}" action="edit"/>
-                                <c:if test="${not print}"><a href="${newAppt}"></c:if><fmt:formatDate value="${row.date}" type="time" timeStyle="short"/>
+                                <c:if test="${not print}"><a href="${fn:escapeXml(newAppt)}"></c:if><fmt:formatDate value="${row.date}" type="time" timeStyle="short"/>
                                 <c:if test="${not print}"></a></c:if>
                                     <fmt:formatDate var="timetitle" value="${row.date}" type="time" timeStyle="long"/>
                                 <%--<fmt:formatDate value="${timetitle}" pattern="${titleFormat}"/>--%>
@@ -450,7 +450,7 @@
                         <td valign=top class='ZhCalDayHour' nowrap width="1%" rowspan="4" style='border-left:none;color:blue;'>
                             <fmt:formatDate var="dateDf" value="${row.date}" pattern="yyyyMMdd'T'HHmmss" timeZone="${timezone}"/>
                             <app:calendarUrl var="newAppt" timezone="${timezone}" date="${dateDf}" action="edit"/>
-                            <c:if test="${not print}"><a href="${newAppt}"></c:if><fmt:formatDate value="${row.date}" type="time" timeStyle="short"/>
+                            <c:if test="${not print}"><a href="${fn:escapeXml(newAppt)}"></c:if><fmt:formatDate value="${row.date}" type="time" timeStyle="short"/>
                             <c:if test="${not print}"></a></c:if>
                                 <fmt:formatDate var="timetitle" value="${row.date}" type="time" timeStyle="long"/>
                             <%--<fmt:formatDate value="${timetitle}" pattern="${titleFormat}"/>--%>


### PR DESCRIPTION
When rendering the basic html client calendar view, protect against XSS using the fn:escapeXML function to render newAppt