### PR TITLE
ZCS-12397: WCAG | Fixed medium complexity Aria issues part-1

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/ZmCalendarApp.js
+++ b/WebRoot/js/zimbraMail/calendar/ZmCalendarApp.js
@@ -441,13 +441,13 @@ function() {
 
 ZmCalendarApp.prototype._registerOperations =
 function() {
-	ZmOperation.registerOp(ZmId.OP_CAL_LIST_VIEW, {textKey:"list", tooltipKey:"viewCalListTooltip", image:"CalListView", shortcut:ZmKeyMap.CAL_LIST_VIEW});
+	ZmOperation.registerOp(ZmId.OP_CAL_LIST_VIEW, {textKey:"list", tooltipKey:"viewCalListTooltip", image:"CalListView", shortcut:ZmKeyMap.CAL_LIST_VIEW, role: "tab"});
 	ZmOperation.registerOp(ZmId.OP_CAL_REFRESH, {textKey:"refresh", tooltipKey:"calRefreshTooltip", image:"Refresh", shortcut:ZmKeyMap.REFRESH, showImageInToolbar: true});
 	ZmOperation.registerOp(ZmId.OP_CAL_VIEW_MENU, {textKey:"view", image:"Appointment"}, null,
 		AjxCallback.simpleClosure(function(parent) {
 			ZmOperation.addDeferredMenu(ZmCalendarApp.addCalViewMenu, parent);
 	}));
-	ZmOperation.registerOp(ZmId.OP_DAY_VIEW, {textKey:"viewDay", tooltipKey:"viewDayTooltip", image:"DayView", shortcut:ZmKeyMap.CAL_DAY_VIEW});
+	ZmOperation.registerOp(ZmId.OP_DAY_VIEW, {textKey:"viewDay", tooltipKey:"viewDayTooltip", image:"DayView", shortcut:ZmKeyMap.CAL_DAY_VIEW, role: "tab"});
 	ZmOperation.registerOp(ZmId.OP_EDIT_REPLY_ACCEPT, {textKey:"replyAccept", image:"Check"});
 	ZmOperation.registerOp(ZmId.OP_EDIT_REPLY_CANCEL);
 	ZmOperation.registerOp(ZmId.OP_EDIT_REPLY_TENTATIVE, {textKey:"replyTentative", image:"QuestionMark"});
@@ -459,7 +459,7 @@ function() {
 			ZmOperation.addDeferredMenu(ZmCalendarApp.addInviteReplyMenu, parent);
 	}));
 	ZmOperation.registerOp(ZmId.OP_INVITE_REPLY_TENTATIVE, {textKey:"editReply", image:"QuestionMark"});
-	ZmOperation.registerOp(ZmId.OP_MONTH_VIEW, {textKey:"viewMonth", tooltipKey:"viewMonthTooltip", image:"MonthView", shortcut:ZmKeyMap.CAL_MONTH_VIEW});
+	ZmOperation.registerOp(ZmId.OP_MONTH_VIEW, {textKey:"viewMonth", tooltipKey:"viewMonthTooltip", image:"MonthView", shortcut:ZmKeyMap.CAL_MONTH_VIEW, role: "tab"});
 	ZmOperation.registerOp(ZmId.OP_MOUNT_CALENDAR, {textKey:"mountCalendar", image:"GroupSchedule"});
 	ZmOperation.registerOp(ZmId.OP_NEW_ALLDAY_APPT, {textKey:"newAllDayAppt", tooltipKey:"newAllDayApptTooltip", image:"NewAppointment"});
 	ZmOperation.registerOp(ZmId.OP_NEW_APPT, {textKey:"newAppt", tooltipKey:"newApptTooltip", image:"NewAppointment", shortcut:ZmKeyMap.NEW_APPT});
