### PR TITLE
ZBUG-11203 Fix max parameter sanitization issue

### DIFF
--- a/WebRoot/WEB-INF/tags/searchPageOffset.tag
+++ b/WebRoot/WEB-INF/tags/searchPageOffset.tag
@@ -26,6 +26,6 @@
 <c:set var="last" value="${searchResult.offset+searchResult.size}"/>    
 <span class='Paging'>
 ${first} <c:if test="${first ne last}"> - ${last}</c:if>
-<c:if test="${!empty max}"> of ${max} </c:if>
+<c:if test="${!empty max}"> of ${fn:escapeXml(max)} </c:if>
 <c:if test="${empty max and !searchResult.hasMore}">&nbsp;<fmt:message key="of"/>&nbsp;${last} </c:if>
 </span>


### PR DESCRIPTION
Problem: "max" parameter was not sanitized in the classic version.

Solution: Applied sanitization on "max" parameter in classic version and fix the problem.