### PR TITLE
ZBUG-2821 Prevent root folder sharing from webclient

### DIFF
--- a/WebRoot/js/zimbraMail/abook/controller/ZmAddrBookTreeController.js
+++ b/WebRoot/js/zimbraMail/abook/controller/ZmAddrBookTreeController.js
@@ -269,6 +269,14 @@ function() {
 ZmAddrBookTreeController.prototype._shareAddrBookListener = 
 function(ev) {
 	this._pendingActionData = this._getActionedOrganizer(ev);
+	
+	// This is a transient fix untill we find actual steps to reproduce problem and find exact root cause
+	if (this._pendingActionData.id === "1") {
+		var ex = new AjxException("Root folder sharing is not allowed, ignoring action.", AjxException.INVALID_PARAM);
+		appCtxt.getAppController()._handleException(ex);
+		return;
+	}
+
 	appCtxt.getSharePropsDialog().popup(ZmSharePropsDialog.NEW, this._pendingActionData);
 };
 

--- a/WebRoot/js/zimbraMail/briefcase/controller/ZmBriefcaseTreeController.js
+++ b/WebRoot/js/zimbraMail/briefcase/controller/ZmBriefcaseTreeController.js
@@ -220,6 +220,13 @@ function(ev) {
 	var briefcase = this._pendingActionData;
 	var share = null;
 
+	// This is a transient fix untill we find actual steps to reproduce problem and find exact root cause
+	if (briefcase.id === "1") {
+		var ex = new AjxException("Root folder sharing is not allowed, ignoring action.", AjxException.INVALID_PARAM);
+		appCtxt.getAppController()._handleException(ex);
+		return;
+	}
+
 	var sharePropsDialog = appCtxt.getSharePropsDialog();
 	sharePropsDialog.popup(ZmSharePropsDialog.NEW, briefcase, share);
 };

--- a/WebRoot/js/zimbraMail/calendar/controller/ZmCalendarTreeController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmCalendarTreeController.js
@@ -614,6 +614,14 @@ function(ev) {
 ZmCalendarTreeController.prototype._shareCalListener =
 function(ev) {
 	this._pendingActionData = this._getActionedOrganizer(ev);
+	
+	// This is a transient fix untill we find actual steps to reproduce problem and find exact root cause
+	if (this._pendingActionData.id === "1") {
+		var ex = new AjxException("Root folder sharing is not allowed, ignoring action.", AjxException.INVALID_PARAM);
+		appCtxt.getAppController()._handleException(ex);
+		return;
+	}
+
 	appCtxt.getSharePropsDialog().popup(ZmSharePropsDialog.NEW, this._pendingActionData);
 };
 

--- a/WebRoot/js/zimbraMail/prefs/view/ZmSharingPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmSharingPage.js
@@ -563,6 +563,14 @@ function(chooserDialog, org) {
 
 	chooserDialog.popdown();
 	var shareDialog = appCtxt.getSharePropsDialog();
+	
+	// This is a transient fix untill we find actual steps to reproduce problem and find exact root cause
+	if (org.id === "1") {
+		var ex = new AjxException("Root folder sharing is not allowed, ignoring action.", AjxException.INVALID_PARAM);
+		appCtxt.getAppController()._handleException(ex);
+		return;
+	}
+
 	shareDialog.popup(ZmSharePropsDialog.NEW, org);
 };
 

--- a/WebRoot/js/zimbraMail/share/controller/ZmFolderTreeController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmFolderTreeController.js
@@ -716,6 +716,14 @@ function(ev) {
 ZmFolderTreeController.prototype._shareFolderListener =
 function(ev) {
 	this._pendingActionData = this._getActionedOrganizer(ev);
+
+	// This is a transient fix untill we find actual steps to reproduce problem and find exact root cause
+	if (this._pendingActionData.id === "1") {
+		var ex = new AjxException("Root folder sharing is not allowed, ignoring action.", AjxException.INVALID_PARAM);
+		appCtxt.getAppController()._handleException(ex);
+		return;
+	}
+
 	appCtxt.getSharePropsDialog().popup(ZmSharePropsDialog.NEW, this._pendingActionData);
 };
 

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderNotifyDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderNotifyDialog.js
@@ -101,6 +101,14 @@ function() {
 ZmFolderNotifyDialog.prototype._handleAddShareButton =
 function(event) {
 	var sharePropsDialog = appCtxt.getSharePropsDialog();
+
+    // This is a transient fix untill we find actual steps to reproduce problem and find exact root cause
+	if (this._organizer.id === "1") {
+		var ex = new AjxException("Root folder sharing is not allowed, ignoring action.", AjxException.INVALID_PARAM);
+		appCtxt.getAppController()._handleException(ex);
+		return;
+	}
+
 	sharePropsDialog.popup(ZmSharePropsDialog.NEW, this._organizer, null);
 };
 

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
@@ -139,6 +139,14 @@ ZmFolderPropsDialog.prototype._handleEditShare =
 function(event, share) {
 	share = share || Dwt.getObjectFromElement(DwtUiEvent.getTarget(event));
 	var sharePropsDialog = appCtxt.getSharePropsDialog();
+
+	// This is a transient fix untill we find actual steps to reproduce problem and find exact root cause
+	if (share.object.id === "1") {
+		var ex = new AjxException("Root folder sharing is not allowed, ignoring action.", AjxException.INVALID_PARAM);
+		appCtxt.getAppController()._handleException(ex);
+		return;
+	}
+
 	sharePropsDialog.popup(ZmSharePropsDialog.EDIT, share.object, share);
 	return false;
 };
@@ -193,6 +201,14 @@ function(event, share) {
 ZmFolderPropsDialog.prototype._handleAddShareButton =
 function(event) {
 	var sharePropsDialog = appCtxt.getSharePropsDialog();
+
+	// This is a transient fix untill we find actual steps to reproduce problem and find exact root cause
+	if (this._organizer.id === "1") {
+		var ex = new AjxException("Root folder sharing is not allowed, ignoring action.", AjxException.INVALID_PARAM);
+		appCtxt.getAppController()._handleException(ex);
+		return;
+	}
+	
 	sharePropsDialog.popup(ZmSharePropsDialog.NEW, this._organizer, null);
 };
 

--- a/WebRoot/js/zimbraMail/tasks/controller/ZmTaskTreeController.js
+++ b/WebRoot/js/zimbraMail/tasks/controller/ZmTaskTreeController.js
@@ -183,6 +183,14 @@ ZmTaskTreeController.prototype._getActionMenuOps = function() {
 ZmTaskTreeController.prototype._shareTaskFolderListener =
 function(ev) {
 	this._pendingActionData = this._getActionedOrganizer(ev);
+
+	// This is a transient fix untill we find actual steps to reproduce problem and find exact root cause
+	if (this._pendingActionData.id === "1") {
+		var ex = new AjxException("Root folder sharing is not allowed, ignoring action.", AjxException.INVALID_PARAM);
+		appCtxt.getAppController()._handleException(ex);
+		return;
+	}
+
 	appCtxt.getSharePropsDialog().popup(ZmSharePropsDialog.NEW, this._pendingActionData);
 };
 


### PR DESCRIPTION
- There is certain possibility that user wants to share calendar folder but somehow selection changes and share folder dialog takes root folder for sharing
- User is not aware about this and unintentionally share the root folder which is problematic
- So have added a check to ignore action and show error message when user encounters this situation
- We still need to find exact steps to reproduce this problem to reliably investigate it