### PR TITLE
ZCS-9175, ZBUG-1876: validation of Email Address field in external account setting

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
@@ -2756,6 +2756,7 @@ function(evt) {
 	if (!m) return;
 
 	var dataSource = this._currentAccount;
+	dataSource.email = email;
 	if (dataSource.userName == "") {
 		this._setControlValue("USERNAME", section, m[1]);
 	}

--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
@@ -1577,6 +1577,12 @@ function() {
 			this._errorMsg = ZmMsg.invalidPersonaName;
 			return false;
 		}
+		var section = this._currentSection;
+		var email = this._getControlValue("EMAIL", section);
+
+		if (isExternal && !this.__mandatoryEmail(email)) {
+			return false;
+		}
 		// bug 950
 		if (isExternal && !this.__validateEmail(this.__getAccountValue(account, "EMAIL"))) {
 			return false;
@@ -1614,6 +1620,15 @@ function(account, id) {
 	if (!prop) return;
 	var identity = account.getIdentity();
 	return identity && (typeof prop == "string" ? identity[prop] : identity[prop]());
+};
+
+ZmAccountsPage.prototype.__mandatoryEmail =
+function(str) {
+	if (!str || str.trim().length == 0) {
+		this._errorMsg = AjxMessageFormat.format(ZmMsg.fieldNameIsARequiredField, [ZmMsg.emailAddr]);
+		return false;
+	}
+	return true;
 };
 
 ZmAccountsPage.prototype.__validateEmail =
@@ -2975,6 +2990,14 @@ function(continueCallback) {
 			appCtxt.setStatusMsg(params);
 			continueCallback.run(false);
 			return;
+		}
+		if ((account.type == ZmAccount.TYPE_POP || account.type == ZmAccount.TYPE_IMAP) && account.email == "") {
+			if (account.userName.includes('@')) {
+				account.email = account.userName;
+			} else {
+				account.email = account.userName && account.mailServer ? [account.userName,account.mailServer].join("@") : account.userName;
+			}
+			this._accountListView.setCellContents(account, ZmItem.F_EMAIL, AjxStringUtil.htmlEncode(account.email));
 		}
 	}
 


### PR DESCRIPTION
**Problems:**
There are two problems in external imap/pop account setting. `zimbraDataSourceEmailAddress` is not set in a data source object in both cases. It should always be set and unique for check of duplication and for sieve filter execution.

* ZCS-9175
    * When the same email address is set in "Email address" and "Username of Account", `emailAddress` attribute is not set in CreateDetaSourceRequest. 

* ZBUG-1876
    * When "Email address" field is empty, `emailAddress` attribute is not set in CreateDetaSourceRequest.

**Changes:**
* ZCS-9175
    * Add the entered string to datasource object which is being edited

* ZBUG-1876
    * Add empty check on Email address
    * Generate an email address and set it to the list of accounts in Accounts section when it is empty.