### PR TITLE
ZCS-12602: added notifyZimlets

### DIFF
--- a/WebRoot/js/zimbraMail/abook/view/ZmContactSplitView.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmContactSplitView.js
@@ -641,10 +641,17 @@ function(data) {
 				var date = ZmEditContactViewOther.parseDate(value);
 				if (date) {
 					var includeYear = date.getFullYear() != 0;
-					var formatter = includeYear ?
-					    AjxDateFormat.getDateInstance(AjxDateFormat.LONG) : new AjxDateFormat(ZmMsg.formatDateLongNoYear);
+					var result = { value: null };
+					appCtxt.notifyZimlets("onZmContactSplitView_showContactListItem", [includeYear, result]);
+					var formatter;
+					if (result.value) {
+						formatter = result.value;
+					} else {
+						formatter = includeYear ?
+							AjxDateFormat.getDateInstance(AjxDateFormat.LONG) : new AjxDateFormat(ZmMsg.formatDateLongNoYear);
+					}
 					value = formatter.format(date);
-		        	}
+				}
 			}
 			if (data.findObjects) {
 				value = data.findObjects(value, data.objectType);
@@ -1205,7 +1212,13 @@ function(contact, params, asHtml, count) {
 
 	// checkbox selection
 	if (appCtxt.get(ZmSetting.SHOW_SELECTION_CHECKBOX)) {
-		idx = this._getImageHtml(htmlArr, idx, "CheckboxUnchecked", this._getFieldId(contact, ZmItem.F_SELECTION));
+		var result = { value: null };
+		appCtxt.notifyZimlets("onZmContactSplitView_createItemHtml", [this, htmlArr, idx, contact, result]);
+		if (result.value) {
+			idx = result.value;
+		} else {
+			idx = this._getImageHtml(htmlArr, idx, "CheckboxUnchecked", this._getFieldId(contact, ZmItem.F_SELECTION));
+		}
 	}
 
 	// icon

--- a/WebRoot/js/zimbraMail/calendar/controller/ZmApptComposeController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmApptComposeController.js
@@ -558,23 +558,27 @@ function() {
 	if (optionsButton){
         optionsButton.setVisible(true); //might be invisible if not ZmSetting.HTML_COMPOSE_ENABLED (see ZmCalItemComposeController._createToolBar)
 
-        var m = optionsButton.getMenu();
-        if (m) {
-            var sepMi = new DwtMenuItem({parent:m, style:DwtMenuItem.SEPARATOR_STYLE});
-        }
-        else {
-            m = new DwtMenu({parent:optionsButton});
-            optionsButton.setMenu(m);
-        }
+        var result = { handled: false };
+        appCtxt.notifyZimlets("onZmApptComposeController_createToolBar", [this, optionsButton, result]);
+        if (!result.handled) {
+            var m = optionsButton.getMenu();
+            if (m) {
+                var sepMi = new DwtMenuItem({parent:m, style:DwtMenuItem.SEPARATOR_STYLE});
+            }
+            else {
+                m = new DwtMenu({parent:optionsButton});
+                optionsButton.setMenu(m);
+            }
 
-        var mi = this._requestResponses = new DwtMenuItem({parent:m, style:DwtMenuItem.CHECK_STYLE});
-        mi.setText(ZmMsg.requestResponses);
-        mi.setChecked(true, true);
+            var mi = this._requestResponses = new DwtMenuItem({parent:m, style:DwtMenuItem.CHECK_STYLE});
+            mi.setText(ZmMsg.requestResponses);
+            mi.setChecked(true, true);
 
-        sepMi = new DwtMenuItem({parent:m, style:DwtMenuItem.SEPARATOR_STYLE});
-        mi = new DwtMenuItem({parent:m, style:DwtMenuItem.NO_STYLE});
-        mi.setText(ZmMsg.suggestionPreferences);
-        mi.addSelectionListener(this._prefListener.bind(this));
+            sepMi = new DwtMenuItem({parent:m, style:DwtMenuItem.SEPARATOR_STYLE});
+            mi = new DwtMenuItem({parent:m, style:DwtMenuItem.NO_STYLE});
+            mi.setText(ZmMsg.suggestionPreferences);
+            mi.addSelectionListener(this._prefListener.bind(this));
+        }
     }
 
 	this._toolbar.addSelectionListener(ZmOperation.SPELL_CHECK, new AjxListener(this, this._spellCheckListener));

--- a/WebRoot/js/zimbraMail/calendar/controller/ZmApptController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmApptController.js
@@ -76,6 +76,8 @@ function() {
 		buttons.push(ZmOperation.PRINT);
 	}
 
+	appCtxt.notifyZimlets("onZmApptController_createToolBar", [buttons, secondaryButtons]);
+
 	this._toolbar = new ZmButtonToolBar({parent:this._container, buttons:buttons, context:this._currentViewId, controller:this, secondaryButtons:secondaryButtons});
 	this._toolbar.addSelectionListener(ZmOperation.SAVE, this._saveListener.bind(this));
 	this._toolbar.addSelectionListener(ZmOperation.CANCEL, this._cancelListener.bind(this));

--- a/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
@@ -3492,6 +3492,9 @@ function(recurrenceMode) {
 	    		forwardOp,
 	    		deleteOp,
 	    		ZmOperation.SEP];
+
+	appCtxt.notifyZimlets("onZmCalViewController_getActionMenuOps", [retVal]);
+
 	if (recurrenceMode != ZmOperation.VIEW_APPT_INSTANCE) {
 		retVal.push(ZmOperation.MOVE);
 	}

--- a/WebRoot/js/zimbraMail/calendar/controller/ZmCalendarTreeController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmCalendarTreeController.js
@@ -229,6 +229,9 @@ function(actionMenu, type, id) {
 ZmCalendarTreeController.prototype._getFreeBusySubMenu =
 function(actionMenu, restUrl){
         var subMenuItems = [ZmOperation.SEND_FB_HTML,ZmOperation.SEND_FB_ICS,ZmOperation.SEND_FB_ICS_EVENT];
+
+        appCtxt.notifyZimlets("onZmCalendarTreeController_getFreeBusySubMenu", [subMenuItems]);
+
         var params = {parent:actionMenu, menuItems:subMenuItems};
 	    var subMenu = new ZmActionMenu(params);
         for(var s=0;s<subMenuItems.length;s++){
@@ -304,6 +307,8 @@ function() {
     }
 
 	ops.push(ZmOperation.FIND_SHARES);
+
+	appCtxt.notifyZimlets("onZmCalendarTreeController_getHeaderActionMenuOps", [ops]);
 
 	return ops;
 };

--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptListView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptListView.js
@@ -203,8 +203,18 @@ ZmApptListView.prototype._getFieldId = function(item, field) {
 };
 
 ZmApptListView.prototype._getCellId = function(item, field) {
+	var id;
 	if (field == ZmItem.F_SUBJECT || field == ZmItem.F_DATE || field == ZmItem.F_LOCATION || field == ZmItem.F_STATUS || field == ZmItem.F_FOLDER) {
-		return this._getFieldId(item, field);
+		id = this._getFieldId(item, field);
+	}
+	if (id) {
+		return id;
+	}
+
+	var result = { value: null };
+	appCtxt.notifyZimlets("onZmApptListView_getCellId", [this, item, field, result]);
+	if (result.value) {
+		return result.value;
 	}
 };
 

--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptViewHelper.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptViewHelper.js
@@ -818,11 +818,18 @@ function(calItem, attach, hasCheckbox, getLinkIdCallback) {
 	// start building html for this attachment
 	html[i++] = "<table role='presentation' border=0 cellpadding=0 cellspacing=0><tr>";
 	if (hasCheckbox) {
-		html[i++] = "<td width=1%><input type='checkbox' checked value='";
-		html[i++] = attach.part;
-		html[i++] = "' name='";
-		html[i++] = ZmCalItem.ATTACHMENT_CHECKBOX_NAME;
-		html[i++] = "'></td>";
+		var result = { value: null };
+		appCtxt.notifyZimlets("onZmApptViewHelper_getAttachListHtml", [html, i, attach, result]);
+		if (result.value) {
+			html = result.value.html;
+			i = result.value.i;
+		} else {
+			html[i++] = "<td width=1%><input type='checkbox' checked value='";
+			html[i++] = attach.part;
+			html[i++] = "' name='";
+			html[i++] = ZmCalItem.ATTACHMENT_CHECKBOX_NAME;
+			html[i++] = "'></td>";
+		}
 	}
 
 	var hrefRoot = ["href='", msgFetchUrl, "&id=", calItem.invId, "&amp;part=", attach.part].join("");

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalColView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalColView.js
@@ -451,6 +451,12 @@ function(hour) {
 
 ZmCalColView.prototype._updateTitle =
 function() {
+	var result = { handled: false };
+	appCtxt.notifyZimlets("onZmCalColView_updateTitle", [this, result]);
+	if (result.handled) {
+		return;
+	}
+
 	var dayFormatter = DwtCalendar.getDayFormatter();
 
 	if (this.numDays == 1) {
@@ -828,6 +834,13 @@ function(html) {
 	var date = new Date();
 	date.setHours(0, 0, 0, 0);
     var timeTDWidth = ZmCalColView._HOURS_DIV_WIDTH - (this._fbBarEnabled ? ZmCalColView._FBBAR_DIV_WIDTH : 0 );
+
+    var result = { handled: false };
+    appCtxt.notifyZimlets("onZmCalColView_createHoursHtml", [this, html, timeTDWidth, formatter, date, result]);
+    if (result.handled) {
+        return;
+    }
+
     html.append("<table role='presentation' class=calendar_grid_day_table>");
 	for (var h=0; h < 25; h++) {
 		html.append("<tr><td class=calendar_grid_body_time_td style='height:",

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalItemEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalItemEditView.js
@@ -771,6 +771,7 @@ function(width) {
         // Fix for bug: 83100. Fix adapted from ZmReminderDialog::_createButtons
 		Dwt.setSize(reminderInputEl, "120px", "2rem");
 		reminderInputEl.onblur = AjxCallback.simpleClosure(this._handleReminderOnBlur, this, reminderInputEl);
+		appCtxt.notifyZimlets("onZmCalItemEditView_createWidgets", [reminderInputEl]);
 
 		var reminderButtonListener = new AjxListener(this, this._reminderButtonListener);
 		var reminderSelectionListener = new AjxListener(this, this._reminderSelectionListener);

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalListView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalListView.js
@@ -146,6 +146,12 @@ function() {
 
 ZmCalListView.prototype._updateTitle =
 function() {
+	var result = { handled: false };
+	appCtxt.notifyZimlets("onZmCalListView_updateTitle", [this, result]);
+	if (result.handled) {
+		return;
+	}
+
 	var dayFormatter = DwtCalendar.getDayFormatter();
 	var start = new Date(this._timeRangeStart);
 	var end = new Date(this._timeRangeEnd);
@@ -163,6 +169,7 @@ function(startDate, endDate) {
 		AjxDateUtil._getMonthName(endDate, true),
 		endDate.getDate()
 	];
+	appCtxt.notifyZimlets("onZmCalListView_updateDateRange", [startDate, endDate, params]);
 	this._dateRangeField.innerHTML = AjxMessageFormat.format(ZmMsg.viewCalListDateRange, params);
 };
 

--- a/WebRoot/js/zimbraMail/calendar/view/ZmExternalCalendarDialog.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmExternalCalendarDialog.js
@@ -81,6 +81,12 @@ function() {
 
 ZmExternalCalendarDialog.prototype.popup =
 function() {
+    var result = { handled: false };
+    appCtxt.notifyZimlets("onZmExternalCalendarDialog_popup", [this, result]);
+    if (result.handled) {
+        return;
+    }
+
     this.showView(ZmExternalCalendarDialog.FIRST_VIEW, ZmExternalCalendarDialog.TYPE_YAHOO);
     ZmDialog.prototype.popup.call(this);
 };
@@ -278,7 +284,11 @@ function(viewId, type) {
         break;
 
         case ZmExternalCalendarDialog.SECOND_VIEW :
-            this.getButton(ZmExternalCalendarDialog.BACK_BUTTON).setVisibility(true);
+            var result1 = { handled: false };
+            appCtxt.notifyZimlets("onZmExternalCalendarDialog_showView1", [this, result1]);
+            if (!result1.handled) {
+                this.getButton(ZmExternalCalendarDialog.BACK_BUTTON).setVisibility(true);
+            }
             if(type == ZmExternalCalendarDialog.TYPE_YAHOO) {
                 this._userNameInput.setHint(ZmMsg.sharedCalUserNameYahooHint);
                 this._urlInput._hideHint(ZmMsg.sharedCalCalDAVServerYahoo);
@@ -302,7 +312,12 @@ function(viewId, type) {
 
     }
     Dwt.setDisplay(this._views[viewId], Dwt.DISPLAY_BLOCK);
-    this._setSecondViewTabGroup();
+
+    var result2 = { handled: false };
+    appCtxt.notifyZimlets("onZmExternalCalendarDialog_showView2", [this, result2]);
+    if (!result2.handled) {
+        this._setSecondViewTabGroup();
+    }
 };
 
 ZmExternalCalendarDialog.prototype.loadView =

--- a/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
+++ b/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
@@ -728,6 +728,8 @@ function() {
  */
 ZmAppCtxt.prototype.getChooseFolderDialog =
 function(appName) {
+	appCtxt.notifyZimlets("onZmAppCtxt_getChooseFolderDialog1", [this]);
+
 	var app = appName ? this.getApp(appName) : this.getCurrentApp();
 	// this.getCurrentAppName() returns "Search" for search apps. Let's re-use dialogs from regular apps.
 	appName = app.isZmSearchApp ? this.searchAppName : app.getName();
@@ -736,6 +738,9 @@ function(appName) {
 		AjxDispatcher.require("Extras");
 		this._chooseFolderDialogs[appName] = new ZmChooseFolderDialog(this._shell);
 	}
+
+	appCtxt.notifyZimlets("onZmAppCtxt_getChooseFolderDialog2", [this]);
+
 	this._chooseFolderDialog = this._chooseFolderDialogs[appName];
 	return this._chooseFolderDialog;
 };
@@ -1837,7 +1842,11 @@ function(event, args, options) {
 	if (options && options.noChildWindow && this.isChildWindow) { return; }
 	try {
 		return window.skin && AjxUtil.isFunction(window.skin.handleNotification) && window.skin.handleNotification(event, args);
-	} catch (e) {}
+	} catch (e) {
+		if (window.console && window.console.error) {
+			console.error(e);
+		}
+	}
 };
 
 
@@ -1971,8 +1980,15 @@ function(ev) {
     		url = AjxUtil.formatUrl({protocol: proto, port: port, path: path, qsReset: true, qsArgs: qsArgs});
     	}
 
-    	var args  = "height=675,width=705,location=no,menubar=no,resizable=yes,scrollbars=no,status=yes,toolbar=no";
-    	window.open(url,'ChangePasswordWindow', args);
+        var args;
+        var result = { value: null };
+        appCtxt.notifyZimlets("onZmAppCtxt_getChangePasswordWindow", [result]);
+        if (result.value) {
+            args = result.value;
+        } else {
+            args = "height=675,width=705,location=no,menubar=no,resizable=yes,scrollbars=no,status=yes,toolbar=no";
+        }
+        window.open(url,'ChangePasswordWindow', args);
 };
 
 /**

--- a/WebRoot/js/zimbraMail/core/ZmOperation.js
+++ b/WebRoot/js/zimbraMail/core/ZmOperation.js
@@ -92,6 +92,12 @@ ZmOperation.registerOp = function(op, params, precondition, callback) {
 	if (callback)	    { ZmOperation.CALLBACK[op]	    = callback; }
 };
 
+ZmOperation.unregisterOp = function(op) {
+	delete ZmOperation[op];
+	delete ZmOperation.SETUP[op];
+	delete ZmOperation.PRECONDITION[op];
+	delete ZmOperation.CALLBACK[op];
+};
 
 ZmOperation.KEY_ID		= "opId";
 ZmOperation.MENUITEM_ID	= "menuItemId";
@@ -245,6 +251,8 @@ function() {
 	ZmOperation.NEW_ORG_OPS.push(ZmOperation.NEW_FOLDER, ZmOperation.NEW_TAG);
 	ZmOperation.NEW_ORG_KEY[ZmOperation.NEW_FOLDER]	= "folder";
 	ZmOperation.NEW_ORG_KEY[ZmOperation.NEW_TAG]	= "tag";
+
+	appCtxt.notifyZimlets("onZmOperation_initialize", []);
 };
 
 /**

--- a/WebRoot/js/zimbraMail/mail/ZmMailApp.js
+++ b/WebRoot/js/zimbraMail/mail/ZmMailApp.js
@@ -764,6 +764,8 @@ function() {
 			options:			[true, false]
 		});
 	}
+
+	appCtxt.notifyZimlets('onZmMailApp_registerPrefs', []);
 };
 
 ZmMailApp.prototype.formatKeySeq = function(keySeq) {
@@ -945,6 +947,8 @@ function() {
 	ZmOperation.registerOp(ZmId.OP_SHOW_ORIG, {textKey:"showOrig", image:"Message"});
 	ZmOperation.registerOp(ZmId.OP_SPAM, {textKey:"junkLabel", tooltipKey:"junkTooltip", image:"JunkMail", shortcut:ZmKeyMap.SPAM, textPrecedence:70}, ZmSetting.SPAM_ENABLED);
 	ZmOperation.registerOp(ZmId.OP_USE_PREFIX, {textKey:"usePrefix"});
+
+	appCtxt.notifyZimlets('onZmMailApp_registerOperations', []);
 };
 
 /**

--- a/WebRoot/js/zimbraMail/mail/controller/ZmComposeController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmComposeController.js
@@ -606,6 +606,13 @@ function(attId, docIds, draftType, callback, contactId) {
 
 	var respCallback = this._handleResponseSendMsg.bind(this, draftType, msg, callback);
 	var errorCallback = this._handleErrorSendMsg.bind(this, draftType, msg);
+
+	var result = { value: null };
+	appCtxt.notifyZimlets("onZmComposeController_sendMsg", [this, result]);
+	if (result.value) {
+		acctName = result.value;
+	}
+
 	msg.send(isDraft, respCallback, errorCallback, acctName, null, requestReadReceipt, null, this._sendTime, isAutoSave);
 	this._resetDelayTime();
 };

--- a/WebRoot/js/zimbraMail/mail/controller/ZmMailListController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmMailListController.js
@@ -2319,6 +2319,8 @@ function(parent, num) {
 	parent.setItemVisible(ZmOperation.CREATE_TASK, !(isDrafts || isOutboxFolder));
     parent.setItemVisible(ZmOperation.ACTIONS_MENU, !isOutboxFolder);
 
+	appCtxt.notifyZimlets("onZmMailListController_resetOperations", [this, parent, isDrafts]);
+
 	// bug fix #37154 - disable non-applicable buttons if rfc/822 message
 	var isRfc822 = appCtxt.isChildWindow && window.newWindowParams && window.newWindowParams.isRfc822;
 	if (isRfc822 || (isReadOnly && num > 0)) {

--- a/WebRoot/js/zimbraMail/mail/view/ZmConvListView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmConvListView.js
@@ -461,13 +461,22 @@ function(item, colIdx) {
 			break;
 		}
 	}
-	htmlArr[idx++] = "<div class='TopRow " + selectionCssClass + "' ";
-	htmlArr[idx++] = "id='";
-	htmlArr[idx++] = DwtId.getListViewItemId(DwtId.WIDGET_ITEM_FIELD, this._view, item.id, ZmItem.F_ITEM_ROW_3PANE);
-	htmlArr[idx++] = "'>";
-	if (selectionCssClass) {
-		idx = ZmMailListView.prototype._getCellContents.apply(this, [htmlArr, idx, item, ZmItem.F_SELECTION, colIdx]);
+
+	var result = { value: null };
+	appCtxt.notifyZimlets("onZmConvListView_getAbridgedContent", [this, item, colIdx, htmlArr, idx, selectionCssClass, result]);
+	if (result.value) {
+		htmlArr = result.value.htmlArr;
+		idx = result.value.idx;
+	} else {
+		htmlArr[idx++] = "<div class='TopRow " + selectionCssClass + "' ";
+		htmlArr[idx++] = "id='";
+		htmlArr[idx++] = DwtId.getListViewItemId(DwtId.WIDGET_ITEM_FIELD, this._view, item.id, ZmItem.F_ITEM_ROW_3PANE);
+		htmlArr[idx++] = "'>";
+		if (selectionCssClass) {
+			idx = ZmMailListView.prototype._getCellContents.apply(this, [htmlArr, idx, item, ZmItem.F_SELECTION, colIdx]);
+		}
 	}
+
 	if (isMsg) {
 		idx = this._getAbridgedCell(htmlArr, idx, item, ZmItem.F_EXPAND, colIdx);
 	}

--- a/WebRoot/js/zimbraMail/mail/view/ZmInviteMsgView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmInviteMsgView.js
@@ -464,8 +464,9 @@ function(ptst) {
 		 disableButtonIds[ ZmOperation.PROPOSE_NEW_TIME] = true;
 	}
 	var inviteToolbar = this.getInviteToolbar();
-
 	var buttonIds = [ZmOperation.REPLY_ACCEPT, ZmOperation.REPLY_DECLINE, ZmOperation.REPLY_TENTATIVE, ZmOperation.PROPOSE_NEW_TIME];
+	appCtxt.notifyZimlets("onZmInviteMsgView_enableToolbarButtons", [buttonIds]);
+
 	for (var i = 0; i < buttonIds.length; i++) {
 		var buttonId = buttonIds[i];
 		inviteToolbar.getButton(buttonId).setEnabled(appCtxt.isExternalAccount() ? false : !disableButtonIds[buttonId]);
@@ -740,6 +741,8 @@ function() {
 		ZmOperation.REPLY_DECLINE,
 		ZmOperation.PROPOSE_NEW_TIME
 	];
+
+	appCtxt.notifyZimlets("onZmInviteMsgView_createInviteToolbar", [replyButtonIds, notifyOperationButtonIds, ignoreOperationButtonIds, inviteOps]);
 
 	var params = {
 		parent: this.parent,

--- a/WebRoot/js/zimbraMail/mail/view/ZmMailMsgListView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailMsgListView.js
@@ -219,14 +219,23 @@ function(item, colIdx) {
 			break;
 		}
 	}
-	// first row
-	htmlArr[idx++] = "<div class='TopRow " + selectionCssClass + "' ";
-	htmlArr[idx++] = "id='";
-	htmlArr[idx++] = DwtId.getListViewItemId(DwtId.WIDGET_ITEM_FIELD, this._view, item.id, ZmItem.F_ITEM_ROW_3PANE);
-	htmlArr[idx++] = "'>";
-	if (selectionCssClass) {
-		idx = ZmMailListView.prototype._getCellContents.apply(this, [htmlArr, idx, item, ZmItem.F_SELECTION, colIdx]);
+
+	var result = { value: null };
+	appCtxt.notifyZimlets("onZmMailMsgListView_getAbridgedContent", [this, item, colIdx, htmlArr, idx, selectionCssClass, result]);
+	if (result.value) {
+		htmlArr = result.value.htmlArr;
+		idx = result.value.idx;
+	} else {
+		// first row
+		htmlArr[idx++] = "<div class='TopRow " + selectionCssClass + "' ";
+		htmlArr[idx++] = "id='";
+		htmlArr[idx++] = DwtId.getListViewItemId(DwtId.WIDGET_ITEM_FIELD, this._view, item.id, ZmItem.F_ITEM_ROW_3PANE);
+		htmlArr[idx++] = "'>";
+		if (selectionCssClass) {
+			idx = ZmMailListView.prototype._getCellContents.apply(this, [htmlArr, idx, item, ZmItem.F_SELECTION, colIdx]);
+		}
 	}
+
 	idx = this._getAbridgedCell(htmlArr, idx, item, ZmItem.F_READ, colIdx, width);
 	idx = this._getAbridgedCell(htmlArr, idx, item, ZmItem.F_FROM, colIdx);
 	idx = this._getAbridgedCell(htmlArr, idx, item, ZmItem.F_DATE, colIdx, ZmMsg.COLUMN_WIDTH_DATE, "align=right", ["ZmMsgListDate"]);

--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmSignaturesPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmSignaturesPage.js
@@ -480,6 +480,13 @@ function(addSigs) {
 	}
 	var ic = appCtxt.getIdentityCollection();
 	var identities = ic && ic.getIdentities(true);
+
+	var result = { handled: false };
+	appCtxt.notifyZimlets("onZmSignaturesPage_resetUsageSelects", [this, identities, table, signatures, result]);
+	if (result.handled) {
+		return;
+	}
+
 	if (identities && identities.length) {
 		for (var i = 0, len = identities.length; i < len; i++) {
 			this._addUsageSelects(identities[i], table, signatures);

--- a/WebRoot/js/zimbraMail/prefs/ZmPreferencesApp.js
+++ b/WebRoot/js/zimbraMail/prefs/ZmPreferencesApp.js
@@ -525,6 +525,7 @@ ZmPreferencesApp.prototype._registerPrefs = function() {
 		}
 	}
 
+	appCtxt.notifyZimlets("onZmPreferencesApp_registerPrefs_before_registerPrefSection", [sections]);
 
 	for (var id in sections) {
 		ZmPref.registerPrefSection(id, sections[id]);
@@ -982,6 +983,8 @@ ZmPreferencesApp.prototype._registerPrefs = function() {
 		displayOptions:		[ZmMsg.displayAsHTML, ZmMsg.displayAsText],
 		options:			[true, false]
 	});
+
+	appCtxt.notifyZimlets("onZmPreferencesApp_registerPrefs", []);
 };
 
 // other

--- a/WebRoot/js/zimbraMail/prefs/controller/ZmFilterRulesController.js
+++ b/WebRoot/js/zimbraMail/prefs/controller/ZmFilterRulesController.js
@@ -340,7 +340,11 @@ function(ev) {
 	if (!listView) { return; }
 
 	var sel = listView.getSelection();
-	appCtxt.getFilterRuleDialog().popup(sel[0], true, null, null, this._outgoing);
+	var result = { handled: false };
+	appCtxt.notifyZimlets("onZmFilterRulesController_editListener", [this, sel, result]);
+	if (!result.handled) {
+		appCtxt.getFilterRuleDialog().popup(sel[0], true, null, null, this._outgoing);
+	}
 };
 
 /**

--- a/WebRoot/js/zimbraMail/prefs/controller/ZmPrefController.js
+++ b/WebRoot/js/zimbraMail/prefs/controller/ZmPrefController.js
@@ -399,6 +399,11 @@ function(ev, callback, noPop) {
 		return;
 	}
 
+	var result = { handled: false };
+	appCtxt.notifyZimlets("onZmPrefController_saveListener", [this, result]);
+	if (result.handled) {
+		return;
+	}
 	this.save(callback, noPop);
 };
 
@@ -521,8 +526,9 @@ function() {
 ZmPrefController.prototype._resetPageListener =
 function() {
 	var viewPage = this.getCurrentPage();
-
 	viewPage.reset(false);
+
+	appCtxt.notifyZimlets("onZmPrefController_resetPageListener", [this, viewPage]);
 	appCtxt.setStatusMsg(ZmMsg.defaultsPageRestore);
 };
 

--- a/WebRoot/js/zimbraMail/prefs/model/ZmPref.js
+++ b/WebRoot/js/zimbraMail/prefs/model/ZmPref.js
@@ -117,6 +117,11 @@ ZmPref.PAGE_SIZES = ["10", "25", "50", "100", "250", "500", "1000"];
 
 ZmPref.validateEmail =
 function(emailStr) {
+	var result = { handled: false, value: null };
+	appCtxt.notifyZimlets("onZmPref_validateEmail", [emailStr, result]);
+	if (result.handled) {
+		return result.value;
+	}
 	if (emailStr) {
 		// NOTE: Handle localhost for development purposes
 		return emailStr.match(/\@localhost$/i) || AjxEmailAddress.parse(emailStr) != null;

--- a/WebRoot/js/zimbraMail/prefs/view/ZmFilterPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmFilterPage.js
@@ -51,6 +51,9 @@ function() {
 		this._activityStreamsButton.setText(ZmMsg.activityStreamSettings);
 		this._activityStreamsButton.addSelectionListener(new AjxListener(this, this._activityStreamDialog));
 	}
+
+	appCtxt.notifyZimlets("onZmFilterPage_createControls", [this]);
+
 	this._tabView = new DwtTabView({parent:this, posStyle:Dwt.STATIC_STYLE});
 	this._tabView.reparentHtmlElement(this._htmlElId+"_tabview");
 	var incomingController = this._controller.getIncomingFilterRulesController();

--- a/WebRoot/js/zimbraMail/prefs/view/ZmFilterRulesView.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmFilterRulesView.js
@@ -374,6 +374,7 @@ function(sForce, tForce) {
 			this._moveDownButton.setEnabled(true);
 			this._moveUpButton.setEnabled(true);
 		}
+		appCtxt.notifyZimlets("onZmFilterRulesChooser_enableButtons", [this, listView, sel]);
 	}
 };
 

--- a/WebRoot/js/zimbraMail/prefs/view/ZmPrefView.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmPrefView.js
@@ -455,7 +455,11 @@ ZmPrefView.prototype._checkSection = function(section, viewPage, dirtyCheck, noV
                     } else {
                         pref.setValue(value);
                         if (pref.name) {
-                            list.push(pref);
+                            var result = { handled: false };
+                            appCtxt.notifyZimlets("onZmPrefView_checkSection", [this, pref, list, result]);
+                            if (!result.handled) {
+                                list.push(pref);
+                            }
                         }
                     }
                 } else if (!dirtyCheck) {

--- a/WebRoot/js/zimbraMail/prefs/view/ZmPreferencesPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmPreferencesPage.js
@@ -1086,6 +1086,13 @@ function(ev) {
 	var item = ev.dwtObj;
 	var button = this._dwtObjects[ZmSetting.LOCALE_NAME];
 	this._showLocale(item._localeId, button);
+
+	var result = { handled: false };
+	appCtxt.notifyZimlets("onZmPreferencesPage_localeSelectionListener", [this, item, result]);
+	if (result.handled) {
+		return;
+	}
+
     this._showComposeDirection(item._localeId);
 };
 

--- a/WebRoot/js/zimbraMail/share/controller/ZmFolderTreeController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmFolderTreeController.js
@@ -171,6 +171,7 @@ function(parent, type, id) {
 	var op = parent.getOp(ZmOperation.EMPTY_FOLDER);
 	if (op) {
 		op.setText(emptyText);
+		appCtxt.notifyZimlets("onZmFolderTreeController_resetOperations", [op, nId]);
 	}
 
     var isTrash = (nId == ZmOrganizer.ID_TRASH);

--- a/WebRoot/js/zimbraMail/share/controller/ZmSearchResultsController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmSearchResultsController.js
@@ -153,6 +153,7 @@ function(search, resultsCtlr) {
 	elements[ZmAppViewMgr.C_APP_CONTENT] = resultsCtlr.getViewMgr ? resultsCtlr.getViewMgr() : resultsCtlr.getCurrentView();
 
 	if (appCtxt.getCurrentViewId().indexOf(this._currentViewId) !== -1) {
+		appCtxt.notifyZimlets("onZmSearchResultsController_displayResults1", [this, search, resultsCtlr]);
 		appCtxt.getAppViewMgr().setViewComponents(this._currentViewId, elements, true);
 	}
 	else {
@@ -162,13 +163,21 @@ function(search, resultsCtlr) {
 		callbacks[ZmAppViewMgr.CB_POST_SHOW]    = this._postShowCallback.bind(this);
 		elements[ZmAppViewMgr.C_SEARCH_RESULTS_TOOLBAR] = this._toolbar;
 
+		var tabParams;
+		var result = { value: null };
+		appCtxt.notifyZimlets("onZmSearchResultsController_displayResults2", [this, search, resultsCtlr, result]);
+		if (result.value) {
+			tabParams = result.value;
+		} else {
+			tabParams = this._getTabParams();
+		}
 		this._app.createView({	viewId:		this._currentViewId,
 								viewType:	this._currentViewType,
 								elements:	elements,
 								callbacks:	callbacks,
 								controller:	this,
 								hide:		[ ZmAppViewMgr.C_TREE_FOOTER ],
-								tabParams:	this._getTabParams()});
+								tabParams:	tabParams});
 		this._app.pushView(this._currentViewId);
 		this._filterPanel.reset();
 
@@ -176,6 +185,8 @@ function(search, resultsCtlr) {
 			this._button = appCtxt.getAppChooser().getButton(this.tabId);
 			Dwt.addClass(this._button.getHtmlElement(), "SearchTabButton");
 			this._button.addSelectionListener(this._pinnedListener.bind(this));
+		} else {
+			appCtxt.notifyZimlets("onZmSearchResultsController_displayResults3", [this, search, resultsCtlr]);
 		}
 	}
 

--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -378,9 +378,13 @@ ZmSettings.prototype.setUserSettings = function(params) {
 		this.set(ZmSetting.MAIL_PREFERENCES_ENABLED, enableMailPrefs, setDefault, skipNotify, skipImplicit);
 		// Disable other areas where mail could be exposed to a prefs-only admin
 		if (this.get(ZmSetting.MAIL_PREFERENCES_ENABLED) && !this.get(ZmSetting.MAIL_ENABLED)) {
-			this.set(ZmSetting.MAIL_FORWARDING_ENABLED, false, setDefault, skipNotify, skipImplicit);
-			this.set(ZmSetting.FILTERS_MAIL_FORWARDING_ENABLED, false, setDefault, skipNotify, skipImplicit);
-			this.set(ZmSetting.NOTIF_FEATURE_ENABLED, false, setDefault, skipNotify, skipImplicit);
+			var result = { handled: false };
+			appCtxt.notifyZimlets("onZmSettings_setUserSettings", [this, setDefault, skipNotify, skipImplicit, result]);
+			if (!result.handled) {
+				this.set(ZmSetting.MAIL_FORWARDING_ENABLED, false, setDefault, skipNotify, skipImplicit);
+				this.set(ZmSetting.FILTERS_MAIL_FORWARDING_ENABLED, false, setDefault, skipNotify, skipImplicit);
+				this.set(ZmSetting.NOTIF_FEATURE_ENABLED, false, setDefault, skipNotify, skipImplicit);
+			}
 		}
 	}
 
@@ -1088,6 +1092,8 @@ function() {
 	this.registerSetting("CHAT_PLAY_SOUND",					{name:"zimbraPrefChatPlaySound", type: ZmSetting.T_PREF, dataType: ZmSetting.D_BOOLEAN, defaultValue:true, isGlobal:true});
 	this.registerSetting("CHAT_FEATURE_ENABLED",				{name:"zimbraFeatureChatEnabled", type: ZmSetting.T_COS, dataType: ZmSetting.D_BOOLEAN, defaultValue:true, isGlobal:true});
 	this.registerSetting("CHAT_ENABLED",				{name:"zimbraPrefChatEnabled", type: ZmSetting.T_PREF, dataType: ZmSetting.D_BOOLEAN, defaultValue:true, isGlobal:true});
+
+	appCtxt.notifyZimlets("onZmSettings_initialize", [this]);
 
 	ZmApp.runAppFunction("registerSettings", this);
 };

--- a/WebRoot/js/zimbraMail/share/view/ZmImportExportBaseView.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmImportExportBaseView.js
@@ -176,7 +176,9 @@ ZmImportExportBaseView.prototype._folderButton_onclick = function() {
                 continue;  //Skip voice folders for import/export (Bug: 72269)
             }
             var settingId = ZmApp.SETTING[ZmOrganizer.APP2ORGANIZER_R[org]];
-            if (settingId == null || appCtxt.get(settingId)) {
+            var result = { value: false };
+            appCtxt.notifyZimlets("onZmImportExportBaseView_folderButton_onclick", [settingId, result]);
+            if (settingId == null || appCtxt.get(settingId) || result.value) {
                 this._TREES[ZmImportExportController.TYPE_TGZ].push(org);
             }
         }

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmChooseFolderDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmChooseFolderDialog.js
@@ -581,7 +581,14 @@ function(ev) {
 	if (organizer.id == ZmFolder.ID_LOAD_FOLDERS) {
 		return;
 	}
-	var value = organizer ? organizer.getName(null, null, true) : ev.item.getText();
+	var value;
+	var result = { value: null };
+	appCtxt.notifyZimlets("onZmChooseFolderDialog_treeViewSelectionListener", [organizer, ev, result]);
+	if (result.value) {
+		value = result.value;
+	} else {
+		value = organizer ? organizer.getName(null, null, true) : ev.item.getText()
+	}
 	this._inputField.setValue(value);
 	if (ev.detail == DwtTree.ITEM_DBL_CLICKED || ev.enter) {
 		this._okButtonListener();

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropertyView.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropertyView.js
@@ -248,7 +248,12 @@ function(event) {
 	this._props.setPropertyVisible(this._permId, showPerm);
     $('#folderOfflineLblId').val(organizer.webOfflineSyncDays || 0)
 
-	Dwt.setVisible(this._excludeFbEl, !organizer.link && (organizer.type == ZmOrganizer.CALENDAR));
+	var result = { handled: false };
+	appCtxt.notifyZimlets("onZmFolderPropertyView_handleFolderChange", [this, result]);
+	if (!result.handled) {
+		Dwt.setVisible(this._excludeFbEl, !organizer.link && (organizer.type == ZmOrganizer.CALENDAR));
+	}
+
 	// TODO: False until server handling of the flag is added
 	//Dwt.setVisible(this._globalMarkReadEl, organizer.type == ZmOrganizer.FOLDER);
     Dwt.setVisible(this._globalMarkReadEl, false);

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
@@ -284,6 +284,7 @@ function(event) {
         this._tabInUse[retentionIndex] = true;
         retentionTabButton.setVisible(true);
         tabBar.setVisible(true);
+        appCtxt.notifyZimlets("onZmFolderPropsDialog_handleFolderChange", [this, retentionTabButton, tabBar, retentionIndex]);
     }
 
     for (var i = 0; i < this._tabViews.length; i++) {


### PR DESCRIPTION
Add notifyZimlets to create custom zimlets.

Additional changes:
* WebRoot/js/zimbraMail/core/ZmAppCtxt.js - modified `catch` block in `ZmAppCtxt.prototype.notifySkin` to output an error log in developer tools. No error dialog is shown in UI.
* WebRoot/js/zimbraMail/core/ZmOperation.js - add `ZmOperation.unregisterOp`. It is not called from anywhere in Zimbra code.