### PR TITLE
ZCS-12553: WCAG | Classic UI | Medium Complexity | Keyboard issues Part - 2

### DIFF
--- a/WebRoot/js/zimbraMail/abook/view/ZmEditContactView.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmEditContactView.js
@@ -2413,8 +2413,9 @@ ZmEditContactViewOther.prototype._createHtmlFromTemplate = function(templateId, 
         var checkbox = new DwtCheckbox({parent:container});
         checkbox.setText(ZmMsg.includeYear);
 		checkbox.addSelectionListener(new AjxListener(this, this._handleDateSelection,[calendar]));
-        this._calendarIncludeYear = checkbox;
-	}                                                        
+		this._calendarIncludeYear = checkbox;
+		calendar.tabgroup.addMember(checkbox);
+	}
 };
 
 // HACK: This function executes in the scope of the calendar picker

--- a/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
@@ -1080,12 +1080,17 @@ function(viewId) {
 	// possible, we position the navigation toolbar after it.
 	var pos = AjxUtil.indexOf(this._getToolBarOps(), ZmOperation.FILLER) + 1;
 
+	var prevButton = toolbar.getButton(ZmOperation.TODAY);
+	var nextButton = toolbar.getButton(ZmOperation.DAY_VIEW)
+
 	var tb = new ZmNavToolBar({
 		parent: toolbar,
 		index: pos,
 		className: "ZmNavToolbar ZmCalendarNavToolbar",
 		context: ZmId.VIEW_CAL,
-		posStyle: Dwt.ABSOLUTE_STYLE
+		posStyle: Dwt.ABSOLUTE_STYLE,
+		prevButton: prevButton,
+		nextButton: nextButton
 	});
 	this._setNavToolBar(tb, ZmId.VIEW_CAL);
 

--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptAssistantView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptAssistantView.js
@@ -132,7 +132,13 @@ function() {
 
     this._configureSuggestionWidgets();
 
-    this._tabGroup.addMember([this._optionsBtn, this._closeBtn]);
+    if (this._tabGroup) {
+        this._tabGroup.addMember([
+            this._optionsBtn,
+            this._closeBtn,
+            this._miniCalendar._compositeTabGroup
+        ]);
+    }
 };
 
 ZmApptAssistantView._handleKeyPress =

--- a/WebRoot/js/zimbraMail/calendar/view/ZmLocationSuggestionView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmLocationSuggestionView.js
@@ -36,6 +36,7 @@ ZmLocationSuggestionView = function(parent, controller, apptEditView, className)
     ZmSuggestionsView.call(this, parent, controller, apptEditView, ZmId.VIEW_SUGGEST_LOCATION_PANE, false, className);
     this._warning = false;
     this._emailToDivIdMap = {};
+    this._tabMember = null;
 };
 
 ZmLocationSuggestionView.prototype = new ZmSuggestionsView;
@@ -78,7 +79,8 @@ function(params) {
     this._emailToDivIdMap = {};
     this._items = params.locationInfo.locations;
     ZmListView.prototype.set.call(this, params.locationInfo.locations);
-    this.parent._tabGroup.addMember(this);
+    this.parent._tabGroup.replaceMember(this._tabMember, this);
+    this._tabMember = this;
 };
 
 ZmLocationSuggestionView.prototype.handleLocationOverflow =
@@ -118,7 +120,9 @@ function(warning) {
 
 // To prevent set of current focus location (when user navigate location using keyboard) as appointment's location.
 ZmLocationSuggestionView.prototype._emulateSingleClick =
-function() {
+function(params) {
+    this._clickDiv = this.findItemDiv(params.target);
+    ZmListView.prototype._itemSelected.call(this, this._clickDiv);
 };
 
 ZmLocationSuggestionView.prototype.handleKeyAction =

--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -1899,10 +1899,10 @@ function() {
 	}
 
 	if (appCtxt.get(ZmSetting.CAL_ALWAYS_SHOW_MINI_CAL)) {
-        var miniCalendar = appCtxt.getCalManager().getMiniCalendar();
-        rootTg.addMember(miniCalendar._compositeTabGroup);
-        miniCalendar.tabgroup = rootTg;
-    }
+		var miniCalendar = appCtxt.getCalManager().getMiniCalendar();
+		rootTg.addMember(miniCalendar._compositeTabGroup);
+		miniCalendar.tabgroup = rootTg;
+	}
 	
 	appCtxt.getKeyboardMgr().setTabGroup(rootTg);
 };

