### PR TITLE
ZCS-12531: WCAG | Classic UI | Medium Complexity | Keyboard issues Part - 1

### DIFF
--- a/WebRoot/css/dwt.css
+++ b/WebRoot/css/dwt.css
@@ -2434,6 +2434,10 @@ INPUT.xform_field {
 #ENDIF
 }
 
+.DwtForm {
+	padding: 1px;
+}
+
 .DwtFormRowAdd .ZButtonBorder,
 .DwtFormRowRemove .ZButtonBorder {
 	background-color:transparent;

--- a/WebRoot/js/zimbraMail/abook/view/ZmGroupView.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmGroupView.js
@@ -966,14 +966,24 @@ function() {
 		fields.push(document.getElementById(this._groupNameId));
 	}
 	if (!this._noManualEntry) {
-		fields.push(this._groupMembers);
+		fields.push(this._groupMembersListView);
 	}
+	fields.push(this._addButton);
+	fields.push(this._addAllButton);
+	fields.push(this._locationButton);
+
 	for (var fieldId in this._searchField) {
 		fields.push(this._searchField[fieldId]);
 	}
 	fields.push(this._searchButton);
 	fields.push(this._searchInSelect);
 
+	fields.push(this._listview);
+	fields.push(this._prevButton);
+	fields.push(this._nextButton);
+
+	fields.push(this._addNewButton);
+	fields.push(this._addNewField);
 	return fields;
 };
 
@@ -1644,6 +1654,51 @@ ZmGroupMembersListView.prototype.constructor = ZmGroupMembersListView;
 ZmGroupMembersListView.prototype._getHeaderList =
 function() {
 	return [(new DwtListHeaderItem({field:ZmItem.F_EMAIL, text:ZmMsg.membersLabel, view:this._view}))];
+};
+
+ZmGroupMembersListView.prototype.getKeyMapName =
+function() {
+	return DwtKeyMap.MAP_MENU;
+};
+
+ZmGroupMembersListView.prototype.handleKeyAction = function(actionCode, ev) {
+
+	if (!this.size()) {
+		return false;
+	}
+
+	var isRowElement = this._focusElement.getAttribute('role') === 'option';
+	var isDeleteElement = this._focusElement.classList.value.includes('ImgDelete');
+
+	if (isDeleteElement) {
+		switch (actionCode) {
+			case DwtKeyMap.CANCEL:
+			case DwtKeyMap.PARENTMENU:
+				var rowElement = this._focusElement.parentElement;
+				while (rowElement.getAttribute('role') !== 'option') {
+					rowElement = rowElement.parentElement;
+				}
+				this._setKbFocusElement(rowElement);
+				break;
+			case DwtKeyMap.SELECT:
+				return DwtListView.prototype.handleKeyAction.call(this, actionCode, ev);
+			default:
+				return false;
+		}
+	}
+
+	if (isRowElement) {
+		switch (actionCode) {
+			case DwtKeyMap.SUBMENU:
+				var deleteElement = this._focusElement.getElementsByClassName('ImgDelete')[0];
+				this._setKbFocusElement(deleteElement);
+				break;
+			default:
+				return DwtListView.prototype.handleKeyAction.call(this, actionCode, ev);
+		}
+	}
+
+	return true;
 };
 
 ZmGroupMembersListView.prototype._getCellContents =

