### PR TITLE
ZCS-12599: fixed script error in Compose

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
@@ -1019,7 +1019,7 @@ function(composeMode, initOnly) {
 	// reset the body field Id and object ref
 	this._bodyFieldId = this._htmlEditor.getBodyFieldId();
 	this._bodyField = Dwt.byId(this._bodyFieldId);
-	if (this._bodyField.disabled) {
+	if (this._bodyField && this._bodyField.disabled) {
 		this._bodyField.disabled = false;
 	}
 
@@ -1452,6 +1452,10 @@ function(bEnable) {
     DBG.println('draft', 'ZmComposeView.enableInputs for ' + this._view + ': ' + bEnable);
     this._recipients.enableInputs(bEnable);
     try {
+       if (!this._bodyField) {
+           this._bodyFieldId = this._htmlEditor.getBodyFieldId();
+           this._bodyField = document.getElementById(this._bodyFieldId);
+       }
        this._subjectField.disabled = this._bodyField.disabled = !bEnable;
     } catch (err){}
 };


### PR DESCRIPTION
**Issues:**
Two issues are observed in Japanese language setting in Compose page.
1. Login to Classic UI
2. Configure preferences as follows.
    Preferences -> Mail -> Composing Messages -> Choose "Compose As Text"
    Preferences -> General -> Language -> Japanese
3. Reload the page (press F5 key)
4. Click "New Message"
5. Click Options -> Format as HTML
6. A script error dialog is shown (Issue 1)
7. Close the dialog and add any email address in To field.
8. Click Cancel. A confirmation dialog is shown.
9. `disabled` attribute is not added to `input` element of subject field. (Issue 2)
    It should be added as follows.
    ```
   <input type="text" id="zv__COMPOSE-1_subject_control" class="subjectField" autocomplete="off" aria-label="件名" disabled>
   ```

**Changes:**
* Issue 1: add a condition to `if` statement in `ZmComposeView.prototype.setComposeMode`
* Issue 2: load an element of html editor if `this._bodyField` is `undefined` or empty in `ZmComposeView.prototype.enableInputs`

**Note:**
`try-catch` in `ZmComposeView.prototype.enableInputs` is not removed. According to the history of the changes of this part, there might be a case that `this._subjectField` is `undefined`.

References:
* https://github.com/Zimbra/zm-web-client/pull/371
* https://github.com/Zimbra/zm-web-client/pull/484