### PR TITLE
ZCS-12655 WCAG | Classic UI | Medium Complexity | Keyboard issues Part - 4

### DIFF
--- a/WebRoot/js/zimbraMail/briefcase/view/ZmDetailListView.js
+++ b/WebRoot/js/zimbraMail/briefcase/view/ZmDetailListView.js
@@ -640,6 +640,12 @@ function(ev) {
 	}
 };
 
+ZmDetailListView.prototype.createHeaderHtml =
+function (defaultColumnSort) {
+	DwtListView.prototype.createHeaderHtml.call(this, defaultColumnSort, this._isMultiColumn);
+	this.addHeaderItemInTagGroup();
+};
+
 ZmDetailListView.prototype._createHeader =
 function(htmlArr, idx, headerCol, i, numCols, id, defaultColumnSort) {
 

--- a/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
+++ b/WebRoot/js/zimbraMail/calendar/controller/ZmCalViewController.js
@@ -1117,9 +1117,10 @@ ZmCalViewController.prototype._initializeTabGroup = function(viewId) {
 	// ZmCalListView
 	if (viewId === ZmId.VIEW_CAL_LIST) {
 		var view = this._view[viewId];
+		var compositeMember = view._compositeTabGroup;
 		var topTabGroup = view._getSearchBarTabGroup();
 
-		this._tabGroups[viewId].addMemberBefore(topTabGroup, view);
+		this._tabGroups[viewId].addMemberBefore(topTabGroup, compositeMember);
 	}
 }
 
@@ -4114,6 +4115,22 @@ function(work, view, list, skipMiniCalUpdate, query) {
 				}
 			}
 		}
+
+		if (view.view !== ZmId.VIEW_CAL_LIST) {
+			for (var i = 0; i < list.size(); i++) {
+				var element = document.getElementById(view._getItemId(list.get(i)));
+				
+				if (element) {
+					element.setAttribute('tabindex', 0);
+					Dwt.setHandler(element, DwtEvent.ONKEYDOWN, ZmCalViewController._onKeyDown.bind(view));
+					if (!view._apptMember) {
+						view._compositeTabGroup.addMember(element);
+						view._apptMember = element;
+					}
+				}
+			}
+		}
+
 		this._resetToolbarOperations();
 	}
 
@@ -4131,6 +4148,16 @@ function(work, view, list, skipMiniCalUpdate, query) {
 	}
 };
 