--- a/WebRoot/js/zimbraMail/abook/view/ZmGroupView.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmGroupView.js
@@ -1675,7 +1675,7 @@ ZmGroupMembersListView.prototype.handleKeyAction = function(actionCode, ev) {
 			case DwtKeyMap.CANCEL:
 			case DwtKeyMap.PARENTMENU:
 				var rowElement = this._focusElement.parentElement;
-				while (rowElement.getAttribute('role') !== 'option') {
+				while (rowElement && rowElement.getAttribute('role') !== 'option') {
 					rowElement = rowElement.parentElement;
 				}
 				this._setKbFocusElement(rowElement);

--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptAssistantView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptAssistantView.js
@@ -110,6 +110,7 @@ function() {
     this._closeId = this._htmlElId + "_suggest_close";
     this._closeBtn = document.getElementById(this._closeId);
     Dwt.setHandler(this._closeBtn, DwtEvent.ONCLICK, this._closeListener.bind(this));
+    Dwt.setHandler(this._closeBtn, DwtEvent.ONKEYDOWN, ZmApptAssistantView._handleKeyPress.bind(this, this._closeListener));
 
     this._suggestionContainerElId = this._htmlElId + "_suggest_container";
     this._suggestionsContainer = document.getElementById(this._suggestionContainerElId);
@@ -127,9 +128,20 @@ function() {
     this._optionsBtnId = this._htmlElId + "_suggest_options_image";
     this._optionsBtn = document.getElementById(this._optionsBtnId);
     Dwt.setHandler(this._optionsBtn, DwtEvent.ONCLICK, this._prefListener.bind(this));
+    Dwt.setHandler(this._optionsBtn, DwtEvent.ONKEYDOWN, ZmApptAssistantView._handleKeyPress.bind(this, this._prefListener));
 
     this._configureSuggestionWidgets();
+
+    this._tabGroup.addMember([this._optionsBtn, this._closeBtn]);
 };
+
+ZmApptAssistantView._handleKeyPress =
+function (listener, ev) {
+    var keyCode = DwtKeyEvent.getCharCode(ev);
+    if (keyCode === DwtKeyEvent.KEY_RETURN) {
+        listener.call(this);
+    }
+}
 
 ZmApptAssistantView.prototype._configureSuggestionWidgets =
 function() {

--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
@@ -2228,7 +2228,7 @@ function() {
 	if (this._showResources) {
 		this._makeFocusable(this._showResources);
 		Dwt.setHandler(this._showResources, DwtEvent.ONCLICK, ZmCalItemEditView._onClick);
-        Dwt.setHandler(this._showResources, DwtEvent.ONKEYUP, ZmApptEditView._handleKeyPress);
+		Dwt.setHandler(this._showResources, DwtEvent.ONKEYUP, ZmApptEditView._handleKeyPress);
 	}
 	Dwt.setHandler(this._repeatDescField, DwtEvent.ONMOUSEOVER, ZmCalItemEditView._onMouseOver);
 	Dwt.setHandler(this._repeatDescField, DwtEvent.ONMOUSEOUT, ZmCalItemEditView._onMouseOut);

--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
@@ -709,6 +709,7 @@ function() {
 
 ZmApptEditView.prototype._addTabGroupMembers =
 function(tabGroup) {
+    tabGroup.addMember(this.identitySelect);
     tabGroup.addMember(this._subjectField);
     if(this.GROUP_CALENDAR_ENABLED) {
         tabGroup.addMember([this._pickerButton[ZmCalBaseItem.PERSON],
@@ -721,10 +722,10 @@ function(tabGroup) {
                         this._pickerButton[ZmCalBaseItem.LOCATION],
                         this._attInputField[ZmCalBaseItem.LOCATION]]);
     if(this.GROUP_CALENDAR_ENABLED && appCtxt.get(ZmSetting.GAL_ENABLED)) {
-        tabGroup.addMember([this._pickerButton[ZmCalBaseItem.EQUIPMENT],
-                            this._attInputField[ZmCalBaseItem.EQUIPMENT],
-                            this._showResources,
-                            this._suggestLocation]);
+        tabGroup.addMember([this._showResources,
+                            this._suggestLocation,
+                            this._pickerButton[ZmCalBaseItem.EQUIPMENT],
+                            this._attInputField[ZmCalBaseItem.EQUIPMENT]]);
     }
     tabGroup.addMember([this._startDateField,
                         this._startDateButton,
@@ -744,11 +745,10 @@ function(tabGroup) {
                         this._privateCheckbox,
 
                         this._schButton,
-                        this._scheduleView,
+                        this._scheduleView._tabGroup,
                         this.getHtmlEditor(),
-
-                        this._suggestTime,
-                        this._suggestLocation]);
+                        this._scheduleAssistant._tabGroup
+                    ]);
 };
 
 ZmApptEditView.prototype._finishReset =
@@ -1269,6 +1269,7 @@ function(width) {
     this._makeFocusable(this._schButton);
     this._makeFocusable(this._schImage);
     Dwt.setHandler(this._schButton, DwtEvent.ONCLICK, ZmCalItemEditView._onClick);
+    Dwt.setHandler(this._schButton, DwtEvent.ONKEYUP, ZmApptEditView._handleKeyPress);
     Dwt.setHandler(this._schImage, DwtEvent.ONCLICK, ZmCalItemEditView._onClick);
 
 	this._resourcesContainer = document.getElementById(this._htmlElId + "_resourcesContainer");
@@ -2204,6 +2205,14 @@ function(addrType) {
     this.handleAttendeeChange();
 };
 
+ZmApptEditView._handleKeyPress =
+function (ev) {
+    var keyCode = DwtKeyEvent.getCharCode(ev);
+    if (keyCode === DwtKeyEvent.KEY_RETURN) {
+        ZmCalItemEditView._onClick(ev);
+    }
+}
+
 ZmApptEditView.prototype._addEventHandlers =
 function() {
 	var edvId = AjxCore.assignId(this);
@@ -2214,10 +2223,12 @@ function() {
 	if (this._showOptional) {
 		this._makeFocusable(this._showOptional);
 		Dwt.setHandler(this._showOptional, DwtEvent.ONCLICK, ZmCalItemEditView._onClick);
+        Dwt.setHandler(this._showOptional, DwtEvent.ONKEYUP, ZmApptEditView._handleKeyPress);
 	}
 	if (this._showResources) {
 		this._makeFocusable(this._showResources);
 		Dwt.setHandler(this._showResources, DwtEvent.ONCLICK, ZmCalItemEditView._onClick);
+        Dwt.setHandler(this._showResources, DwtEvent.ONKEYUP, ZmApptEditView._handleKeyPress);
 	}
 	Dwt.setHandler(this._repeatDescField, DwtEvent.ONMOUSEOVER, ZmCalItemEditView._onMouseOver);
 	Dwt.setHandler(this._repeatDescField, DwtEvent.ONMOUSEOUT, ZmCalItemEditView._onMouseOut);
@@ -2228,9 +2239,11 @@ function() {
     if (this.GROUP_CALENDAR_ENABLED) {
         this._makeFocusable(this._suggestTime);
         Dwt.setHandler(this._suggestTime, DwtEvent.ONCLICK, ZmCalItemEditView._onClick);
+        Dwt.setHandler(this._suggestTime, DwtEvent.ONKEYUP, ZmApptEditView._handleKeyPress);
     }
     this._makeFocusable(this._suggestLocation);
     Dwt.setHandler(this._suggestLocation, DwtEvent.ONCLICK, ZmCalItemEditView._onClick);
+    Dwt.setHandler(this._suggestLocation, DwtEvent.ONKEYUP, ZmApptEditView._handleKeyPress);
     this._makeFocusable(this._locationStatusAction);
     Dwt.setHandler(this._locationStatusAction, DwtEvent.ONCLICK, ZmCalItemEditView._onClick);
 

--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
@@ -2223,7 +2223,7 @@ function() {
 	if (this._showOptional) {
 		this._makeFocusable(this._showOptional);
 		Dwt.setHandler(this._showOptional, DwtEvent.ONCLICK, ZmCalItemEditView._onClick);
-        Dwt.setHandler(this._showOptional, DwtEvent.ONKEYUP, ZmApptEditView._handleKeyPress);
+		Dwt.setHandler(this._showOptional, DwtEvent.ONKEYUP, ZmApptEditView._handleKeyPress);
 	}
 	if (this._showResources) {
 		this._makeFocusable(this._showResources);

--- a/WebRoot/js/zimbraMail/calendar/view/ZmAttendeePicker.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmAttendeePicker.js
@@ -279,7 +279,31 @@ function(appt, mode, isDirty, apptComposeMode) {
 
     // init listeners
     this.setButtonListener(DwtDialog.OK_BUTTON, new AjxListener(this, this._okButtonListener));
-    this.setButtonListener(DwtDialog.CANCEL_BUTTON, new AjxListener(this, this._cancelButtonListener));    
+    this.setButtonListener(DwtDialog.CANCEL_BUTTON, new AjxListener(this, this._cancelButtonListener));
+
+	this._tabGroup.removeAllMembers();
+	for (var i in this._searchFieldIds) {
+		var id = this._searchFieldIds[i];
+		var element = document.getElementById(id);
+		if (element) {
+			this.addMemberInTabGroup(element);
+		}
+	}
+
+	this.addMemberInTabGroup(this._searchButton);
+	this.addMemberInTabGroup(document.getElementById(this._multLocsCheckboxId));
+	this.addMemberInTabGroup(this._prevButton);
+	this.addMemberInTabGroup(this._nextButton);
+	this.addMemberInTabGroup(this._chooser._compositeTabGroup.__members);
+	this.addMemberInTabGroup(this.getButton(DwtDialog.OK_BUTTON));
+	this.addMemberInTabGroup(this.getButton(DwtDialog.CANCEL_BUTTON));
+};
+
+ZmAttendeePicker.prototype.addMemberInTabGroup =
+function (member) {
+	if (member) {
+		this._tabGroup.addMember(member);
+	}
 };
 
 ZmAttendeePicker.prototype.resize =
@@ -474,7 +498,7 @@ function(id, html, i, addButton, addMultLocsCheckbox) {
 		html[i++] = "<td class='ZmFieldLabelRight'>";
 		html[i++] = ZmMsg[ZmAttendeePicker.SF_LABEL[id]];
 		html[i++] = ":</td><td>";
-		html[i++] = "<input type='text' autocomplete='off' size=30 nowrap id='";
+		html[i++] = "<input type='text' tabindex='0' autocomplete='off' size=30 nowrap id='";
 		html[i++] = this._searchFieldIds[id];
 		html[i++] = "' />";
 		html[i++] = "</td>";
@@ -507,7 +531,7 @@ function(id, html, i, addButton, addMultLocsCheckbox) {
             html[i++] = "<td></td>";
         }
 		html[i++] = "<td><table role='presentation'><tr><td>";
-		html[i++] = "<input type='checkbox' id='";
+		html[i++] = "<input type='checkbox' tabindex='0' id='";
 		html[i++] = this._multLocsCheckboxId;
 		html[i++] = "' /></td><td class='ZmFieldLabelLeft'><label for='";
 		html[i++] = this._multLocsCheckboxId;

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalItemEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalItemEditView.js
@@ -807,7 +807,7 @@ function(width) {
 
 ZmCalItemEditView._keyPressOnRemiderConfigure =
 function(ev) {
-	var keyCode = DwtKeyEvent.getCharCode(ev);
+    var keyCode = DwtKeyEvent.getCharCode(ev);
     if (keyCode === DwtKeyEvent.KEY_RETURN) {
         ev.target.onclick();
     }

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalItemEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalItemEditView.js
@@ -790,6 +790,7 @@ function(width) {
         // NOTE: prefs app is launched.
         this._reminderConfigure.getHtmlElement().onclick = AjxCallback.simpleClosure(skin.gotoPrefs, skin, "NOTIFICATIONS");
         this._reminderConfigure.replaceElement(document.getElementById(this._htmlElId+"_reminderConfigure"));
+		Dwt.setHandler(this._reminderConfigure.getHtmlElement(), DwtEvent.ONKEYDOWN, ZmCalItemEditView._keyPressOnRemiderConfigure);
 		this._setEmailReminderControls();
 	    var settings = appCtxt.getSettings();
         var listener = new AjxListener(this, this._settingChangeListener);
@@ -802,6 +803,14 @@ function(width) {
 
     this._notesHtmlEditor = new ZmHtmlEditor(this, null, null, this._composeMode, null, this._htmlElId + "_notes");
     this._notesHtmlEditor.addOnContentInitializedListener(new AjxCallback(this,this.resize));
+};
+
+ZmCalItemEditView._keyPressOnRemiderConfigure =
+function(ev) {
+	var keyCode = DwtKeyEvent.getCharCode(ev);
+    if (keyCode === DwtKeyEvent.KEY_RETURN) {
+        ev.target.onclick();
+    }
 };
 
 ZmCalItemEditView.prototype._handleReminderOnBlur =

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalendarPrefsPage.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalendarPrefsPage.js
@@ -698,9 +698,12 @@ ZmWorkHours.prototype._openCustomizeDlg =
 function() {
     if(!this._customDlg) {
         this._customDlg = new ZmCustomWorkHoursDlg(appCtxt.getShell(), "CustomWorkHoursDlg", this._workHours);
+        this._customDlg._tabGroup.removeAllMembers();
         this._customDlg.initialize(this._workHours);
         this._customDlg.setButtonListener(DwtDialog.OK_BUTTON, new AjxListener(this, this._closeCustomDialog, [true]));
         this._customDlg.setButtonListener(DwtDialog.CANCEL_BUTTON, new AjxListener(this, this._closeCancelCustomDialog, [false]));
+        this._customDlg._tabGroup.addMember(this._customDlg.getButton(DwtDialog.OK_BUTTON));
+        this._customDlg._tabGroup.addMember(this._customDlg.getButton(DwtDialog.CANCEL_BUTTON));
     }
     this._customDlg.popup();
 };
@@ -892,6 +895,10 @@ ZmCustomWorkHoursDlg.prototype.initialize = function(workHours) {
 	    checkbox.setSelected(workHours[i].isWorkingDay);
         checkbox.addSelectionListener(new AjxListener(this, this._setTimeInputEnabled, [i, checkbox]));
         this._workDaysCheckBox.push(checkbox);
+
+        this._tabGroup.addMember(checkbox);
+        this._tabGroup.addMember([startTimeSelect.getTabGroupMember(),
+            endTimeSelect.getTabGroupMember()]);
     }
 };
 

--- a/WebRoot/js/zimbraMail/calendar/view/ZmFreeBusySchedulerView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmFreeBusySchedulerView.js
@@ -491,7 +491,7 @@ function(isAllAttendees, organizer, drawBorder, index, updateTabGroup, setFocus)
 				button.dwtInputField = dwtInputField;
 			}
 			dwtInputField.reparentHtmlElement(sched.dwtNameId);
-            this._tabGroup.addMember(dwtInputField);
+			this._tabGroup.addMember(dwtInputField);
 		}
 
 		sched.ptstObj = document.getElementById(sched.dwtNameId+"_ptst");

--- a/WebRoot/js/zimbraMail/calendar/view/ZmFreeBusySchedulerView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmFreeBusySchedulerView.js
@@ -78,6 +78,7 @@ ZmFreeBusySchedulerView = function(parent, attendees, controller, dateInfo, appt
     this._isPageless = false;
 
     this._fbConflict = {};
+    this._tabGroup = new DwtTabGroup(this.toString());
 
     //this._fbCache = controller.getApp().getFreeBusyCache();
     this._fbCache = parent.getFreeBusyCache();
@@ -472,6 +473,7 @@ function(isAllAttendees, organizer, drawBorder, index, updateTabGroup, setFocus)
             button.setImage("AttendeesRequired");
             button.setMenu(new AjxListener(this, this._getAttendeeRoleMenu, [index]));
             sched.btnObj = button;
+            this._tabGroup.addMember(button);
 		}
 		// add DwtInputField
 		var nameDiv = document.getElementById(sched.dwtNameId);
@@ -489,6 +491,7 @@ function(isAllAttendees, organizer, drawBorder, index, updateTabGroup, setFocus)
 				button.dwtInputField = dwtInputField;
 			}
 			dwtInputField.reparentHtmlElement(sched.dwtNameId);
+            this._tabGroup.addMember(dwtInputField);
 		}
 
 		sched.ptstObj = document.getElementById(sched.dwtNameId+"_ptst");

--- a/WebRoot/js/zimbraMail/calendar/view/ZmLocationSuggestionView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmLocationSuggestionView.js
@@ -78,6 +78,7 @@ function(params) {
     this._emailToDivIdMap = {};
     this._items = params.locationInfo.locations;
     ZmListView.prototype.set.call(this, params.locationInfo.locations);
+    this.parent._tabGroup.addMember(this);
 };
 
 ZmLocationSuggestionView.prototype.handleLocationOverflow =
@@ -113,8 +114,29 @@ function() {
 ZmLocationSuggestionView.prototype.setWarning =
 function(warning) {
     this._warning = warning;
-}
+};
 
+// To prevent set of current focus location (when user navigate location using keyboard) as appointment's location.
+ZmLocationSuggestionView.prototype._emulateSingleClick =
+function() {
+};
+
+ZmLocationSuggestionView.prototype.handleKeyAction =
+function (actionCode, ev) {
+
+    if (!this.size()) {
+        return false;
+    }
+    switch (actionCode) {
+        case DwtKeyMap.SELECT:
+            this._itemSelected(ev.target, ev);
+            break;
+        default:
+            return ZmListView.prototype.handleKeyAction.call(this, actionCode, ev);
+    }
+
+    return true;
+};
 
 ZmLocationSuggestionView.prototype._renderList =
 function(list, noResultsOk, doAdd) {

--- a/WebRoot/js/zimbraMail/calendar/view/ZmScheduleAssistantView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmScheduleAssistantView.js
@@ -39,6 +39,7 @@ ZmScheduleAssistantView = function(parent, controller, apptEditView, closeCallba
     this._fbStat = new AjxVector();
     this._fbStatMap = {};
     this._schedule = {};
+    this._tabGroup = new DwtTabGroup(this.toString());
 
 	ZmApptAssistantView.call(this, parent, controller, apptEditView, closeCallback);
 };

--- a/WebRoot/js/zimbraMail/calendar/view/ZmSuggestionsView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmSuggestionsView.js
@@ -51,6 +51,7 @@ ZmSuggestionsView = function(parent, controller, apptEditView, id, showHeaders, 
     this.setMultiSelect(false);
 
     this._showHeaders = showHeaders;
+    this._tabMember = null;
 };
 
 ZmSuggestionsView.prototype = new ZmListView;
@@ -66,6 +67,9 @@ function(params) {
     this._items = params.items;
     this._itemIndex = params.itemIndex;
     ZmListView.prototype.set.call(this, params.list);
+
+    this.parent._tabGroup.replaceMember(this._tabMember, this);
+    this._tabMember = this;
 };
 
 ZmSuggestionsView.prototype._setNoResultsHtml =

--- a/WebRoot/js/zimbraMail/calendar/view/ZmTimeSuggestionPrefDialog.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmTimeSuggestionPrefDialog.js
@@ -132,6 +132,27 @@ function(account) {
 		// it and resets it to an offscreen value.
 		el.style.left = "0px";
 	}
+
+    this._tabGroup.removeAllMembers();
+
+    this.addMemberInTabGroup(document.getElementById(this._htmlElId + '_' + ZmTimeSuggestionPrefDialog.MY_WORKING_HOURS_FIELD));
+    this.addMemberInTabGroup(document.getElementById(this._htmlElId + '_' + ZmTimeSuggestionPrefDialog.OTHERS_WORKING_HOURS_FIELD));
+    this.addMemberInTabGroup(this._recurrenceSelect);
+    this.addMemberInTabGroup(document.getElementById(this._htmlElId + '_name'));
+    this.addMemberInTabGroup(document.getElementById(this._htmlElId + '_capacity'));
+    this.addMemberInTabGroup(document.getElementById(this._htmlElId + '_desc'));
+    this.addMemberInTabGroup(document.getElementById(this._htmlElId + '_site'));
+    this.addMemberInTabGroup(document.getElementById(this._htmlElId + '_building'));
+    this.addMemberInTabGroup(document.getElementById(this._htmlElId + '_floor'));
+    this.addMemberInTabGroup(this.getButton(DwtDialog.OK_BUTTON));
+	this.addMemberInTabGroup(this.getButton(DwtDialog.CANCEL_BUTTON));
+};
+
+ZmTimeSuggestionPrefDialog.prototype.addMemberInTabGroup =
+function (member) {
+	if (member) {
+		this._tabGroup.addMember(member);
+	}
 };
 
 ZmTimeSuggestionPrefDialog.prototype.popdown =

--- a/WebRoot/js/zimbraMail/calendar/view/ZmTimeSuggestionPrefDialog.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmTimeSuggestionPrefDialog.js
@@ -145,7 +145,7 @@ function(account) {
     this.addMemberInTabGroup(document.getElementById(this._htmlElId + '_building'));
     this.addMemberInTabGroup(document.getElementById(this._htmlElId + '_floor'));
     this.addMemberInTabGroup(this.getButton(DwtDialog.OK_BUTTON));
-	this.addMemberInTabGroup(this.getButton(DwtDialog.CANCEL_BUTTON));
+    this.addMemberInTabGroup(this.getButton(DwtDialog.CANCEL_BUTTON));
 };
 
 ZmTimeSuggestionPrefDialog.prototype.addMemberInTabGroup =

--- a/WebRoot/js/zimbraMail/calendar/view/ZmTimeSuggestionView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmTimeSuggestionView.js
@@ -328,12 +328,24 @@ function() {
 	div.innerHTML = AjxTemplate.expand("calendar.Appointment#TimeSuggestion-NoSuggestions", subs);
 	this._addRow(div);
 
+    var oldSearchAllLink = this._searchAllLink;
     //add event handlers for no results action link
     this._searchAllId = this.getHTMLElId() + "_showall";
     this._searchAllLink = document.getElementById(this._searchAllId);
     if(this._searchAllLink) {
         this._searchAllLink._viewId = AjxCore.assignId(this);
-        Dwt.setHandler(this._searchAllLink, DwtEvent.ONCLICK, AjxCallback.simpleClosure(ZmTimeSuggestionView._onClick, this, this._searchAllLink));
+        this.parent._tabGroup.replaceMember(oldSearchAllLink, this._searchAllLink);
+        var callBack = AjxCallback.simpleClosure(ZmTimeSuggestionView._onClick, this, this._searchAllLink);
+        Dwt.setHandler(this._searchAllLink, DwtEvent.ONCLICK, callBack);
+        Dwt.setHandler(this._searchAllLink, DwtEvent.ONKEYUP, ZmApptAssistantView._handleKeyPress.bind(this, callBack));
+    }
+};
+
+ZmTimeSuggestionView._handleKeyPress =
+function (listener, ev) {
+    var keyCode = DwtKeyEvent.getCharCode(ev);
+    if (keyCode === DwtKeyEvent.KEY_RETURN) {
+        listener.call(this);
     }
 };
 

--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmMailPrefsPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmMailPrefsPage.js
@@ -151,7 +151,9 @@ function() {
 
 
     this._startDateField = Dwt.byId(this._htmlElId + "_VACATION_FROM1");
+	this._startDateField.setAttribute('parentid', this._htmlElId);
 	this._endDateField = Dwt.byId(this._htmlElId + "_VACATION_UNTIL1");
+	this._endDateField.setAttribute('parentid', this._htmlElId);
 
 	if (this._startDateField && this._endDateField) {
 		this._startDateVal = Dwt.byId(this._htmlElId + "_VACATION_FROM");

--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmMailPrefsPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmMailPrefsPage.js
@@ -151,13 +151,14 @@ function() {
 
 
     this._startDateField = Dwt.byId(this._htmlElId + "_VACATION_FROM1");
-	this._startDateField.setAttribute('parentid', this._htmlElId);
 	this._endDateField = Dwt.byId(this._htmlElId + "_VACATION_UNTIL1");
-	this._endDateField.setAttribute('parentid', this._htmlElId);
 
 	if (this._startDateField && this._endDateField) {
 		this._startDateVal = Dwt.byId(this._htmlElId + "_VACATION_FROM");
 		this._endDateVal = Dwt.byId(this._htmlElId + "_VACATION_UNTIL");
+		this._startDateField.setAttribute('parentid', this._htmlElId);
+		this._endDateField.setAttribute('parentid', this._htmlElId);
+
         if(this._startDateVal.value.length < 15){
             this._startDateVal.value = appCtxt.get(ZmSetting.VACATION_FROM);
         }

--- a/WebRoot/js/zimbraMail/prefs/view/ZmFilterRulesView.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmFilterRulesView.js
@@ -60,6 +60,7 @@ function() {
 
 ZmFilterRulesView.prototype.showMe =
 function() {
+	this.setZIndex(Dwt.Z_VIEW);
 	Dwt.setTitle(this._title);
 	var section = ZmPref.getPrefSectionWithPref(ZmSetting.FILTERS);
 
@@ -94,6 +95,13 @@ function() {
 	this._chooser.targetListView.setSize(Dwt.CLEAR, Dwt.DEFAULT);
 	this._controller.initialize(this._toolbar, this._chooser.activeListView, this._chooser.notActiveListView);
 	this.hasRendered = true;
+	this._tabGroup.addMember([this._chooser.targetListView, 
+		this._chooser._transferButton,
+		this._chooser._removeButton,
+		this._chooser._moveUpButton,
+		this._chooser._moveDownButton,
+		this._chooser.sourceListView
+	]);
 };
 
 /**

--- a/WebRoot/js/zimbraMail/prefs/view/ZmPreferencesPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmPreferencesPage.js
@@ -206,6 +206,9 @@ function() {
 		var element = elements[i];
 		var control = DwtControl.fromElement(element);
 
+		if (control instanceof ZmFilterRulesView) {
+			continue;
+		} 
 		// add the child to our tab group
 		if (control && control.parent == this) {
 			this._tabGroup.addMember(control.getTabGroupMember());

--- a/WebRoot/js/zimbraMail/prefs/view/ZmPriorityMessageFilterDialog.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmPriorityMessageFilterDialog.js
@@ -29,7 +29,10 @@ ZmPriorityMessageFilterDialog = function() {
 	this.setContent(this._contentHtml());
 	this._initialize();
 	var okButton = this.getButton(DwtDialog.OK_BUTTON);
+	var cancelButton = this.getButton(DwtDialog.CANCEL_BUTTON);
 	okButton.setText(ZmMsg.save);
+	this._tabGroup.addMember([okButton, cancelButton]);
+
 	this.setButtonListener(DwtDialog.OK_BUTTON, new AjxListener(this, this._okButtonListener));
 	this._rules = AjxDispatcher.run("GetFilterRules");
 };
@@ -67,6 +70,7 @@ function() {
 	this._priorityMessageForm.appendElement(div);
 	
 	this._moveMsgIntoStream = this._priorityMessageForm.getControl("MOVE_MSG_STREAM");
+	this._moveMsgIntoStream.getHtmlElement().style.margin = '1px';
 	this._notToMe = this._priorityMessageForm.getControl("NOT_TO_ME");
 	this._selectField = this._priorityMessageForm.getControl("SELECT_FIELD");
 	this._selectField.fixedButtonWidth();
@@ -80,11 +84,30 @@ function() {
 	this._streamHash[ZmFilterRule.TEST_ADDRBOOK] = {control: this._notInMyAddrBk, negative: true, headerValue: "from"};
 	this._streamHash[ZmFilterRule.TEST_ME] = {control: this._notToMe, negative: true, headerValue: "to"};
 	
-    this._advancedControls = new DwtText({parent:this,className:"FakeAnchor"});
-    this._advancedControls.setText(ZmMsg.advancedControls);
-    this._advancedControls.getHtmlElement().onclick = advancedListener;
-    this._advancedControls.replaceElement(document.getElementById("PriorityInboxAdvancedControls"));
+	this._advancedControls = new DwtText({parent:this,className:"FakeAnchor"});
+	this._advancedControls.setText(ZmMsg.advancedControls);
+	this._advancedControls.getHtmlElement().onclick = advancedListener;
+	Dwt.setHandler(this._advancedControls.getHtmlElement(), DwtEvent.ONKEYDOWN, ZmPriorityMessageFilterDialog._handelKeypress.bind(this));
+	this._advancedControls.replaceElement(document.getElementById("PriorityInboxAdvancedControls"));
+
+	this._tabGroup.removeAllMembers();
+	this._tabGroup.addMember([this._moveMsgIntoStream._inputEl,
+		this._dlSubscribedTo._inputEl,
+		this._massMarketing._inputEl,
+		this._notToMe._inputEl,
+		this._selectField,
+		this._notInMyAddrBk._inputEl,
+		this._advancedControls.getHtmlElement()
+	]);
 };
+
+ZmPriorityMessageFilterDialog._handelKeypress =
+function(ev) {
+	var keyCode = DwtKeyEvent.getCharCode(ev);
+	if (keyCode === DwtKeyEvent.KEY_RETURN) {
+		this._onAdvancedControls();
+	}
+}
 
 ZmPriorityMessageFilterDialog.prototype.popup =
 function() {

--- a/WebRoot/js/zimbraMail/prefs/view/ZmSharingPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmSharingPage.js
@@ -409,7 +409,6 @@ function() {
 	this._shareForm = new DwtForm(params);
 	var shareFormDiv = document.getElementById(this._pageId + "_shareForm");
 	shareFormDiv.appendChild(this._shareForm.getHtmlElement());
-	this._shareForm.getHtmlElement().style.padding = '1px'
 
 	this._compositeTabGroup.removeMember(this._shareForm);
 	this._compositeTabGroup.addMember([this._shareForm.getControl(ZmSharingView.ID_GROUP),
@@ -484,8 +483,10 @@ function() {
 	}
 
 	this._compositeTabGroup.removeMember(this._grantForm);
-	this._compositeTabGroup.addMember([this._grantForm.getControl(ZmSharingView.ID_FOLDER_TYPE), 
-		this._grantForm.getControl(ZmSharingView.ID_SHARE_BUTTON)]);
+	this._compositeTabGroup.addMember([
+		this._grantForm.getControl(ZmSharingView.ID_FOLDER_TYPE), 
+		this._grantForm.getControl(ZmSharingView.ID_SHARE_BUTTON)
+	]);
 
 	appCtxt.getFolderTree().addChangeListener(new AjxListener(this, this._folderTreeChangeListener));
 };

--- a/WebRoot/js/zimbraMail/prefs/view/ZmSharingPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmSharingPage.js
@@ -409,6 +409,14 @@ function() {
 	this._shareForm = new DwtForm(params);
 	var shareFormDiv = document.getElementById(this._pageId + "_shareForm");
 	shareFormDiv.appendChild(this._shareForm.getHtmlElement());
+	this._shareForm.getHtmlElement().style.padding = '1px'
+
+	this._compositeTabGroup.removeMember(this._shareForm);
+	this._compositeTabGroup.addMember([this._shareForm.getControl(ZmSharingView.ID_GROUP),
+		this._shareForm.getControl(ZmSharingView.ID_USER),
+		this._shareForm.getControl(ZmSharingView.ID_OWNER),
+		this._shareForm.getControl(ZmSharingView.ID_FIND_BUTTON)
+	]);
 
 	// form for creating a new share
 	var options = [];
@@ -474,6 +482,10 @@ function() {
 		this._acAddrSelectList.handle(inputCtrl.getInputElement(), inputCtrl._htmlElId);
 		inputCtrl.setAutocompleteListView(this._acAddrSelectList);
 	}
+
+	this._compositeTabGroup.removeMember(this._grantForm);
+	this._compositeTabGroup.addMember([this._grantForm.getControl(ZmSharingView.ID_FOLDER_TYPE), 
+		this._grantForm.getControl(ZmSharingView.ID_SHARE_BUTTON)]);
 
 	appCtxt.getFolderTree().addChangeListener(new AjxListener(this, this._folderTreeChangeListener));
 };

--- a/WebRoot/js/zimbraMail/prefs/view/ZmZimletsPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmZimletsPage.js
@@ -516,6 +516,28 @@ function(list) {
     }
 };
 
+ZmPrefZimletListView.prototype.handleKeyAction = function(actionCode, ev) {
+
+	if (!this.size()) {
+		return false;
+	}
+
+	switch (actionCode) {
+		case DwtKeyMap.SELECT_NEXT:
+			if (ev.charCode === 32) {
+				ev.button = DwtMouseEvent.LEFT;
+				ev.target = ev.target.querySelector('input');
+				this._itemClicked(ev.target, ev);
+				var checked = ev.target.checked;
+				ev.target.checked = !checked;
+				break;
+			}
+		default:
+			return DwtListView.prototype.handleKeyAction.call(this, actionCode, ev);
+	}
+	return true;
+};
+
 ZmPrefZimletListView.prototype._handleZimletsLoaded = function(evt) {
     this._zimletsLoaded = true;
     var array = this.parent.getZimletsArray();

--- a/WebRoot/templates/calendar/Appointment.template
+++ b/WebRoot/templates/calendar/Appointment.template
@@ -223,10 +223,10 @@
 	<div id='${id}_suggest_container' class='ZmSuggestContainer'>
 		<div class='ZmSuggestHeader'>
 			<div id='${id}_suggestion_name'			class='ZmSuggestLabel'>&nbsp;</div>
-			<div id='${id}_suggest_options_image'	class='ZmSuggestOptionsButton'>
+			<div id='${id}_suggest_options_image' tabindex='0' class='ZmSuggestOptionsButton'>
 				<$=AjxImg.getImageHtml("Options")$>
 			</div>
-			<div id='${id}_suggest_close'			class='ZmSuggestCloseButton'>
+			<div id='${id}_suggest_close'	tabindex='0' class='ZmSuggestCloseButton'>
 				<$=AjxImg.getImageHtml("CloseGray")$>
 			</div>
 		</div>
@@ -1134,7 +1134,7 @@
 
 
 <template id='calendar.Appointment#TimeSuggestion'>
-	<table role="presentation" id='${id}' width="100%" class="Row ZPropertySheet" cellspacing="6">
+	<table role="presentation" id='${id}' width="100%" tabindex="0" class="Row ZPropertySheet" cellspacing="6">
 		<tr>
 			<td width="16" ><$= AjxImg.getImageHtml(data.attendeeImage) $></td>
 			<td><$= data.timeLabel $></td>
@@ -1179,7 +1179,7 @@
 <template id='calendar.Appointment#TimeSuggestion-NoSuggestions'>
 	<div class='NoSuggestions'>
 		<div style='margin-bottom:2em;'>${message}</div>
-		<span class="FakeAnchor" id="${id}_showall"><$= ZmMsg.showTimesAnyway $></span>
+		<span class="FakeAnchor" tabindex="0" id="${id}_showall"><$= ZmMsg.showTimesAnyway $></span>
 	</div>
 </template>
 
@@ -1222,14 +1222,14 @@
         </tr>
         <tr>
             <td class="ZmFieldLabelRight"><$= ZmMsg.suggestionTimes $>:</td>
-            <td align="right"><input type="checkbox" id="${id}_my_working_hrs_pref"></td>
+            <td align="right"><input type="checkbox" tabindex="0" id="${id}_my_working_hrs_pref"></td>
             <td width="100%">
                 <label for="${id}_my_working_hrs_pref"><$= ZmMsg.schedulerPrefMyWorkingHours $></label>
             </td>
         </tr>
         <tr>
             <td>&nbsp;</td>
-            <td align="right"><input type="checkbox" id="${id}_others_working_hrs_pref"></td>
+            <td align="right"><input type="checkbox" tabindex="0" id="${id}_others_working_hrs_pref"></td>
             <td width="100%">
                 <label for="${id}_others_working_hrs_pref"><$= ZmMsg.schedulerPrefOtherWorkingHours $></label>
             </td>
@@ -1250,21 +1250,21 @@
         </tr>
         <tr>
             <td class='ZmFieldLabelRight'><$= ZmMsg._name $>:</td>
-            <td><input type="text" id="${id}_name" nowrap="" size="30" autocomplete="off"></td>
+            <td><input type="text" tabindex="0" id="${id}_name" nowrap="" size="30" autocomplete="off"></td>
             <td class='ZmFieldLabelRight' style='padding-left:2em;'><$= ZmMsg.site $>:</td>
-            <td><input type="text" id="${id}_site" nowrap="" size="30" autocomplete="off"></td>
+            <td><input type="text" tabindex="0" id="${id}_site" nowrap="" size="30" autocomplete="off"></td>
         </tr>
         <tr>
             <td class='ZmFieldLabelRight'><$= ZmMsg.minimumCapacity $>:</td>
-            <td><input type="text" id="${id}_capacity" nowrap="" size="30" autocomplete="off"></td>
+            <td><input type="text" tabindex="0" id="${id}_capacity" nowrap="" size="30" autocomplete="off"></td>
             <td class='ZmFieldLabelRight' style='padding-left:2em;'><$= ZmMsg.building $>:</td>
-            <td><input type="text" id="${id}_building" nowrap="" size="30" autocomplete="off"></td>
+            <td><input type="text" tabindex="0" id="${id}_building" nowrap="" size="30" autocomplete="off"></td>
         </tr>
         <tr>
             <td class='ZmFieldLabelRight'><$= ZmMsg.description $>:</td>
-            <td><input type="text" id="${id}_desc" nowrap="" size="30" autocomplete="off"></td>
+            <td><input type="text" tabindex="0" id="${id}_desc" nowrap="" size="30" autocomplete="off"></td>
             <td class='ZmFieldLabelRight' style='padding-left:2em;'><$= ZmMsg.floor $>:</td>
-            <td><input type="text" id="${id}_floor" nowrap="" size="30" autocomplete="off"></td>
+            <td><input type="text" tabindex="0" id="${id}_floor" nowrap="" size="30" autocomplete="off"></td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
**2.1.1_Checkboxes are not accessible with keyboard.docx**
> Fixed. Now user can interact with Calendar folder's checkbox using keyboard spacebar. 

**2.1.1_UnabletoAccessInteractiveElementswithKeyboard.docx**
> Fixed. All interactive elements of appointment dialog are accessible using Tab and Arrow keys. User can access toolbar option with keyboard Left & Right arrow key once focus comes to `Save & Close` button.
> Also, Added keyboard accessibility support on `Find Locations`, `Find Equipments`, `Suggest Time` (except mini calendar component which will be handled in ZCS-12553) and `Suggest location` panel. 

**2.1.1_access issue-Contacts Group.docx**
> Fixed. Now user can access all the interactive elements using keyboard Tab key.

**2.1.1_access issue-Preferences.docx** 
> 1. `Preferences > General > Other > Confirmation message sent checkbox` This will be fixed in separate ticket as this setting coming from zimlet.
> 2. `Preferences > Filters`. Fixed. 
> 3. `Preferences > Filters > Active Stream`. Fixed. 
> 4. `Preferences >  Signature > Using Signatures`. The issue is not reproducible. All elements are accessible using keyboard.
> 5. `Preferences > Out of Office`. Fixed.
> 6. `Preferences > Zimlets`. Fixed.
> 7.  `Preferences > Sharing`. Fixed.
> 8. `Preferences >  Calendar > Custom Working hours dialog`. Fixed.


See the changes of zm-ajax https://github.com/Zimbra/zm-ajax/pull/110