--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -1844,6 +1844,38 @@ ZmZimbraMail.prototype._setupTabGroups =
 function() {
 	DBG.println(AjxDebug.DBG2, "SETTING SEARCH CONTROLLER TAB GROUP");
 	var rootTg = appCtxt.getRootTabGroup();
+
+	var logoAnchor = document.querySelector('#skin_container_logo a');
+	if (logoAnchor) {
+		rootTg.addMember(logoAnchor);
+	}
+	
+	var topRow = document.querySelector('#skin_spacing_top_row');
+	if (topRow) {
+		var customSearchTabBlock = topRow.querySelector('#tabbed_search_syn ul');
+		if (customSearchTabBlock) {
+			var tabs = customSearchTabBlock.querySelectorAll('li a');
+
+			for (var i = 0; i < tabs.length; i++) {
+				var tab = tabs[i];
+				tab.setAttribute('tabindex', 0);
+				rootTg.addMember(tab);
+			}
+		}
+
+		var customSearchInput = topRow.querySelector('input#search_input');
+		if (customSearchInput) {
+			customSearchInput.setAttribute('tabindex', 0);
+			rootTg.addMember(customSearchInput);
+		}
+
+		var customSearchButton = topRow.querySelector('#search_input_button');
+		if (customSearchButton) {
+			customSearchButton.setAttribute('tabindex', 0);
+			rootTg.addMember(customSearchButton);
+		}
+	}
+
 	if (appCtxt.get(ZmSetting.SEARCH_ENABLED)) {
 		rootTg.addMember(appCtxt.getSearchController().getSearchToolbar().getTabGroupMember());
 	}
@@ -1865,6 +1897,12 @@ function() {
 		rootTg.addMember(overview.getTabGroupMember());
 		ZmController._currentOverview = overview;
 	}
+
+	if (appCtxt.get(ZmSetting.CAL_ALWAYS_SHOW_MINI_CAL)) {
+        var miniCalendar = appCtxt.getCalManager().getMiniCalendar();
+        rootTg.addMember(miniCalendar._compositeTabGroup);
+        miniCalendar.tabgroup = rootTg;
+    }
 	
 	appCtxt.getKeyboardMgr().setTabGroup(rootTg);
 };

