### PR TITLE
PREAPPS-6566: Direct access to calendar URL

### DIFF
--- a/WebRoot/public/modern.jsp
+++ b/WebRoot/public/modern.jsp
@@ -8,6 +8,20 @@
 %>
 <script TYPE="text/javascript">
     localStorage.setItem("csrfToken" , "${csrfToken}");
-    var url = window.location.origin + "/modern/"
-    window.location.href = url;
+    
+    const currentURL = new URL(window.location.href);
+    const redirectToPath = currentURL.searchParams.get("RelayState") || '';
+
+    /**
+     * After sucessful login app will redirect to RelayState path if it exist and it start with /modern/ and'
+     * if redirectToPath doesn't contains /../ (i.e. parent directory access)
+     * i.e. https://<server>/?RelayState=%2Fmodern%2Fcalendar on this case app will 
+     * redirect to https://<server>/modern/calendar
+     */
+    if (redirectToPath.indexOf('/modern/') === 0 && !redirectToPath.includes('/../')) {
+        window.location.href = window.location.origin + redirectToPath;
+    } else {
+        var url = window.location.origin + "/modern/"
+        window.location.href = url;
+    }
 </script>


### PR DESCRIPTION
### Problem
Deep linking modern ui resource (i.e. /modern/calendar) doesn't get redirect automatically after login

### Solution.
Get deep linking resource from RelayState param and redirect it if it's value start with `/modern/`
