### PR TITLE
ZCS-11201 Fix counter parameter sanitized issue

### DIFF
--- a/WebRoot/WEB-INF/tags/message/body.tag
+++ b/WebRoot/WEB-INF/tags/message/body.tag
@@ -48,7 +48,7 @@
         <c:choose>
             <c:when test="${zm:boolean(isPrintView)}">
                 <%-- Render inline for printview bug #34780 --%>
-                <div id="iframeBody${counter}" class="MsgBody-html">
+                <div id="iframeBody${fn:escapeXml(counter)}" class="MsgBody-html">
                 ${theBody}
                 </div>
             </c:when>

--- a/WebRoot/WEB-INF/tags/message/displayMessage.tag
+++ b/WebRoot/WEB-INF/tags/message/displayMessage.tag
@@ -342,7 +342,7 @@
         </tr>
     </c:if>
     <tr>
-        <td id="iframeBody${counter}" class=MsgBody valign='top' colspan="${needExtraCol ? 1 : 2}">
+        <td id="iframeBody${fn:escapeXml(counter)}" class=MsgBody valign='top' colspan="${needExtraCol ? 1 : 2}">
             <app:body message="${message}" body="${body}" theBody="${body.isTextHtml ? zm:stripHtmlComments(theBody) : theBody}" mailbox="${mailbox}" counter="${counter}"/>
             <c:set var="bodies" value="${zm:getAdditionalBodies(body,message)}"/>
             <c:if test="${not empty bodies}">

--- a/WebRoot/WEB-INF/tags/message/messagePrintView.tag
+++ b/WebRoot/WEB-INF/tags/message/messagePrintView.tag
@@ -232,7 +232,7 @@
         </tr>
     </c:if>
     <tr>
-        <td id="iframeBody${counter}" style="padding:5px; font-family: monospace" valign='top' colspan="${needExtraCol ? 1 : 2}">
+        <td id="iframeBody${fn:escapeXml(counter)}" style="padding:5px; font-family: monospace" valign='top' colspan="${needExtraCol ? 1 : 2}">
             <app:body message="${message}" body="${body}" theBody="${body.isTextHtml ? zm:stripHtmlComments(theBody) : theBody}" mailbox="${mailbox}" counter="${counter}" isPrintView="${true}"/>
             <c:set var="bodies" value="${zm:getAdditionalBodies(body,message)}"/>
             <c:if test="${not empty bodies}">


### PR DESCRIPTION
Problem: "counter" parameter can accept HTML entity from URL and it needs to be sanitized. 

Solution: "counter" parameter sanitized with the method and after sanitization, it is working fine.