### PR TITLE
Cross site scripting on Error Page

### DIFF
--- a/WebRoot/public/error.jsp
+++ b/WebRoot/public/error.jsp
@@ -46,9 +46,9 @@
     String errorMsg = errorCode+"Msg";
 %>
 
-<c:set var="errCode" value="<%=errorCode%>"/>
-<c:set var="errTitle" value="<%=errorTitle%>"/>
-<c:set var="errMsg" value="<%=errorMsg%>"/>
+<c:set var="errCode" value="${fn:escapeXml(errorCode)}"/>
+<c:set var="errTitle" value="${fn:escapeXml(errorTitle)}"/>
+<c:set var="errMsg" value="${fn:escapeXml(errorMsg)}"/>
 <c:set var="skin" value="<%=skin%>"/>
 <html>
 <head>


### PR DESCRIPTION
There is an XSS problem on the error page in `/public/error.jsp`. The function `escapeXml` was used but in context of `<fmt:message key="${fn:escapeXml(errTitle)}"/>` That seems not to work (if the mail zimbra instatllation has the current version). I tested it on mail.zimbra.com

XSS Proof of concept: https://mail.zimbra.com/public/error.jsp?errCode=%3Cimg%20src=1337core%20onError=alert(%27XSS%27)%3E

I tried to fix it based on this commit: https://github.com/Zimbra/zm-web-client/pull/735/commits/e4be8b2257a5203e92739e497e947fd297073ca6

I have no running dev build to actually test this fix but I hope someone can look into this.