### PR TITLE
ZBUG-3142: changed to use default start app in case Mail feature is disabled

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmAppViewMgr.js
+++ b/WebRoot/js/zimbraMail/core/ZmAppViewMgr.js
@@ -821,7 +821,8 @@ function(force, viewId, skipHistory) {
 	
 	if (noShow) {
 		if (goToApp) {
-			this._controller.activateApp(ZmApp.MAIL);
+			var app = appCtxt.getZimbraMail()._getDefaultStartAppName();
+			this._controller.activateApp(app);
 		}
 		return !noHide;
 	}


### PR DESCRIPTION
**Problem:**
* When a user log in on Classic UI with `app=options` parameter in the URL, Preferences page is shown as the initial app. Then if any setting is modified and saved, Mail app is shown even when zimbraFeatureMailEnabled is FALSE.
* When an administrator clicks View Mail to on Admin Console, login on Classic UI, and add `app=options` param to the URL, Preferences page is shown. Then if any setting is modified and saved, Mail app is shown even when zimbraFeatureAdminMailEnabled is FALSE.

**Change:**
Use default start app as a target of page transition after the save, rather than Mail app.