### PR TITLE
ZBUG-2649: removed "mailto:" from actions on email object

### DIFF
--- a/WebRoot/js/zimbraMail/share/zimlet/handler/ZmEmailObjectHandler.js
+++ b/WebRoot/js/zimbraMail/share/zimlet/handler/ZmEmailObjectHandler.js
@@ -107,7 +107,7 @@ ZmEmailObjectHandler.prototype.getActionMenu = function(obj, span, context, ev) 
 		this._actionMenu = ctlr._getBubbleActionMenu();
 	}
 
-	ctlr._bubbleActionListener(ev, obj);
+	ctlr._bubbleActionListener(ev, ctlr._actionEv.address);
 
 	return this._actionMenu;
 };


### PR DESCRIPTION
**Problem:**
When an action in right-click menu is executed on an email link which has "mailto:", the string "mailto:" is included as follows:

Example of a mailto link:
`<a href="mailto:user1@domain1.zimbra.com">user1@domain1.zimbra.com</a>`

Bahavior before the fix:
On message/conversation/contact/appointment/task view,
* Copy: `mailto:user1@domain1.zimbra.com;` is copied to clipboard
* Find Emails: Search is not executed due to an error. "Unable to parse the search query" is shown in a toaster.
    * Received From Sender -> search query is `from:mailto:dummy@domain1.zimbra.com`
    * Sent To Sender -> search query is `tocc:mailto:user1@domain1.zimbra.com`
* New Email: `mailto:user1@domain1.zimbra.com` is set in To field
* Add To Contacts: `mailto:user1@domain1.zimbra.com` is set in Email field
* (Mail app only) Add To Filter: `mailto:user1@domain1.zimbra.com` is set in a condition

For Add To Contacts, even if a contact whose email address is `user1@domain1.zimbra.com` exists, not "Edit Contact" but "Add To Contacts" is shown.

**Root Cause:**
"mailto:" is removed at `ZmEmailObjectHandler.prototype.getActionMenu`, but an original string with "mailto:" is set again in `ZmBaseController.prototype._bubbleActionListener`.
```
ZmEmailObjectHandler.prototype.getActionMenu = function(obj, span, context, ev) {  // ★obj is a string "mailto:user1@domain1.zimbra.com", for example
	//...
	ctlr._actionEv.address = AjxStringUtil.parseMailtoLink(obj).to;   // ★"mailto:" is removed
	//...
	ctlr._bubbleActionListener(ev, obj);   // ★obj contains "mailto:". 
	//...

ZmBaseController.prototype._bubbleActionListener = function(ev, addr) {
	this._actionEv = ev;
	var bubble = this._actionEv.bubble = ev.item,
		address = this._actionEv.address = addr || bubble.addrObj || bubble.address,   // ★this._actionEv.address is changed to "mailto:user1@domain1.zimbra.com"
		menu = this._getBubbleActionMenu();
	//...
```

**Change:**
Set an email address without "mailto:" in 2nd param of `ZmBaseController._bubbleActionListener` in `ZmEmailObjectHandler.prototype.getActionMenu`.

The behavior changes as follows.
Behavior after the fix:
* Copy: `user1@domain1.zimbra.com;` is copied
* Find Emails: Search is executed.
    * Received From Sender -> search query is `from:user1@domain1.zimbra.com`
    * Sent To Sender -> search query is `tocc:user1@domain1.zimbra.com`
* New Email: `user1@domain1.zimbra.com` is set in To field
* Add To Contacts: `user1@domain1.zimbra.com` is set in Email field
* Add To Filter: `user1@domain1.zimbra.com` is set in a condition

For Add To Contacts, if a contact whose email address is `user1@domain1.zimbra.com` exists, "Edit Contact" is shown. Othersize, "Add To Contacts" is shown.

**Known Issues:**
On Contacts App, we see different behavior after the fix.
* Find Emails: if a contact whose email address is `user1@domain1.zimbra.com` does not exist, no search action is executed (= SearchRequest is not sent). No error message is shown.
* New Email: `mailto:user1@domain1.zimbra.com` is set in To field. An email address of a contact is set in To field as is.
* When "New Email" is clicked in a contact group, a contact whose email address has "mailto:" is not added to To field because it is regarded as an invalid email address. It is observed before the fix as well.