### PR TITLE
Include messages unconditionally, or the page looks broken.

### DIFF
--- a/WebRoot/public/error.jsp
+++ b/WebRoot/public/error.jsp
@@ -33,10 +33,8 @@
                           Pattern.matches("^[0-9A-Za-z]+$", skin));
 %>
 
-<c:if test="${skinOK}">
 <fmt:setBundle basename="/messages/ZhMsg" scope="request"/>
 <fmt:setBundle basename="/messages/ZmMsg" var="zmmsg" scope="request"/>
-</c:if>
 
 <%
 	Object errorCode = request.getAttribute("javax.servlet.error.status_code");


### PR DESCRIPTION
Fix the messages in error.jsp page on Zimbra 8.8.15.
This was fixed in Zimbra 9.0.0 as part of a restyle (PREAPPS-4347), but still broken in 8.8.15.  Not sure which branch to send this PR to...

Cherry-picked from https://github.com/Zimbra/zm-web-client/pull/578.

Before:
![image](https://user-images.githubusercontent.com/23522924/153206139-000de42f-cb5b-48c1-8f40-9c9b7902e677.png)

After:
![image](https://user-images.githubusercontent.com/23522924/153206254-b0fbb7a5-9ab6-4f6a-a1f4-d8064e1b69eb.png)
