### PR TITLE
ZBUG-1539: blank search : 'include shared items' shows inid:<number> in search query

### DIFF
--- a/WebRoot/js/zimbraMail/share/view/ZmSearchResultsToolBar.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmSearchResultsToolBar.js
@@ -133,7 +133,7 @@ function(search) {
 	this._settingSearch = true;
 	this._searchField.clear(true);
 	var tokens = search.getTokens();
-	if (tokens && tokens.length) {
+	if (search.query && tokens && tokens.length) {
 		for (var i = 0, len = tokens.length; i < len; i++) {
 			var token = tokens[i], prevToken = tokens[i - 1], nextToken = tokens[i + 1];
 			var showAnd = (prevToken && prevToken.op == ZmParsedQuery.GROUP_CLOSE) || (nextToken && nextToken.op == ZmParsedQuery.GROUP_OPEN);


### PR DESCRIPTION
On performing a blank search using the topmost search bar with 'Include shared items' checked, search results toolbar was being populated with a query of shared items' ids. Changes have been made in share/view/ZmSearchResultsToolbar.js file to setSearch method to perform a check for the user entered search query. The search results toolbar will be populated with the user entered search query only if it exists. 