### PR TITLE
ZBUG-896: Always add username to logout redirect URL

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -2771,9 +2771,9 @@ function(ev, relogin) {
                         loginOp: relogin ? 'relogin' : 'logout'
                     }
                 };
-	if (relogin) {
-		urlParams.qsArgs.username = appCtxt.getLoggedInUsername();
-	}
+	// Formerly, only set below when "relogin" is true.
+	urlParams.qsArgs.username = appCtxt.getLoggedInUsername();
+
     if(appCtxt.isExternalAccount()) {
         var vAcctDomain = appCtxt.getUserDomain();
         urlParams.qsArgs.virtualacctdomain = vAcctDomain ? vAcctDomain : "";


### PR DESCRIPTION
**Problem**
During login/logout in classic web UI, the code does not have access to the specific domain of the user.

**Fix**
Send username as parameter of the logout redirect URL, and derive domain from that.

**See Also**
https://github.com/Zimbra/zm-taglib/pull/44

