### PR TITLE
ZCS-11204: Fix maddrbooks page parameter sanitized issue

### DIFF
--- a/WebRoot/WEB-INF/tags/button.tag
+++ b/WebRoot/WEB-INF/tags/button.tag
@@ -29,11 +29,11 @@
 <%@ taglib prefix="fmt" uri="com.zimbra.i18n" %>
 <%@ taglib prefix="app" uri="com.zimbra.htmlclient" %>
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
-<c:if test="${not empty text}"><fmt:message key="${text}" var="text"/></c:if>
-<c:if test="${not empty tooltip}"><fmt:message key="${tooltip}" var="tooltip"/></c:if>
+<c:if test="${not empty text}"><fmt:message key="${fn:escapeXml(text)}" var="text"/></c:if>
+<c:if test="${not empty tooltip}"><fmt:message key="${fn:escapeXml(tooltip)}" var="tooltip"/></c:if>
 <c:choose>
-<c:when test="${app:boolean(disabled)}"><c:set var="clazz" value="${clazz} ImgDisabled"/></c:when>
-<c:otherwise> <c:set var="clazz" value="${clazz}"/> </c:otherwise>
+<c:when test="${app:boolean(disabled)}"><c:set var="clazz" value="${fn:escapeXml(clazz)} ImgDisabled"/></c:when>
+<c:otherwise> <c:set var="clazz" value="${fn:escapeXml(clazz)}"/> </c:otherwise>
 </c:choose>
 <c:if test="${app:boolean(width)}"><c:set var="width" value="${width}"/></c:if>
 <c:if test="${not empty src}">

--- a/WebRoot/WEB-INF/tags/img.tag
+++ b/WebRoot/WEB-INF/tags/img.tag
@@ -30,7 +30,7 @@
 <c:if test="${not empty altkey}"><fmt:message key="${altkey}" var="alt"/></c:if>
 <c:if test="${not empty title and not rawtitle}"><fmt:message key="${title}" var="title"/></c:if> 
 <c:if test="${zm:boolean(disabled)}"><c:set var="clazz" value="${clazz} ImgDisabled"/></c:if>
-<app:imginfo var="info" value="${src}" />
+<app:imginfo var="info" value="${fn:escapeXml(src)}" />
 <zm:getUserAgent var="ua" session="false" /><img <c:choose>
         <c:when test="${fn:endsWith(fn:toLowerCase(src),'.png') and ua.isIE and not ua.isIE7up}"> 
             src="<c:url value='/img/zimbra/ImgBlank_1.gif' />"
@@ -40,9 +40,9 @@
         <c:otherwise> src="${info.src}" </c:otherwise>
     </c:choose>
     <c:choose>
-        <c:when test="${not empty title}"> title='${title}' </c:when>
-        <c:when test="${not empty alt}"> title='${alt}' </c:when>
+        <c:when test="${not empty title}"> title='${fn:escapeXml(title)}' </c:when>
+        <c:when test="${not empty alt}"> title='${fn:escapeXml(alt)}' </c:when>
     </c:choose>
     <c:if test="${not empty alt}"> alt="${fn:escapeXml(alt)}" </c:if>
-    <c:if test="${not empty clazz}"> class='${clazz}' </c:if>
-    <c:forEach items="${dynattrs}" var="a"> ${a.key}="${a.value}" </c:forEach> >
+    <c:if test="${not empty clazz}"> class='${fn:escapeXml(clazz)}' </c:if>
+    <c:forEach items="${dynattrs}" var="a"> ${a.key}="${fn:escapeXml(a.value)}" </c:forEach> >


### PR DESCRIPTION
Problem: maddrbooks page URL parameter class and a few more parameters were unsanitized.

Solution: Used fn:escapeXml to sanitize parameters to secure from attacks.