### PR TITLE
ZBUG-2762: reset search toolbar after shared folder is loaded at login

### DIFF
--- a/WebRoot/js/zimbraMail/abook/model/ZmContactList.js
+++ b/WebRoot/js/zimbraMail/abook/model/ZmContactList.js
@@ -180,7 +180,7 @@ function() {
 		}
 		query = query.replace(/\sor\s$/, '');
 		var sc = appCtxt.getSearchController();
-		sc.setDefaultSearchType(ZmItem.CONTACT);
+		var originalSearchFieldValue = sc.getSearchFieldValue();
 		var params = {
 			query: query,
 			searchFor: ZmItem.CONTACT,
@@ -190,6 +190,7 @@ function() {
 			noRender: true
 		};
 		sc.search(params);
+		sc.setSearchField(originalSearchFieldValue);
 	}
 };
 


### PR DESCRIPTION
**Problem:**
When a shared contact folder exists, default search type becomes Contacts in search toolbar. If zimbraPrefShowSearchString is TRUE, a wrong search string appears in the search toolbar.

**Root cause:**
A function to load shared folder at login has been added in https://github.com/Zimbra/zm-web-client/pull/666. It changes default search type to Contacts. Search string is changed when SearchRequest is executed.

**Fix:**
* Change not to set default search type to Contacts in order to keep a default type.
* Set search string back to the original after SearchRequest is executed.