+ZmCalViewController._onKeyDown =
+function (ev) {
+    if (ev.keyCode === DwtKeyEvent.KEY_ENTER && ev.metaKey) {
+        ev.button = DwtMouseEvent.RIGHT;
+        var rect = ev.target.getBoundingClientRect();
+        ev.docX = rect.x;
+        ev.docY = rect.y;
+        ZmCalBaseView.prototype._mouseDownListener.call(this, ev);
+    }
+}
 
 ZmCalViewController.prototype.refreshCurrentView =
  function() {

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalColView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalColView.js
@@ -1008,12 +1008,12 @@ function(abook) {
 	if (!this._scheduleMode) {
 		for (var i =0; i < this.numDays; i++) {
 		  html.append("<div id='", this._columns[i].daySepDivId, "' class='calendar_day_separator' style='position:absolute'></div>");
-		  html.append("<div id='", this._columns[i].workingHrsFirstDivId, "' style='position:absolute;background-color:#FFFFFF;'><div id='", this._columns[i].workingHrsFirstChildDivId, "' class='ImgCalendarDayGrid' style='position:absolute;top:0px;left:0px;overflow:hidden;'></div></div>");
+		  html.append("<div id='", this._columns[i].workingHrsFirstDivId, "' style='position:absolute;background-color:#FFFFFF;'><div id='", this._columns[i].workingHrsFirstChildDivId, "' tabindex='0' class='ImgCalendarDayGrid' style='position:absolute;top:0px;left:0px;overflow:hidden;'></div></div>");
 		  html.append("<div id='", this._columns[i].workingHrsSecondDivId, "' style='position:absolute;background-color:#FFFFFF;'><div id='", this._columns[i].workingHrsSecondChildDivId, "' class='ImgCalendarDayGrid' style='position:absolute;top:0px;left:0px;overflow:hidden;'></div></div>");
 		}
 	}
     else {
-        html.append("<div id='", this._workingHrsFirstDivId, "' style='position:absolute;background-color:#FFFFFF;'><div class='ImgCalendarDayGrid' id='", this._workingHrsFirstChildDivId, "' style='position:absolute;top:0px;left:0px;overflow:hidden;'></div></div>");
+        html.append("<div id='", this._workingHrsFirstDivId, "' style='position:absolute;background-color:#FFFFFF;'><div class='ImgCalendarDayGrid' tabindex='0' id='", this._workingHrsFirstChildDivId, "' style='position:absolute;top:0px;left:0px;overflow:hidden;'></div></div>");
         html.append("<div id='", this._workingHrsSecondDivId, "' style='position:absolute;background-color:#FFFFFF;'><div class='ImgCalendarDayGrid' id='", this._workingHrsSecondChildDivId, "' style='position:absolute;top:0px;left:0px;overflow:hidden;'></div></div>");
     }
 
@@ -1026,6 +1026,23 @@ function(abook) {
 	html.append("</div>");
 
 	this.getHtmlElement().innerHTML = html.toString();
+
+	if (!this._scheduleMode) {
+		for (var i = 0; i < this.numDays; i++) {
+			var workingHour = document.getElementById(this._columns[i].workingHrsFirstChildDivId);
+			if (workingHour) {
+				this._compositeTabGroup.addMember(workingHour);
+				Dwt.setHandler(workingHour, DwtEvent.ONKEYUP, ZmCalColView._onKeyUp.bind(this));
+			}
+		}
+	}
+	else {
+		var workingHour = document.getElementById(this._workingHrsFirstDivId);
+		if (workingHour) {
+			this._compositeTabGroup.addMember(workingHour);
+			Dwt.setHandler(workingHour, DwtEvent.ONKEYUP, ZmCalColView._onKeyUp.bind(this));
+		}
+	}
 
     var func = AjxCallback.simpleClosure(ZmCalColView.__onScroll, ZmCalColView, this);
 	document.getElementById(this._bodyDivId).onscroll = func;
@@ -1045,6 +1062,21 @@ ZmCalColView.prototype.updateTimeIndicator = function(force) {
 	this._updateTimeIndicator(force);
 	return this.setTimer(1);
 }
+
+ZmCalColView._onKeyUp =
+function(ev) {
+	if (ev.keyCode === DwtKeyEvent.KEY_ENTER) {
+		var rect = ev.target.getBoundingClientRect();
+		ev.docX = ev.elementX = rect.x;
+		ev.docY = ev.elementY = rect.y;
+		var start = this._getDateFromXY(rect.x + 10, rect.y, ZmCalColView._SNAP_MINUTES, false);
+		var currentDate = new Date();
+		start.setHours(currentDate.getHours());
+		start.setMinutes(currentDate.getMinutes());
+		start.setSeconds(currentDate.getSeconds());
+		appCtxt.getCurrentController().newAppointmentHelper(start, 0, null, null);
+	}
+};
 
 
 ZmCalColView.prototype._updateTimeIndicator = function(force) {

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalDayView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalDayView.js
@@ -284,7 +284,7 @@ function(abook) {
 	html.append("<div id='", this._timeSelectionDivId, "' name='_timeSelectionDivId' class='calendar_time_selection' style='position:absolute; display:none;z-index:10;'></div>");
 	html.append("<div id='", this._newApptDivId, "' name='_newApptDivId' class='appt-selected' style='position:absolute; display:none;'></div>");
 
-    html.append("<div id='", this._workingHrsFirstDivId, "' style='position:absolute;background-color:#FFFFFF;'><div class='ImgCalendarDayGrid' id='", this._workingHrsFirstChildDivId, "' style='position:absolute;top:0px;left:0px;overflow:hidden;'></div></div>");
+    html.append("<div id='", this._workingHrsFirstDivId, "' tabindex='0' style='position:absolute;background-color:#FFFFFF;'><div class='ImgCalendarDayGrid' id='", this._workingHrsFirstChildDivId, "' style='position:absolute;top:0px;left:0px;overflow:hidden;'></div></div>");
     html.append("<div id='", this._workingHrsSecondDivId, "' style='position:absolute;background-color:#FFFFFF;'><div class='ImgCalendarDayGrid' id='", this._workingHrsSecondChildDivId, "' style='position:absolute;top:0px;left:0px;overflow:hidden;'></div></div>");
 
     html.append("<div id='", this._borderLeftDivId, "' name='_borderLeftDivId' class='ZmDayTabSeparator' style='background-color:#FFFFFF;position:absolute;'></div>");
@@ -656,7 +656,13 @@ function() {
         this._createDivForColumn(col.borderRightDivId, dayParentEl, "ZmDayTabSeparator", calColor, calColor);
         this._createDivForColumn(col.borderTopDivId, allDaySepEl, "ZmDayTabSeparator", calColor, calColor);
 
-	}
+        var workingHrsFirstChildDiv = document.getElementById(col.workingHrsFirstChildDivId);
+        if (workingHrsFirstChildDiv){
+            workingHrsFirstChildDiv.setAttribute('tabindex',0);
+            this._compositeTabGroup.addMember(workingHrsFirstChildDiv);
+            Dwt.setHandler(workingHrsFirstChildDiv, DwtEvent.ONKEYUP, ZmCalColView._onKeyUp.bind(this));
+        }
+    }
 };
 
 ZmCalDayTabView.prototype._createDivForColumn =

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalListView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalListView.js
@@ -91,6 +91,7 @@ function(needsRefresh) {
 ZmCalListView.prototype.createHeaderHtml =
 function(defaultColumnSort) {
 	DwtListView.prototype.createHeaderHtml.call(this, defaultColumnSort, true);
+	this.addHeaderItemInTagGroup();
 };
 
 ZmCalListView.prototype.getDate =

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalMonthView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalMonthView.js
@@ -498,7 +498,7 @@ function(html, loc, week, dow) {
 	var did = Dwt.getNextId();
 	var tid = Dwt.getNextId();	
 
-	html.append("<td class='calendar_month_cells_td' id='", tdid, "'>");
+	html.append("<td tabindex='0' class='calendar_month_cells_td' id='", tdid, "'>");
 	html.append("<div style='width:100%;height:100%;'>");
 	html.append("<table role='presentation' class='calendar_month_day_table'>");
 	html.append("<tr><td colspan=2 id='", tid, "'></td></tr></table>");
@@ -613,7 +613,52 @@ function() {
 	html.append("</td></tr>");
 	html.append("</table>");
 	this.getHtmlElement().innerHTML = html.toString();
-    
+
+    var monthBodyEl = document.getElementById(this._daysId);
+    Dwt.setHandler(monthBodyEl, DwtEvent.ONKEYUP, ZmCalMonthView._onKeyUp.bind(this));
+
+};
+
+ZmCalMonthView._onKeyUp =
+function(ev) {
+    if ((ev.keyCode < DwtKeyEvent.KEY_ARROW_LEFT || ev.keyCode > DwtKeyEvent.KEY_ARROW_DOWN) && ev.keyCode !== DwtKeyEvent.KEY_ENTER) {
+        return;
+    }
+
+    var currentEl = ev.target;
+
+    if (currentEl.classList.value.includes('calendar_month_cells_td')) {
+        var currentElIndex = this._getItemData(currentEl, "loc");
+        var nextday = null;
+
+        switch(ev.keyCode) {
+            case DwtKeyEvent.KEY_ENTER:
+                ev.button = DwtMouseEvent.LEFT
+                this._mouseDownAction(ev, currentEl);
+                break;
+            case DwtKeyEvent.KEY_ARROW_RIGHT:
+                nextday = this._days[currentElIndex + 1];
+                break;
+            case DwtKeyEvent.KEY_ARROW_LEFT:
+                nextday = this._days[currentElIndex - 1];
+                break;
+            case DwtKeyEvent.KEY_ARROW_UP:
+                nextday = this._days[currentElIndex - 7];
+                break;
+            case DwtKeyEvent.KEY_ARROW_DOWN:
+                nextday = this._days[currentElIndex + 7];
+                break;
+            default:
+                return;
+        }
+
+        if (nextday) {
+            var nextDayEl = document.getElementById(nextday.tdId);
+            this._compositeTabGroup.replaceMember(this._tabMember, nextDayEl);
+            appCtxt._rootTabGrp.setFocusMember(nextDayEl)
+            this._tabMember = nextDayEl;
+        }
+    }
 };
 
 ZmCalMonthView.prototype._updateWeekNumber =
@@ -690,6 +735,18 @@ function() {
 	this._title = formatter.format(this._date);
 	var titleEl = document.getElementById(this._titleId);
 	titleEl.innerHTML = this._title;
+
+    if (!this._tabMember) {
+        var today = new Date();
+        var day = this._dateToDayIndex[this._dayKey(today)];
+        if (day) {
+            var todayEl = document.getElementById(day.tdId);
+            if (todayEl) {
+                this._compositeTabGroup.addMember(todayEl);
+                this._tabMember = todayEl;
+            }
+        }
+    }
 };
 
 ZmCalMonthView.prototype._calcDayIndex =
@@ -868,7 +925,7 @@ function(date, list, controller, noheader) {
 			var isNew = ao.ptst == ZmCalBaseItem.PSTATUS_NEEDS_ACTION;
 			var dur = ao.getDurationText(false, false);
 
-			html[idx++] = "<tr><td class='calendar_month_day_item'><div class='";
+			html[idx++] = "<tr><td class='calendar_month_day_item' tabindex='0'><div class='";
 			html[idx++] = ZmCalendarApp.COLORS[controller.getCalendarColor(ao.folderId)];
 			html[idx++] = isNew ? "DarkC" : "C";
 			html[idx++] = "'>";
@@ -1007,6 +1064,11 @@ function(dayInfo) {
     view.setLocation(loc.x+5, loc.y+5);
 
     view._layout(true);
+
+    if (!this.closeButtonInTab) {
+        this._compositeTabGroup.addMember(view._closeButton);
+        this.closeButtonInTab = view._closeButton;
+    }
 };
 
 ZmCalMonthView.prototype.expandDay =

--- a/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
@@ -147,88 +147,6 @@ function(list, sortField) {
 
     this.markDefaultSelection(list);
 
-	if (this._listColDiv && !this.setHeaderListener) {
-		Dwt.setHandler(this._listColDiv, DwtEvent.ONKEYDOWN, ZmMailListView._headerKeyDown.bind(this));
-		this.setHeaderListener = true;
-		this.addHeaderItemInTagGroup();
-	}
-};
-
-ZmMailListView.prototype.addHeaderItemInTagGroup =
-function () {
-	var headerFirstItem = document.getElementById(this._headerItemsId[0]);
-	if (headerFirstItem) {
-		if (this._headerFocusElement) {
-			this._controller._tabGroup.replaceMember(this._headerFocusElement, headerFirstItem);
-		} else {
-			this._controller._tabGroup.addMember(headerFirstItem,1);
-		}
-		this._headerFocusElement = headerFirstItem;
-		this._headerFocusElementIndex = 0;
-	}
-};
-
-ZmMailListView._headerKeyDown =
-function (ev) {
-	var keyCode = DwtKeyEvent.getCharCode(ev);
-	if(keyCode === DwtKeyEvent.KEY_ARROW_RIGHT || keyCode === DwtKeyEvent.KEY_ARROW_LEFT) {
-		var nextElementIndex = keyCode === DwtKeyEvent.KEY_ARROW_RIGHT ? this._headerFocusElementIndex + 1 : this._headerFocusElementIndex - 1;
-		var nextElement = ZmMailListView._nextFocusableHeaderElement.call(this, keyCode, nextElementIndex);
-
-		if (nextElement) {
-			this._controller._tabGroup.replaceMember(this._headerFocusElement, nextElement);
-			this._controller._tabGroup.setFocusMember(nextElement);
-			this._headerFocusElement = nextElement;
-		}
-	}
-
-	if (keyCode === DwtKeyEvent.KEY_SPACE) {
-		var currentHeaderItem = this._headerList[this._headerFocusElementIndex];
-		clickEl = document.getElementById(currentHeaderItem._id);
-		this._columnClicked(clickEl,ev);
-	}
-
-	if (keyCode === DwtKeyEvent.KEY_ENTER && ev.metaKey) {
-		var actionMenu = this._colHeaderActionMenu = this._getActionMenuForColHeader();
-		if (actionMenu && actionMenu instanceof DwtMenu) {
-			var rect = ev.target.getBoundingClientRect();
-			actionMenu.popup(0, rect.x, rect.y);
-		}
-	}
-};
-
-ZmMailListView._nextFocusableHeaderElement =
-function (keyCode, nextIndex) {
-	var nextElement = null;
-	var startIndex = nextIndex;
-
-	if (keyCode === DwtKeyEvent.KEY_ARROW_LEFT) {
-		this._headerItemsId.reverse();
-		startIndex = this._headerItemsId.length - 1 - nextIndex;
-	}
-
-	for (var i = startIndex; i < this._headerItemsId.length; i++) {
-		var element = document.getElementById(this._headerItemsId[i]);
-		if (element) {
-			this._headerFocusElementIndex = keyCode === DwtKeyEvent.KEY_ARROW_RIGHT ? i : (this._headerItemsId.length - 1 - i);
-			nextElement = element;
-			break;
-		}
-	}
-
-	if (keyCode === DwtKeyEvent.KEY_ARROW_LEFT) {
-		this._headerItemsId.reverse();
-	}
-	return nextElement;
-};
-
-ZmMailListView.prototype._colHeaderActionListener =
-function (ev) {
-	ZmListView.prototype._colHeaderActionListener.call(this, ev);
-	var headerElement = document.getElementById(this._headerItemsId[this._headerFocusElementIndex]);
-	this._controller._tabGroup.replaceMember(this._headerFocusElement, headerElement);
-	this._controller._tabGroup.setFocusMember(headerElement);
-	this._headerFocusElement = headerElement;
 };
 
 ZmMailListView.prototype.markDefaultSelection =
@@ -442,7 +360,6 @@ function() {
 		this.set(list.clone());
 		this._restoreState();
 		this._resetFromColumnLabel();
-		this.addHeaderItemInTagGroup();
 	}
 };
 
@@ -746,6 +663,7 @@ function(defaultColumnSort) {
 				}
 			}
 		}
+		this.addHeaderItemInTagGroup();
 	}
 
 	// Setting label on date column

--- a/WebRoot/js/zimbraMail/share/controller/ZmListController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmListController.js
@@ -352,9 +352,9 @@ function(view) {
 
 	ZmBaseController.prototype._initializeTabGroup.apply(this, arguments);
 
-	var navToolBar = this._navToolBar[view];
-	if (navToolBar) {
-		this._tabGroups[view].addMember(navToolBar.getTabGroupMember());
+	if (this._view[view]._compositeTabGroup) {
+		var tabSize = this._tabGroups[view].size();
+		this._tabGroups[view].addMember(this._view[view]._compositeTabGroup, tabSize - 1);
 	}
 };
 
@@ -976,7 +976,7 @@ ZmListController.prototype._initializeNavToolBar =
 function(view) {
 	var prevButton, nextButton;
 
-	if (view === 'TKL-main') {
+	if (view.includes('TKL')) {
 		prevButton = this._toolbar[view].getButton(ZmOperation.VIEW_MENU);
 	}
 

--- a/WebRoot/js/zimbraMail/share/view/ZmListView.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmListView.js
@@ -1065,6 +1065,86 @@ function(ev) {
 	}
 
 	this._relayout();
+
+	if (this._headerFocusElementIndex) {
+		var headerElement = document.getElementById(this._headerItemsId[this._headerFocusElementIndex]);
+		this._compositeTabGroup.replaceMember(this._headerFocusElement, headerElement);
+		this._compositeTabGroup.setFocusMember(headerElement);
+		this._headerFocusElement = headerElement;
+	}
+};
+
+ZmListView.prototype.addHeaderItemInTagGroup =
+function () {
+	Dwt.setHandler(this._listColDiv, DwtEvent.ONKEYDOWN, ZmListView._headerKeyDown.bind(this));
+
+	var headerFirstItem = document.getElementById(this._headerItemsId[0]);
+	if (headerFirstItem) {
+		headerFirstItem.setAttribute('tabindex', 0);
+		if (this._headerFocusElement) {
+			this._compositeTabGroup.replaceMember(this._headerFocusElement, headerFirstItem);
+		} else {
+			this._compositeTabGroup.removeAllMembers();
+			this._compositeTabGroup.addMember(headerFirstItem);
+		}
+		this._headerFocusElement = headerFirstItem;
+		this._headerFocusElementIndex = 0;
+	}
+};
+
+ZmListView._headerKeyDown =
+function (ev) {
+	var keyCode = DwtKeyEvent.getCharCode(ev);
+	if(keyCode === DwtKeyEvent.KEY_ARROW_RIGHT || keyCode === DwtKeyEvent.KEY_ARROW_LEFT) {
+		var nextElementIndex = keyCode === DwtKeyEvent.KEY_ARROW_RIGHT ? this._headerFocusElementIndex + 1 : this._headerFocusElementIndex - 1;
+		var nextElement = ZmListView._nextFocusableHeaderElement.call(this, keyCode, nextElementIndex);
+
+		if (nextElement) {
+			nextElement.setAttribute('tabindex', 0);
+			this._compositeTabGroup.replaceMember(this._headerFocusElement, nextElement);
+			this._compositeTabGroup.setFocusMember(nextElement);
+			this._headerFocusElement = nextElement;
+		}
+	}
+
+	if (keyCode === DwtKeyEvent.KEY_SPACE) {
+		var currentHeaderItem = this._headerList[this._headerFocusElementIndex];
+		clickEl = document.getElementById(currentHeaderItem._id);
+		this._columnClicked(clickEl,ev);
+	}
+
+	if (keyCode === DwtKeyEvent.KEY_ENTER && ev.metaKey) {
+		var actionMenu = this._colHeaderActionMenu = this._getActionMenuForColHeader();
+		if (actionMenu && actionMenu instanceof DwtMenu) {
+			var rect = ev.target.getBoundingClientRect();
+			actionMenu.popup(0, rect.x, rect.y);
+		}
+	}
+};
+
+ZmListView._nextFocusableHeaderElement =
+function (keyCode, nextIndex) {
+	var nextElement = null;
+	var startIndex = nextIndex;
+
+	if (keyCode === DwtKeyEvent.KEY_ARROW_LEFT) {
+		this._headerItemsId.reverse();
+		startIndex = this._headerItemsId.length - 1 - nextIndex;
+	}
+
+	for (var i = startIndex; i < this._headerItemsId.length; i++) {
+		var element = document.getElementById(this._headerItemsId[i]);
+		if (element) {
+			this._headerFocusElementIndex = keyCode === DwtKeyEvent.KEY_ARROW_RIGHT ? i : (this._headerItemsId.length - 1 - i);
+			nextElement = element;
+			break;
+		}
+	}
+
+	if (keyCode === DwtKeyEvent.KEY_ARROW_LEFT) {
+		this._headerItemsId.reverse();
+	}
+	return nextElement;
 };
 
 /**

--- a/WebRoot/js/zimbraMail/tasks/view/ZmTaskListView.js
+++ b/WebRoot/js/zimbraMail/tasks/view/ZmTaskListView.js
@@ -396,7 +396,7 @@ function(list, noResultsOk, doAdd) {
 
 		if (hdr._field == ZmItem.F_SUBJECT || hdr._field == ZmItem.F_SORTED_BY) {
 			this.dId = Dwt.getNextId();
-			htmlArr[idx++] = "<td><div class='newTaskBanner' onclick='ZmTaskListView._handleOnClick(this)' id='";
+			htmlArr[idx++] = "<td><div class='newTaskBanner' tabindex='0' onclick='ZmTaskListView._handleOnClick(this)' id='";
 			htmlArr[idx++] = this.dId;	// bug: 17653 - for QA
 			htmlArr[idx++] = "'>";
 			htmlArr[idx++] = ZmMsg.createNewTaskHint;
@@ -410,7 +410,12 @@ function(list, noResultsOk, doAdd) {
 	htmlArr[idx++] = "</tr></table>";
 	div.innerHTML = htmlArr.join("");
 	this._addRow(div, 0);
-    //this._renderTaskListItemHdr();
+	var newTaskInputs = document.getElementsByClassName('newTaskBanner');
+	if (newTaskInputs.length) {
+		var newTaskInput = newTaskInputs[0];
+		this._compositeTabGroup.addMember(newTaskInput);
+		Dwt.setHandler(newTaskInput, DwtEvent.ONKEYDOWN, ZmTaskListView._handleOnClick.bind(newTaskInput));
+	}
 };
 
 ZmTaskListView.prototype._resetListView =
@@ -715,6 +720,7 @@ function(defaultColumnSort) {
 			}
 		}
 	}
+	this.addHeaderItemInTagGroup();
 };
 
 ZmTaskListView.prototype._createHeader =


### PR DESCRIPTION
**2.1.1_Not able to access the calendar with keyboard.docx**
> Fixed. Now user can navigate to each appointments appear on calendar view, work view block and can open quick add appointment dialog by pressing Enter key when focus is on work view block.

See the changes for MTS theme https://stash.corp.synacor.com/projects/ZIMBRA/repos/mail-client/pull-requests/337/overview