### PR TITLE
ZBUG-1921: Attribute zimbraFeatureSharingEnabled does not work with classic UI

### DIFF
--- a/WebRoot/js/zimbraMail/share/model/ZmFolderTree.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmFolderTree.js
@@ -92,6 +92,7 @@ function(rootObj, elementType, account) {
 ZmFolderTree.createFromJs =
 function(parent, obj, tree, elementType, path, account) {
 	if (!(obj && obj.id)) { return; }
+	if (obj && obj.owner && !appCtxt.get(ZmSetting.SHARING_ENABLED)) { return; }
 
 	var folder;
 	if (elementType == "search") {


### PR DESCRIPTION
This proposed solution prevents the folder from being created in the model if sharing is disabled.