@@ -479,8 +479,8 @@ function() {
 	ZmOperation.registerOp(ZmId.OP_DELETE_APPT_SERIES, {textKey:"deleteApptSeries", image:"Delete"});
 	ZmOperation.registerOp(ZmId.OP_VIEW_APPT_INSTANCE, {textKey:"apptInstance", image:"Appointment"});
 	ZmOperation.registerOp(ZmId.OP_VIEW_APPT_SERIES, {textKey:"apptSeries", image:"Appointment"});
-	ZmOperation.registerOp(ZmId.OP_WEEK_VIEW, {textKey:"viewWeek", tooltipKey:"viewWeekTooltip", image:"WeekView", shortcut:ZmKeyMap.CAL_WEEK_VIEW});
-	ZmOperation.registerOp(ZmId.OP_WORK_WEEK_VIEW, {textKey:"viewWorkWeek", tooltipKey:"viewWorkWeekTooltip", image:"WorkWeekView", shortcut:ZmKeyMap.CAL_WORK_WEEK_VIEW});
+	ZmOperation.registerOp(ZmId.OP_WEEK_VIEW, {textKey:"viewWeek", tooltipKey:"viewWeekTooltip", image:"WeekView", shortcut:ZmKeyMap.CAL_WEEK_VIEW, role: "tab"});
+	ZmOperation.registerOp(ZmId.OP_WORK_WEEK_VIEW, {textKey:"viewWorkWeek", tooltipKey:"viewWorkWeekTooltip", image:"WorkWeekView", shortcut:ZmKeyMap.CAL_WORK_WEEK_VIEW, role: "tab"});
 	ZmOperation.registerOp(ZmId.OP_FORWARD_APPT, {textKey:"forward", tooltipKey:"forward", image:"Forward"});
 	ZmOperation.registerOp(ZmId.OP_FORWARD_APPT_INSTANCE, {textKey:"forwardInstance", tooltipKey:"forwardInstance", image:"Forward"});
 	ZmOperation.registerOp(ZmId.OP_FORWARD_APPT_SERIES, {textKey:"forwardSeries", tooltipKey:"forwardSeries", image:"Forward"});

--- a/WebRoot/js/zimbraMail/share/view/ZmAppChooser.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmAppChooser.js
@@ -327,7 +327,8 @@ function(id, params) {
 		image:		params.image,
 		leftImage:	params.leftImage,
 		rightImage:	params.rightImage,
-		index:		params.index
+		index:		params.index,
+		ariaControls:	'skin_outer_td_main'
 	};
     buttonParams.style = params.style ? params.style : DwtLabel.IMAGE_LEFT;
     var button = new ZmAppButton(buttonParams);

--- a/WebRoot/skins/_base/base3/skin.html
+++ b/WebRoot/skins/_base/base3/skin.html
@@ -85,7 +85,7 @@
 			</div>
 		</div>
 		<div id='skin_tr_main' class="skin_layout_row skin_layout_filler">
-			<div id='skin_outer_td_main' class="skin_layout_cell skin_layout_filler">
+			<div id='skin_outer_td_main' class="skin_layout_cell skin_layout_filler" role="tabpanel">
 				<div class='skin_layout'>
 					<div class="skin_layout_row" id='skin_tr_toolbar'>
 						<div class="skin_layout_cell" id='skin_td_new_button'>

--- a/WebRoot/templates/share/Widgets.template
+++ b/WebRoot/templates/share/Widgets.template
@@ -28,11 +28,11 @@
 <template id='share.Widgets#ZmAppChooserButton' class='ZAppTab'>
 	<$ var buttonClass = data.buttonClass || "AppTab"; $>
 	<table role="presentation" class='ZWidgetTable Z<$=buttonClass$>Table Z<$=buttonClass$>Border'style='table-layout:auto;'>
-		<tr>
-			<td id='${id}_left_icon'  	class='ZLeftIcon ZWidgetIcon'></td>
-			<td id='${id}_title'		class='ZWidgetTitle'></td>
-			<td id='${id}_right_icon' 	class='ZRightIcon ZWidgetIcon'></td>
-			<td id='${id}_dropdown' 	class='ZDropDown'></td>
+		<tr role='none'>
+			<td role='none' id='${id}_left_icon'  	class='ZLeftIcon ZWidgetIcon'></td>
+			<td role='none' id='${id}_title'		class='ZWidgetTitle'></td>
+			<td role='none' id='${id}_right_icon' 	class='ZRightIcon ZWidgetIcon'></td>
+			<td role='none' id='${id}_dropdown' 	class='ZDropDown'></td>
 		</tr>
 	</table>
 </template>


### PR DESCRIPTION
Resolved following issues.

**1.3.1_aria-selectedAttributeMissingForHeaderTABs_Global.docx**
> - Fixed existing code for adding/removing aria-selected='true'.
> - Set role='tabpanel' attribute on app details area.
> - Assigned aria-controls attribute to each app buttons.

**1.3.1_SR is reading the background content even the popup is active.docx**
> - Preventing access of background element by keyboard by focusing on current focused element on dialog if dialog having one element.
> - Set aria-modal='true' to the dialog.

**4.1.2_aria-level wont support for div.docx**
> - Set missing role='heading' attribute to correct element.
> - Updated existing code to set aria-level and aria-labelledby attribute to correct element.
> - Set missing role='heading' attribute to correct element.
> - Updated existing code to set aria-level and aria-labelledby attribute to correct element.

**4.1.2_For role=separator associated aria attribute is not defined.docx**
> - Set aria-orientation='vertical' to separator element which is present on toolbar. 

See the changes of zm-ajax on this pull request #https://github.com/Zimbra/zm-ajax/pull/101