### PR TITLE
ZBUG-2621: show thumbnail photo in GAL

### DIFF
--- a/WebRoot/js/zimbraMail/abook/model/ZmContact.js
+++ b/WebRoot/js/zimbraMail/abook/model/ZmContact.js
@@ -175,6 +175,7 @@ ZmContact.F_workState				= "workState";
 ZmContact.F_workStreet				= "workStreet";
 ZmContact.F_workURL					= "workURL";
 ZmContact.F_imagepart               = "imagepart";          // New field for bug 73146 - Contacts call does not return the image information
+ZmContact.F_thumbnailPhoto          = "thumbnailPhoto";
 ZmContact.F_zimletImage				= "zimletImage";
 ZmContact.X_fileAs					= "fileAs";				// extra fields
 ZmContact.X_firstLast				= "firstLast";
@@ -336,7 +337,7 @@ ZmContact.IGNORE_FIELDS = [].concat(
 	ZmContact.GAL_FIELDS,
 	ZmContact.MYCARD_FIELDS,
 	ZmContact.X_FIELDS,
-	[ZmContact.F_imagepart]
+	[ZmContact.F_imagepart, ZmContact.F_thumbnailPhoto]
 );
 
 ZmContact.ALL_FIELDS = [].concat(
@@ -2218,6 +2219,10 @@ ZmContact.NO_MAX_IMAGE_WIDTH = ZmContact.NO_MAX_IMAGE_HEIGHT = - 1;
  */
 ZmContact.prototype.getImageUrl =
 function(maxWidth, maxHeight) {
+	if (this.getAttr(ZmContact.F_thumbnailPhoto)) {
+		return "data:;base64," + this.getAttr(ZmContact.F_thumbnailPhoto);
+	}
+
   	var image = this.getAttr(ZmContact.F_image);
 	var imagePart  = image && image.part || this.getAttr(ZmContact.F_imagepart); //see bug 73146
 


### PR DESCRIPTION
**Problem:**
When a photo of an account is set, the photo is not shown in a contact in Global Address List.

**Steps to reproduce:**
1. log in to an account on Modern UI
2. click "Change Profile Image" and add a photo. It is saved in the account's `thumbnailPhoto` attribute.
3. force GalSync. `$ zmgsautil forceSync -a GALSYNC_ACCOUNT -n InternalGAL`
4. relogin on Modern UI, go to Contacts and click Global Address List in folder tree
5. relogin on Classic UI, go to Contacts and click the contact of the account in `galsync.xxxx_InternalGAL` folder
6. a photo is not shown as an image of the contact. Instead, base64 encoded string of the photo is shown in Other (thumbnail Photo) field.

**Change:**
* Address thumbnailPhoto in `ZmContact.prototype.getImageUrl` if it exists
* Add thumbnailPhoto to `ZmContact.IGNORE_FIELDS` so that base64 string is not shown.