### PR TITLE
ZCS-12376: Cross Site Scripting in Login Page

### DIFF
--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -32,11 +32,11 @@
                                                         || (ua.isOsAndroid)
                                                         || (ua.isIos))}"/>
 <c:set var="totpAuthRequired" value="false"/>
-<c:set var="trimmedUserName" value="${fn:trim(param.username)}"/>
+<c:set var="trimmedUserName" value="${fn:trim(fn:escapeXml(param.username))}"/>
 <%--'virtualacctdomain' param is set only for external virtual accounts--%>
 <c:if test="${not empty param.username and not empty param.virtualacctdomain}">
 	<%--External login email address are mapped to internal virtual account--%>
-	<c:set var="trimmedUserName" value="${fn:replace(param.username,'@' ,'.')}@${param.virtualacctdomain}"/>
+	<c:set var="trimmedUserName" value="${fn:replace(fn:escapeXml(param.username),'@' ,'.')}@${param.virtualacctdomain}"/>
 </c:if>
 
 <c:if test="${not empty trimmedUserName}">


### PR DESCRIPTION
Issue: The login page in classic UI supports arbitrary data in the username field so that any attacker can pass special characters in the username and try to execute JavaScript.

This implementation makes use of `fn:escapeXml` to escape the value assigned to **_trimmedUserName_** which is later used for validating the zimbraPasswordAllowUsername rule.