### PR TITLE
ZCS-12586: fixed not to show Zimlets tree in the left pane of Preferences

### DIFF
--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -547,7 +547,9 @@ function(allZimlets, props, sync) {
 
 		// update overview tree
 		if (overview) {
-			overview.setTreeView(ZmOrganizer.ZIMLET);
+			if (overview.appName != ZmApp.PREFERENCES) {
+				overview.setTreeView(ZmOrganizer.ZIMLET);
+			}
 
 			// HACK: for multi-account, hide the zimlet section if no panel zimlets
 			if (appCtxt.multiAccounts && zimletMgr.getPanelZimlets().length == 0) {


### PR DESCRIPTION
**Problem:**
When Preferences page is accessed directly by adding `app=options` param in the URL, Zimlets tree is show in the left pane of Preferences.

**Change:**
Add condition check to ZmSettings.js