### PR TITLE
ZCS-12614: WCAG | Classic UI | Medium Complexity | Keyboard issues Part - 3

### DIFF
--- a/WebRoot/js/zimbraMail/abook/view/ZmContactPicker.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmContactPicker.js
@@ -608,6 +608,18 @@ function(account) {
 	}
 	this._tabGroup.addMember(this._searchButton);
 	this._tabGroup.addMember(this._searchInSelect);
+
+	var sourceListHeaderItems = this._chooser.sourceListView._headerList;
+	this._sourceList = {};
+
+	for (var i = 0; i < sourceListHeaderItems.length; i++) {
+		var header = sourceListHeaderItems[i];
+		if (header._field === ZmItem.F_NAME) {
+			this._sourceList.name = document.getElementById(header._id);
+			this._tabGroup.addMember(this._sourceList.name);
+		}
+	}
+ 
 	this._tabGroup.addMember(this._chooser.getTabGroupMember());
 	this._tabGroup.addMember(this._prevButton);
 	this._tabGroup.addMember(this._nextButton);
@@ -978,7 +990,30 @@ function () {
         }
     }
     tlv.createHeaderHtml();
+
+	var sourceListHeaderItems = this._chooser.sourceListView._headerList;
+	for (var i = 0; i < sourceListHeaderItems.length; i++) {
+		var header = sourceListHeaderItems[i];
+		if (header._field === ZmItem.F_NAME) {
+			var nameHeader = document.getElementById(header._id);
+			nameHeader.onkeydown = ZmContactPicker.keydownHandler.bind(this);
+			this._tabGroup.replaceMember(this._sourceList.name, nameHeader);
+			this._sourceList.name = nameHeader;	
+		}
+	}
 };
