### PR TITLE
ZCS-12131 Classic UI shows briefcase file preview using native formatter instead of onlyoffice

### DIFF
--- a/WebRoot/js/zimbraMail/briefcase/view/ZmPreviewPaneView.js
+++ b/WebRoot/js/zimbraMail/briefcase/view/ZmPreviewPaneView.js
@@ -658,7 +658,6 @@ ZmPreviewView.prototype.set = function(item) {
 
         this._setupLoading();
 
-        //Send everything trough ConvertD
         restUrl = this._setupErrorCallback(restUrl);
         restUrl += ( restUrl.match(/\?/) ? '&' : '?' ) + "view=html";
     }

--- a/WebRoot/js/zimbraMail/briefcase/view/ZmPreviewPaneView.js
+++ b/WebRoot/js/zimbraMail/briefcase/view/ZmPreviewPaneView.js
@@ -660,7 +660,7 @@ ZmPreviewView.prototype.set = function(item) {
 
         //Send everything trough ConvertD
         restUrl = this._setupErrorCallback(restUrl);
-        restUrl += ( restUrl.match(/\?/) ? '&' : '?' ) + "fmt=native&view=html";
+        restUrl += ( restUrl.match(/\?/) ? '&' : '?' ) + "view=html";
     }
 
     this._iframePreview.setSrc(restUrl);


### PR DESCRIPTION
- Removed `fmt=native` query param from file preview request to show preview using onlyoffice formatter.