### PR TITLE
ZCS-12600: activate allowed extensions for contact photo

### DIFF
--- a/WebRoot/js/zimbraMail/abook/view/ZmEditContactView.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmEditContactView.js
@@ -1102,6 +1102,9 @@ ZmEditContactViewImage = function(params) {
 
 	this.setToolTipContent(ZmMsg.addImg);
 };
+
+ZmEditContactViewImage.ALLOWED_IMG_EXTENSION = ["png","jpg","jpeg","gif"];
+
 ZmEditContactViewImage.prototype = new DwtControl;
 ZmEditContactViewImage.prototype.constructor = ZmEditContactViewImage;
 ZmEditContactViewImage.prototype.isFocusable = true;
@@ -1187,7 +1190,7 @@ ZmEditContactViewImage.prototype._imageLoaded = function() {
  */
 ZmEditContactViewImage.prototype._chooseImage = function() {
 	var dialog = appCtxt.getUploadDialog();
-	dialog.setAllowedExtensions(["png","jpg","jpeg","gif"]);
+	dialog.setAllowedExtensions(ZmEditContactViewImage.ALLOWED_IMG_EXTENSION);
 	var folder = null;
 	var callback = new AjxCallback(this, this._handleImageSaved);
 	var title = ZmMsg.uploadImage;

--- a/WebRoot/js/zimbraMail/share/ZmUploadManager.js
+++ b/WebRoot/js/zimbraMail/share/ZmUploadManager.js
@@ -315,7 +315,7 @@ function(errors, maxSize, lineBreak) {
 
     var errorMsg = [ZmMsg.uploadFailed];
     if (errorSummary.invalidExtension) {
-        var extensions = this._formatUploadErrorList(this._extensions);
+        var extensions = this._formatUploadErrorList(appCtxt.getUploadDialog()._extensions);
         errorMsg.push("* " + AjxMessageFormat.format(ZmMsg.errorNotAllowedFile, [ extensions ]));
     }
 	var msgFormat, errorFilenames;

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmUploadDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmUploadDialog.js
@@ -271,7 +271,7 @@ ZmUploadDialog.prototype._upload = function(){
             for (var j = 0; j < files.length; j++){
                 file = files[j];
                 fileObj.push(file);
-				newError = zmUploadManager.getErrors(file, maxSize);
+				newError = zmUploadManager.getErrors(file, maxSize, null, this._extensions);
 				if (newError) {
 					errors.push(newError);
 				} else {
@@ -281,7 +281,7 @@ ZmUploadDialog.prototype._upload = function(){
         } else {
 			var fileName = element.value.replace(/^.*[\\\/:]/, "");
             file = { name: fileName };
-			newError = zmUploadManager.getErrors(file, maxSize);
+			newError = zmUploadManager.getErrors(file, maxSize, null, this._extensions);
 			if (newError) {
 				errors.push(newError);
 			} else {


### PR DESCRIPTION
**Problem:**
In Edit Contact page, user can upload photo image. The allowed image file types (extensions) are defined in the source code.
```
ZmEditContactViewImage.prototype._chooseImage = function() {
       var dialog = appCtxt.getUploadDialog();
       dialog.setAllowedExtensions(["png","jpg","jpeg","gif"]);
```
However, it does not work.
(A) Other images like BMP can be uploaded.
(B) Non-image file like PDF can be uploaded and then an error dialog is shown at rendering the image. The allowed extensions must be checked before a file is uploaded.

Regarding (B), an error dialog is shown as the screenshot.
The photo area flickers until the edit contact page is closed.

![error_dialog](https://user-images.githubusercontent.com/32184593/204708235-558a4ed5-7e86-454d-bfcd-c0eac52f47b2.png)
This is because, a file is uploaded to the server and then the browser tries to render it as an image. However, it is actually not an image. Then `onerror` event element is raised on the IMG element.
```
ZmEditContactViewImage.prototype.setValue = function(value, promptOnError) {
    //...
    this._imgEl.onerror = this._handleCorruptImageError.bind(this, promptOnError);
};
```

**Changes:**
* Add `ZmEditContactViewImage.ALLOWED_IMG_EXTENSION` to define allowed extensions for contact photo
* In `ZmUploadManager.prototype.createUploadErrorMsg`, `this._extensions` is always `undefined`. It is changed to get allowed extensions which is set in a instance of ZmUploadDialog. (i.e. `ZmUploadDialog.prototype._extensions` is referred)
* Add parameters to `zmUploadManager.getErrors` in `ZmUploadDialog.prototype._upload`. `ZmUploadManager.prototype.getErrors` checks if the extension of the uploading file is included in the passed allowed extensions list.
    * If `this._extensions` is `undefined` or empty, extension check is skipped. `ZmUploadDialog.setAllowedExtensions` is called from ZmEditContactView only. The change does not affect other upload dialogs using ZmUploadDialog.
* After the fix, when user tries to upload non-allowed file type like PDF, upload process is blocked and an error message is shown in the upload dialog.
![after_the_fix](https://user-images.githubusercontent.com/32184593/204711577-c2d031ea-ff87-477a-86b3-fb977077831a.png)

**Discussion:**
Currently (= before the fix), not only `"png","jpg","jpeg","gif"` but other image file types like BMP can be uploaded and rendered in contact photo area. After the fix, only the file types defined in `ZmEditContactViewImage.ALLOWED_IMG_EXTENSION` can be uploaded.
What file types should be allowed? Are the four types enough?

Reference:
There are some other image file types.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types