+
+ZmContactPicker.keydownHandler =
+function(event) {
+	if (event.keyCode === DwtKeyEvent.KEY_ENTER) {
+		var iconElement = event.target.querySelector('.ImgColumnDownArrow') || event.target.querySelector('.ImgColumnUpArrow');
+		if (iconElement) {
+			var obj = DwtControl.getTargetControl(event)
+			obj.__ignoreNextClick = false;
+			iconElement.click();
+		}
+	}
+}
 
 /**
  * Done choosing addresses, add them to the compose form.

--- a/WebRoot/js/zimbraMail/abook/view/ZmEditContactView.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmEditContactView.js
@@ -1099,6 +1099,7 @@ ZmEditContactViewImage = function(params) {
 	this.addListener(DwtEvent.ONMOUSEOVER, new AjxListener(Dwt.addClass, [el,DwtControl.HOVER]));
 	this.addListener(DwtEvent.ONMOUSEOUT, new AjxListener(Dwt.delClass, [el,DwtControl.HOVER]));
 	this.addListener(DwtEvent.ONMOUSEUP, new AjxListener(this, this._chooseImage));
+	el.onkeydown = ZmEditContactViewImage._onKeyDown.bind(this);
 
 	this.setToolTipContent(ZmMsg.addImg);
 };
@@ -1180,6 +1181,12 @@ ZmEditContactViewImage.prototype._imageLoaded = function() {
 	var w = this._imgEl.width;
 	var h = this._imgEl.height;
     this._imgEl.setAttribute(w>h ? 'width' : 'height', 48);
+};
+
+ZmEditContactViewImage._onKeyDown = function(ev) {
+	if (ev.keyCode === DwtKeyEvent.KEY_ENTER) {
+		this._chooseImage();
+	}
 };
 
 /**

--- a/WebRoot/js/zimbraMail/abook/view/ZmEditContactView.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmEditContactView.js
@@ -1186,6 +1186,7 @@ ZmEditContactViewImage.prototype._imageLoaded = function() {
 ZmEditContactViewImage._onKeyDown = function(ev) {
 	if (ev.keyCode === DwtKeyEvent.KEY_ENTER) {
 		this._chooseImage();
+		return false;
 	}
 };
 

--- a/WebRoot/js/zimbraMail/abook/view/ZmEditContactView.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmEditContactView.js
@@ -1099,7 +1099,7 @@ ZmEditContactViewImage = function(params) {
 	this.addListener(DwtEvent.ONMOUSEOVER, new AjxListener(Dwt.addClass, [el,DwtControl.HOVER]));
 	this.addListener(DwtEvent.ONMOUSEOUT, new AjxListener(Dwt.delClass, [el,DwtControl.HOVER]));
 	this.addListener(DwtEvent.ONMOUSEUP, new AjxListener(this, this._chooseImage));
-	el.onkeydown = ZmEditContactViewImage._onKeyDown.bind(this);
+	Dwt.setHandler(el, DwtEvent.ONKEYDOWN, ZmEditContactViewImage._onKeyDown.bind(this));
 
 	this.setToolTipContent(ZmMsg.addImg);
 };

--- a/WebRoot/js/zimbraMail/mail/view/ZmMailConfirmView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailConfirmView.js
@@ -51,6 +51,7 @@ ZmMailConfirmView = function(parent, controller) {
 	this._addContactsButton.addSelectionListener(new AjxListener(this, this._addContactsListener));
 
 	this._summaryFormat = new AjxMessageFormat(ZmMsg.confirmSummary);
+	this._tabToolbarMember = null;
 };
 
 ZmMailConfirmView.prototype = new DwtComposite;
@@ -132,6 +133,13 @@ function(msg, newAddresses, existingContacts, displayAddresses) {
 	this._showNewAddresses(newAddresses);
 	this._showExistingContacts(existingContacts);
 	this._showDisplayAddresses(displayAddresses);
+
+	if (this._controller._toolbar) {
+		var closeButton = this._controller._toolbar.getButton(ZmOperation.CLOSE);
+		if (closeButton) {
+			this._tabGroup.addMember(closeButton);
+		}
+	}
 };
 
 ZmMailConfirmView.prototype._showLoading =

--- a/WebRoot/js/zimbraMail/share/view/ZmExportView.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmExportView.js
@@ -44,7 +44,7 @@ ZmExportView = function(params) {
 				],
 				onclick: this._type_onclick
 			},
-			{ id: "TYPE_HINT", type: "DwtText" },
+			{ id: "TYPE_HINT", type: "DwtText", notab: true },
 			{ id: "SUBTYPE", type: "DwtSelect",
 				visible: "get('TYPE') == ZmImportExportController.TYPE_CSV"
 			},

--- a/WebRoot/js/zimbraMail/share/view/ZmImportView.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmImportView.js
@@ -50,7 +50,7 @@ ZmImportView = function(params) {
 				enabled: "get('FILE')",
 				onclick: this._folderButton_onclick
 			},
-			{ id: "FORM" },
+			{ id: "FORM", notab: true },
 			{ id: "FILE",
 				setter: new Function() // no-op -- can't set a file value
 			},

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmUploadDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmUploadDialog.js
@@ -431,6 +431,7 @@ ZmUploadDialog.prototype._addFileInputRow = function(oneInputOnly) {
         var inputEl = document.getElementById(inputId);
         var sizeEl = cell;
         Dwt.setHandler(inputEl, "onchange", AjxCallback.simpleClosure(this._handleFileSize, this, inputEl, sizeEl));
+        Dwt.setHandler(inputEl, DwtEvent.ONKEYDOWN, ZmUploadDialog._handleEnterSpacePress.bind(inputEl, null));
     }
 
     if(oneInputOnly){
@@ -490,7 +491,12 @@ ZmUploadDialog._handleEnterSpacePress =
 function(listner, event) {
     var keyCode = DwtKeyEvent.getCharCode(event);
     if (keyCode === DwtKeyEvent.KEY_RETURN || keyCode === DwtKeyEvent.KEY_SPACE) {
-        listner(event);
+        if (listner) {
+            listner(event);
+        } else {
+            this.click();
+        }
+
     }
 }
 


### PR DESCRIPTION
**2.1.1_access issue graphic-New Contacts.docx**
- Fixed it by adding `Enter` key support, When focus is on user graphic icon then user need to press Enter key to open `upload image` dialog.

**2.1.1_access issue dialog-Mail.docx**
This issues are happening on client installed zimlets which are available under https://stash.corp.synacor.com/projects/ZIMBRA/repos/mail-client/browse/zimbra/zimlets
- Fixed all this issues. Changes are present at https://stash.corp.synacor.com/projects/ZIMBRA/repos/mail-client/pull-requests/336/overview

**1.4.3_contrast issue text dialog-Mail.docx**
- Fixes present at https://stash.corp.synacor.com/projects/ZIMBRA/repos/mail-client/pull-requests/336/overview

**2.1.1_access issue-Preferences.docx (Fix issue-1 mentioned in the doc file)**
- Added support to access checkbox control with keyboard Tab key navigation.

**2.1.2_trap issue-Preferencess.docx**
- Fixed. All intractable element of Import/export preference page are now accessible with keyboard tab navigation.

**2.1.1_access issue-New Mail Dialog.docx (Fix issue -4 mentioned in the doc file)**
- Fixed. Now `Name` header is accessible with keyboard tab navigation and user can sort the data by pressing `Space` key when focus is on `Name` header.

**2.1.1_access issue-Message Sent.docx**
- Fixed. User can access `Cancel` button appear on sent message delivery report with keyboard tab key.

See the changes of mail-client repo at https://stash.corp.synacor.com/projects/ZIMBRA/repos/mail-client/pull-requests/336/overview