### PR TITLE
ZBUG-2691: set favicon in calendar shown in a separate window

### DIFF
--- a/WebRoot/WEB-INF/tags/rest/restHead.tag
+++ b/WebRoot/WEB-INF/tags/rest/restHead.tag
@@ -21,6 +21,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ taglib prefix="fmt" uri="com.zimbra.i18n" %>
+<fmt:setBundle basename="/messages/ZhMsg" scope="request"/>
 
 <head>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">

--- a/WebRoot/WEB-INF/tags/rest/restHead.tag
+++ b/WebRoot/WEB-INF/tags/rest/restHead.tag
@@ -21,7 +21,6 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ taglib prefix="fmt" uri="com.zimbra.i18n" %>
-<fmt:setBundle basename="/messages/ZhMsg" scope="request"/>
 
 <head>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">

--- a/WebRoot/WEB-INF/tags/rest/restView.tag
+++ b/WebRoot/WEB-INF/tags/rest/restView.tag
@@ -18,6 +18,7 @@
 <%@ attribute name="title" rtexprvalue="true" required="true" %>
 <%@ attribute name="onload" rtexprvalue="true" required="false" %>
 <%@ attribute name="rssfeed" rtexprvalue="true" required="false" %>
+<%@ taglib prefix="app" uri="com.zimbra.htmlclient" %>
 <%@ taglib prefix="rest" uri="com.zimbra.restclient" %>
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>

--- a/WebRoot/WEB-INF/tags/rest/restView.tag
+++ b/WebRoot/WEB-INF/tags/rest/restView.tag
@@ -18,7 +18,6 @@
 <%@ attribute name="title" rtexprvalue="true" required="true" %>
 <%@ attribute name="onload" rtexprvalue="true" required="false" %>
 <%@ attribute name="rssfeed" rtexprvalue="true" required="false" %>
-<%@ taglib prefix="app" uri="com.zimbra.htmlclient" %>
 <%@ taglib prefix="rest" uri="com.zimbra.restclient" %>
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
@@ -26,7 +25,6 @@
 <%@ taglib prefix="fmt" uri="com.zimbra.i18n" %>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
-<app:skin />
 <c:set value="/img" var="iconPath" scope="request"/>
 <rest:head  title="${title}" rssfeed="${rssfeed}"/>
 <body <c:if test="${not empty onload}">onload="${onload}"</c:if>>

--- a/WebRoot/h/rest
+++ b/WebRoot/h/rest
@@ -1,6 +1,7 @@
 <%@ page buffer="8kb" autoFlush="true" %>
 <%@ page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
 <%@ page session="false" %>
+<%@ taglib prefix="app" uri="com.zimbra.htmlclient" %>
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 <%@ taglib prefix="rest" uri="com.zimbra.restclient" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
@@ -8,7 +9,6 @@
 <%@ taglib prefix="fmt" uri="com.zimbra.i18n" %>
 <c:set var="locale" value="${not empty requestScope.zimbra_target_account_prefLocale ? requestScope.zimbra_target_account_prefLocale : pageContext.request.locale}"/>
 <fmt:setLocale value='${locale}' scope='request' />
-<fmt:setBundle basename="/messages/ZhMsg" scope="request"/>
 
 <fmt:setTimeZone var="timezone" value="${zm:getTimeZone(not empty param.tz ? param.tz : requestScope.zimbra_target_account_prefTimeZoneId)}" scope="request"/>
 
@@ -17,8 +17,9 @@
 <c:set var="view" value="${requestScope.zimbra_target_item_view}"/>
 <c:set var="itemColor" value="${not empty param.color ? param.color : requestScope.zimbra_target_item_color}" scope="request"/>
 
-
 <zm:getMailbox var="mailbox" restauthtoken="${requestScope.zimbra_authToken}" csrfenabled="${requestScope.zimbra_csrfEnabled}" resttargetaccountid="${requestScope.zimbra_target_account_id}"/>
+<app:skin mailbox="${mailbox}"/>
+<fmt:setBundle basename="/messages/ZhMsg" scope="request"/>
 
 <c:choose>
     <c:when test="${(type eq 'folder' or type eq 'remote folder') and (view eq 'appointment')}">


### PR DESCRIPTION
**Issue:**
* favicon is not shown in a calendar shown in a separate window. (right-click a calendar and click "Open in a separate window")

**Changes:**
* In `h/rest`, call `app:skin` first and then call `fmt:setBundle` after a skin is identified. All tag files called from here can use a right ZhMsg. If ZhMsg exists in a skin directory, it is used. If it does not exist, default ZhMsg is used.
* `app:skin` in `restView.tag` is no longer necessary.