### PR TITLE
ZCS-11202: Fix title sanitization in html

### DIFF
--- a/WebRoot/WEB-INF/tags/img.tag
+++ b/WebRoot/WEB-INF/tags/img.tag
@@ -40,7 +40,7 @@
         <c:otherwise> src="${info.src}" </c:otherwise>
     </c:choose>
     <c:choose>
-        <c:when test="${not empty title}"> title='${title}' </c:when>
+        <c:when test="${not empty title}"> title='${fn:escapeXml(title)}' </c:when>
         <c:when test="${not empty alt}"> title='${alt}' </c:when>
     </c:choose>
     <c:if test="${not empty alt}"> alt="${fn:escapeXml(alt)}" </c:if>


### PR DESCRIPTION
Problem: "title" was not properly sanitized.

Solution: Sanitized "title" properly for HTML mode.