### PR TITLE
ZBUG-2659 Fix XSS security issue on html client

### DIFF
--- a/WebRoot/WEB-INF/tags/ads.tag
+++ b/WebRoot/WEB-INF/tags/ads.tag
@@ -22,7 +22,7 @@
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 <%@ taglib prefix="app" uri="com.zimbra.htmlclient" %>
 <c:url var="url" value="/h/ads">
-   <c:param name="f" value="${content}"/>
+   <c:param name="f" value="${fn:escapeXml(content)}"/>
 </c:url>
-<!-- ||${content}|| -->
+<!-- ||${fn:escapeXml(content)}|| -->
 <iframe width="163" height="606" frameborder="0" scrolling="no" src="${url}"></iframe>

--- a/WebRoot/WEB-INF/tags/searchPageOffset.tag
+++ b/WebRoot/WEB-INF/tags/searchPageOffset.tag
@@ -26,6 +26,6 @@
 <c:set var="last" value="${searchResult.offset+searchResult.size}"/>    
 <span class='Paging'>
 ${first} <c:if test="${first ne last}"> - ${last}</c:if>
-<c:if test="${!empty max}"> of ${max} </c:if>
+<c:if test="${!empty max}"> of ${fn:escapeXml(max)} </c:if>
 <c:if test="${empty max and !searchResult.hasMore}">&nbsp;<fmt:message key="of"/>&nbsp;${last} </c:if>
 </span>


### PR DESCRIPTION
Problem: This is a Security issue and users can post HTML/Script content with URL parameters. 

Solution: Added escape-xml method in URL params and sanitized them.

Impact: If the user will pass the HTML/script tag in the URL ads parameter, it will be sanitized, no alert dialog will appear.