--- a/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
@@ -179,14 +179,14 @@ function (ev) {
 			this._controller._tabGroup.replaceMember(this._headerFocusElement, nextElement);
 			this._controller._tabGroup.setFocusMember(nextElement);
 			this._headerFocusElement = nextElement;
-		}		
+		}
 	}
 
 	if (keyCode === DwtKeyEvent.KEY_SPACE) {
 		var currentHeaderItem = this._headerList[this._headerFocusElementIndex];
 		clickEl = document.getElementById(currentHeaderItem._id);
-        this._columnClicked(clickEl,ev);
-    }
+		this._columnClicked(clickEl,ev);
+	}
 
 	if (keyCode === DwtKeyEvent.KEY_ENTER && ev.metaKey) {
 		var actionMenu = this._colHeaderActionMenu = this._getActionMenuForColHeader();

--- a/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
@@ -146,8 +146,90 @@ function(list, sortField) {
     ZmListView.prototype.set.apply(this, arguments);
 
     this.markDefaultSelection(list);
+
+	if (this._listColDiv && !this.setHeaderListener) {
+		Dwt.setHandler(this._listColDiv, DwtEvent.ONKEYDOWN, ZmMailListView._headerKeyDown.bind(this));
+		this.setHeaderListener = true;
+		this.addHeaderItemInTagGroup();
+	}
 };
 
+ZmMailListView.prototype.addHeaderItemInTagGroup =
+function () {
+	var headerFirstItem = document.getElementById(this._headerItemsId[0]);
+	if (headerFirstItem) {
+		if (this._headerFocusElement) {
+			this._controller._tabGroup.replaceMember(this._headerFocusElement, headerFirstItem);
+		} else {
+			this._controller._tabGroup.addMember(headerFirstItem,1);
+		}
+		this._headerFocusElement = headerFirstItem;
+		this._headerFocusElementIndex = 0;
+	}
+};
+
+ZmMailListView._headerKeyDown =
+function (ev) {
+	var keyCode = DwtKeyEvent.getCharCode(ev);
+	if(keyCode === DwtKeyEvent.KEY_ARROW_RIGHT || keyCode === DwtKeyEvent.KEY_ARROW_LEFT) {
+		var nextElementIndex = keyCode === DwtKeyEvent.KEY_ARROW_RIGHT ? this._headerFocusElementIndex + 1 : this._headerFocusElementIndex - 1;
+		var nextElement = ZmMailListView._nextFocusableHeaderElement.call(this, keyCode, nextElementIndex);
+
+		if (nextElement) {
+			this._controller._tabGroup.replaceMember(this._headerFocusElement, nextElement);
+			this._controller._tabGroup.setFocusMember(nextElement);
+			this._headerFocusElement = nextElement;
+		}		
+	}
+
+	if (keyCode === DwtKeyEvent.KEY_SPACE) {
+		var currentHeaderItem = this._headerList[this._headerFocusElementIndex];
+		clickEl = document.getElementById(currentHeaderItem._id);
+        this._columnClicked(clickEl,ev);
+    }
+
+	if (keyCode === DwtKeyEvent.KEY_ENTER && ev.metaKey) {
+		var actionMenu = this._colHeaderActionMenu = this._getActionMenuForColHeader();
+		if (actionMenu && actionMenu instanceof DwtMenu) {
+			var rect = ev.target.getBoundingClientRect();
+			actionMenu.popup(0, rect.x, rect.y);
+		}
+	}
+};
+
+ZmMailListView._nextFocusableHeaderElement =
+function (keyCode, nextIndex) {
+	var nextElement = null;
+	var startIndex = nextIndex;
+
+	if (keyCode === DwtKeyEvent.KEY_ARROW_LEFT) {
+		this._headerItemsId.reverse();
+		startIndex = this._headerItemsId.length - 1 - nextIndex;
+	}
+
+	for (var i = startIndex; i < this._headerItemsId.length; i++) {
+		var element = document.getElementById(this._headerItemsId[i]);
+		if (element) {
+			this._headerFocusElementIndex = keyCode === DwtKeyEvent.KEY_ARROW_RIGHT ? i : (this._headerItemsId.length - 1 - i);
+			nextElement = element;
+			break;
+		}
+	}
+
+	if (keyCode === DwtKeyEvent.KEY_ARROW_LEFT) {
+		this._headerItemsId.reverse();
+	}
+	return nextElement;
+};
+
+ZmMailListView.prototype._colHeaderActionListener =
+function (ev) {
+	ZmListView.prototype._colHeaderActionListener.call(this, ev);
+	var headerElement = document.getElementById(this._headerItemsId[this._headerFocusElementIndex]);
+	this._controller._tabGroup.replaceMember(this._headerFocusElement, headerElement);
+	this._controller._tabGroup.setFocusMember(headerElement);
+	this._headerFocusElement = headerElement;
+};
 
 ZmMailListView.prototype.markDefaultSelection =
 function(list) {
@@ -360,6 +442,7 @@ function() {
 		this.set(list.clone());
 		this._restoreState();
 		this._resetFromColumnLabel();
+		this.addHeaderItemInTagGroup();
 	}
 };
 
@@ -729,7 +812,7 @@ function(htmlArr, idx, headerCol, i, numCols, id, defaultColumnSort) {
 													  "DwtListView-Column'";
 		htmlArr[idx++] = " width='auto'><table role='presentation' width='100%'><tr><td id='";
 		htmlArr[idx++] = DwtId.getListViewHdrId(DwtId.WIDGET_HDR_LABEL, this._view, field);
-		htmlArr[idx++] = "' class='DwtListHeaderItem-label'>";
+		htmlArr[idx++] = "' class='DwtListHeaderItem-label' tabindex='0'>";
 		htmlArr[idx++] = headerCol._label;
 		htmlArr[idx++] = "</td>";
 

--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmMailPrefsPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmMailPrefsPage.js
@@ -154,6 +154,8 @@ function() {
 	this._endDateField = Dwt.byId(this._htmlElId + "_VACATION_UNTIL1");
 
 	if (this._startDateField && this._endDateField) {
+		this._startDateField.setAttribute('parentid', this._htmlElId);
+		this._endDateField.setAttribute('parentid', this._htmlElId);
 		this._startDateVal = Dwt.byId(this._htmlElId + "_VACATION_FROM");
 		this._endDateVal = Dwt.byId(this._htmlElId + "_VACATION_UNTIL");
 		this._startDateField.setAttribute('parentid', this._htmlElId);

--- a/WebRoot/js/zimbraMail/share/controller/ZmListController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmListController.js
@@ -974,7 +974,13 @@ function(view, callback, result) {
 
 ZmListController.prototype._initializeNavToolBar =
 function(view) {
-	var tb = new ZmNavToolBar({parent:this._toolbar[view], context:view});
+	var prevButton, nextButton;
+
+	if (view === 'TKL-main') {
+		prevButton = this._toolbar[view].getButton(ZmOperation.VIEW_MENU);
+	}
+
+	var tb = new ZmNavToolBar({parent:this._toolbar[view], context:view, prevButton: prevButton, nextButton: nextButton});
 	this._setNavToolBar(tb, view);
 };
 

--- a/WebRoot/js/zimbraMail/share/controller/ZmSearchResultsController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmSearchResultsController.js
@@ -121,6 +121,15 @@ function() {
 	this._toolbar.registerEnterCallback(this._searchListener.bind(this));
 
 	this.isPinned = false;
+	this._setComposeTabGroup();
+};
+
+ZmSearchResultsController.prototype._setComposeTabGroup =
+function() {
+	this._tabGroup = this._createTabGroup();
+	var rootTg = appCtxt.getRootTabGroup();
+	this._tabGroup.newParent(rootTg);
+	this._tabGroup.addMember(this._toolbar._compositeTabGroup);
 };
 
 /**
@@ -199,6 +208,8 @@ function(search, resultsCtlr) {
         resultsCtlr.updateTimeIndicator();
     }
 	setTimeout(this._toolbar.focus.bind(this._toolbar), 100);
+	this._tabGroup.addMember(this._filterPanel._compositeTabGroup);
+	this._tabGroup.addMember(this._resultsController._tabGroup);
 };
 
 ZmSearchResultsController.prototype._postHideCallback =
@@ -219,6 +230,7 @@ function() {
 	if (appCtxt.isWebClientOfflineSupported) {
 		this.getApp().resetWebClientOfflineOperations(this);
 	}
+	ZmController.prototype._postShowCallback.call(this);
 };
 
 // returns params for the search tab button

--- a/WebRoot/js/zimbraMail/share/view/ZmNavToolBar.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmNavToolBar.js
@@ -46,6 +46,10 @@ ZmNavToolBar = function(params) {
 	params.toolbarType = ZmId.TB_NAV;
 	params.posStyle = params.posStyle || DwtControl.STATIC_STYLE;
 	ZmButtonToolBar.call(this, params);
+	
+	this._prevButton = params.prevButton;
+	this._nextButton = params.nextButton;
+
 	if (hasText) {
 		this._textButton = this.getButton(ZmOperation.TEXT);
 	}
@@ -57,6 +61,29 @@ ZmNavToolBar.prototype.constructor = ZmNavToolBar;
 ZmNavToolBar.prototype.toString = 
 function() {
 	return "ZmNavToolBar";
+};
+
+ZmNavToolBar.prototype.handleKeyAction =
+function (actionCode, ev) {
+	
+	var currentFocuseItem = this._getCurrentFocusItem();
+	switch(actionCode) {
+		case DwtKeyMap.PREV:
+			if (this._prevButton && currentFocuseItem === this.leftMostButton()) {
+				this.blur();
+				this.parent.focus(this._prevButton);
+				return true;
+			}
+			break;
+		case DwtKeyMap.NEXT:
+			if (this._nextButton && currentFocuseItem === this.rightMostButton()) {
+				this.blur();
+				this.parent.focus(this._nextButton);
+				return true;
+			}
+			break;
+	}
+	return DwtToolBar.prototype.handleKeyAction.call(this, actionCode, ev);
 };
 
 /**
@@ -80,6 +107,33 @@ function(ids, enabled) {
 				button.setToolTipContent(null);
 		}
 	}
+};
+
+ZmNavToolBar.prototype.leftMostButton =
+function() {
+	return this.nextSibling(true);
+};
+
+ZmNavToolBar.prototype.rightMostButton =
+function() {
+	return this.nextSibling(false);
+};
+
+ZmNavToolBar.prototype.nextSibling =
+function(next) {
+
+	var childCount = this.getItemCount();
+	var sibling = next ? this.getChild(0) : this.getChild(childCount - 1);
+
+	for (var i = 0; i < childCount; i++) {
+		var childIndex = next ? i : childCount - 1 - i;
+		var child = this.getChild(childIndex);
+		if (child._enabled) {
+			sibling = child;
+			break;
+		}
+	}
+	return sibling;
 };
 
 /**

--- a/WebRoot/templates/share/App.template
+++ b/WebRoot/templates/share/App.template
@@ -17,7 +17,7 @@
 
 <template id="share.App#Banner">
 	<table role="presentation" style='width:100%; height:100%'>
-		<tr><td align='center' valign='middle'><a<$ if (data.url && data.url != '') { $> href='${url}' target='_blank'<$ } $>><div class='ImgAppBanner' <$ if (data.isOffline) { $> style='width:220px;' <$ } $>></div></a></td></tr>
+		<tr><td align='center' valign='middle'><a tabindex='0' style='display:inline-block;'<$ if (data.url && data.url != '') { $> href='${url}' target='_blank'<$ } $>><div class='ImgAppBanner' <$ if (data.isOffline) { $> style='width:220px;' <$ } $>></div></a></td></tr>
 	</table>
 </template>
 


### PR DESCRIPTION
**2.1.1_Not able to access interactive elements with keyboard.docx**
> Fixed the issue of accessing Day, Week, Work week toolbar elements using keyboard left/right arrow keys. 
> The changes of this fixes are also applicable on Task toolbar. Previously, user stuck between Left/Right navigation arrow icons on task toolbar.

**2.1.1_Unable to access the calendar Popup with keyboard.docx**
> Added support to access calendar popup element using keyboard Tab and Arrow keys. 
> The changes are applicable to every calendar popup + mini calendar. 

**2.1.1_access issue-Mail.docx**
> Added support to access Mail list header items using keyboard Tab and left, right arrow keys.
> Added support to access Logo icon + MTS theme's customise search panel.

See the changes of zm-ajax https://github.com/Zimbra/zm-ajax/pull/111
See the changes of Bell MTS theme at https://stash.corp.synacor.com/projects/ZIMBRA/repos/mail-client/pull-requests/334/overview