### PR TITLE
ZCS-12549: add ability to specify favicon directory in a skin

### DIFF
--- a/WebRoot/js/zimbraMail/mail/ZmMailApp.js
+++ b/WebRoot/js/zimbraMail/mail/ZmMailApp.js
@@ -2113,12 +2113,19 @@ function() {
 ZmMailApp.prototype._setFavIcon =
 function(unread) {
     var url;
-    if (unread == 0) {
-        url = [appContextPath, "/img/logo/favicon.ico"].join("");
-    } else if (unread > 9) {
-        url = [appContextPath,"/img/logo/favicon_plus.ico"].join("");
+    var dir;
+    if (skin.hints.favicon && skin.hints.favicon.dir) {
+        dir = skin.hints.favicon.dir;
     } else {
-        url = [appContextPath, "/img/logo/favicon_", unread, ".ico"].join("");
+        dir = appContextPath + "/img/logo";
+    }
+
+    if (unread == 0) {
+        url = [dir, "/favicon.ico"].join("");
+    } else if (unread > 9) {
+        url = [dir,"/favicon_plus.ico"].join("");
+    } else {
+        url = [dir, "/favicon_", unread, ".ico"].join("");
     }
     Dwt.setFavIcon(url);
 };

--- a/WebRoot/skins/_base/base3/ZmSkin.js
+++ b/WebRoot/skins/_base/base3/ZmSkin.js
@@ -34,6 +34,7 @@ ZmSkin.hints = {
 	// skin regions
 	skin:		  	{ containers: "skin_outer" },
 	banner:			{ position:"static", url: "@LogoURL@"},		// == "logo"
+	favicon:		{ dir: "@FaviconDir@"},
 	userInfo:		{ position:"static"},
 	search:		  	{ position:"static" },
 	quota:		  	{ position:"static" },

--- a/WebRoot/skins/_base/base3/skin.properties
+++ b/WebRoot/skins/_base/base3/skin.properties
@@ -54,6 +54,7 @@ SkinVersion		= 1
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/bare/skin.properties
+++ b/WebRoot/skins/bare/skin.properties
@@ -57,6 +57,7 @@ SkinVersion  	= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/beach/skin.properties
+++ b/WebRoot/skins/beach/skin.properties
@@ -57,6 +57,7 @@ SkinVersion   	= 2
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/bones/skin.properties
+++ b/WebRoot/skins/bones/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/carbon/skin.properties
+++ b/WebRoot/skins/carbon/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 2
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/harmony/skin.properties
+++ b/WebRoot/skins/harmony/skin.properties
@@ -57,6 +57,7 @@ SkinVersion   	= 1
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/hotrod/skin.properties
+++ b/WebRoot/skins/hotrod/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/lake/skin.properties
+++ b/WebRoot/skins/lake/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/lavender/skin.properties
+++ b/WebRoot/skins/lavender/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/lemongrass/skin.properties
+++ b/WebRoot/skins/lemongrass/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/oasis/skin.properties
+++ b/WebRoot/skins/oasis/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/pebble/skin.properties
+++ b/WebRoot/skins/pebble/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/sand/skin.properties
+++ b/WebRoot/skins/sand/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/serenity/skin.properties
+++ b/WebRoot/skins/serenity/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 1
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/sky/skin.properties
+++ b/WebRoot/skins/sky/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/smoke/skin.properties
+++ b/WebRoot/skins/smoke/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 2
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/steel/skin.properties
+++ b/WebRoot/skins/steel/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/tree/skin.properties
+++ b/WebRoot/skins/tree/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/twilight/skin.properties
+++ b/WebRoot/skins/twilight/skin.properties
@@ -57,6 +57,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 

--- a/WebRoot/skins/waves/skin.properties
+++ b/WebRoot/skins/waves/skin.properties
@@ -56,6 +56,7 @@ SkinVersion		= 3
 #
 #	LogoImgDir		= @AppContextPath@/skins/@SkinName@/logos
 #	LogoURL			= http://www.yourcompany.com
+#	FaviconDir		= @AppContextPath@/skins/@SkinName@/img/favicon
 #
 #========================================================================#
 


### PR DESCRIPTION
**Enhancement:**
Currently favicon path is hard coded in ZmMailApp.js. Some zimbra users want to change favicon per skin.

**Changes:**
* `FaviconDir` param is added to `skin.properties`. It is commented out by default. Only Network Edition users are allow to change favicon as same as logo image.
* The value of `FaviconDir` is set in `ZmSkin.hints.favicon.dir` as string. It will be 0-length string if `FaviconDir` is not defined in `skin.properties`.
* Update `ZmMailApp.prototype._setFavIcon` to use `skin.hints.favicon.dir` if it has been set.

Note:
The url is sanitized at `appendChild` in `Dwt.setFavIcon`.