### PR TITLE
ZCS-12596: changed the timing of ZmMailApp._registerPrefs on a delegated admin access

### DIFF
--- a/WebRoot/js/zimbraMail/mail/ZmMailApp.js
+++ b/WebRoot/js/zimbraMail/mail/ZmMailApp.js
@@ -2452,7 +2452,6 @@ function() {
 	AjxDispatcher.require("PreferencesCore");
 	this._registerSettings();
 	this._registerOperations();
-	this._registerPrefs();
 };
 
 // Folders to ignore when displaying a conv's messages

--- a/WebRoot/js/zimbraMail/prefs/ZmPreferencesApp.js
+++ b/WebRoot/js/zimbraMail/prefs/ZmPreferencesApp.js
@@ -77,6 +77,10 @@ ZmPreferencesApp._registerAllPrefs =
 function() {
 	AjxDispatcher.require("PreferencesCore");
 	appCtxt.getAppController().runAppFunction("_registerPrefs");
+	if (appCtxt.get(ZmSetting.ADMIN_DELEGATED) && !appCtxt.get(ZmSetting.ADMIN_MAIL_ENABLED) && appCtxt.get(ZmSetting.ADMIN_PREFERENCES_ENABLED)) {
+		var mailApp = appCtxt.getSettings().getMailAppForDelegatedAdmin();
+		mailApp._registerPrefs();
+	}
 };
 ZmZimbraMail.addAppListener(ZmApp.PREFERENCES, ZmAppEvent.PRE_LAUNCH, new AjxListener(ZmPreferencesApp._registerAllPrefs));
 

--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -328,7 +328,7 @@ ZmSettings.prototype.setUserSettings = function(params) {
 	// they can be created and set below in createFromJs().
 	if (this.get(ZmSetting.ADMIN_DELEGATED)) {
 		if (!this.get(ZmSetting.ADMIN_MAIL_ENABLED) && this.get(ZmSetting.ADMIN_PREFERENCES_ENABLED)) {
-			(new ZmMailApp()).enableMailPrefs();
+			this.getMailAppForDelegatedAdmin().enableMailPrefs();
 		}
 	}
 
@@ -1323,4 +1323,12 @@ function(setting) {
     }
 	//Always reload appcache whenever offline setting is enabled/disabled. Appcache will be updated/emptied depending upon the setting.
 	appCtxt.reloadAppCache(true);
+};
+
+ZmSettings.prototype.getMailAppForDelegatedAdmin =
+function() {
+    if (!this.mailApp) {
+        this.mailApp = new ZmMailApp();
+    }
+    return this.mailApp;
 };


### PR DESCRIPTION
**Problem:**
When zimbraFeatureAdminMailEnabled FALSE and zimbraFeatureAdminPreferencesEnabled TRUE and an administrator runs delegated access via Admin Console -> View Mail function, a script error dialog is shown in Preferences -> Out of Office setting.

**Root cause:**
On a normal account (not a delegated access), Prefs are registered in the following order:
1. ZmPreferencesApp._registerPrefs
2. ZmMailApp._registerPrefs

This is executed at
```
ZmPreferencesApp._registerAllPrefs =
function() {
	//...
	appCtxt.getAppController().runAppFunction("_registerPrefs");
```

On the other hand, on a delegated access, Prefs are registered in the different order:
1. ZmMailApp._registerPrefs  at ZmMailApp.prototype.enableMailPrefs
2. ZmPreferencesApp._registerPrefs  at ZmPreferencesApp._registerAllPrefs

The order must be 1) ZmPreferencesApp and 2) ZmMailApp.

**Change:**
* Move `ZmMailApp._registerPrefs()` to the last part of `ZmPreferencesApp._registerAllPrefs` on a delegated admin access. It is executed after `ZmPreferencesApp._registerPrefs`.
* Because the same instance of ZmMailApp needs to be used in both `ZmMailApp.prototype.enableMailPrefs` and `ZmPreferencesApp._registerAllPrefs`, the instance is created at `ZmSettings.prototype.getMailAppForDelegatedAdmin` and stored in `this.mailApp` (`this` is an instance of `ZmSettings`)