### PR TITLE
ZCS-12675: Add ability to change date time format in Rest Calendar and Print Appointment

### DIFF
--- a/WebRoot/WEB-INF/tags/rest/restDisplayAppointment.tag
+++ b/WebRoot/WEB-INF/tags/rest/restDisplayAppointment.tag
@@ -120,7 +120,16 @@
                                             <c:set var="endDateCal" value="${zm:getCalendar(endDate.time, timezone)}"/>
                                         </c:otherwise>
                                     </c:choose>
-                                    ${fn:escapeXml(zm:getApptDateBlurb(pageContext, timezone, startDate.time, endDate.time, appt.allDay))}
+                                    <fmt:message key="ZM_formatRestApptDate" var="formatRestApptDate"/>
+                                    <fmt:message key="ZM_formatRestApptTime" var="formatRestApptTime"/>
+                                    <c:choose>
+                                        <c:when test="${formatRestApptDate eq '???ZM_formatRestApptDate???' or formatRestApptTime eq '???ZM_formatRestApptTime???'}">
+                                            ${fn:escapeXml(zm:getApptDateBlurb(pageContext, timezone, startDate.time, endDate.time, appt.allDay))}
+                                        </c:when>
+                                        <c:otherwise>
+                                            ${fn:escapeXml(zm:getApptDateBlurbWithTemplate(pageContext, timezone, startDate.time, endDate.time, appt.allDay, "ZM_formatRestApptDate", "ZM_formatRestApptTime"))}
+                                        </c:otherwise>
+                                    </c:choose>
                                     &nbsp;<span class='ZhCalTimeZone'>${fn:escapeXml(fn:startsWith(timezoneStr,"???") ? (zm:getCanonicalId(timezone)) : timezoneStr)}</span>
                                 </td>
                             </tr>
@@ -173,7 +182,15 @@
                                         :
                                     </td>
                                     <td class='MsgHdrValue'>
-                                        ${fn:escapeXml(zm:getRepeatBlurb(repeat,pageContext,timezone, appt.start.date))}
+                                        <fmt:message key="ZM_formatRestApptRecurDate" var="formatRestApptRecurDate"/>
+                                        <c:choose>
+                                            <c:when test="${formatRestApptRecurDate eq '???ZM_formatRestApptRecurDate???'}">
+                                                ${fn:escapeXml(zm:getRepeatBlurb(repeat,pageContext,timezone, appt.start.date))}
+                                            </c:when>
+                                            <c:otherwise>
+                                                ${fn:escapeXml(zm:getRepeatBlurbWithTemplate(repeat,pageContext,timezone, appt.start.date, "ZM_formatRestApptRecurDate"))}
+                                            </c:otherwise>
+                                        </c:choose>
                                     </td>
                                 </tr>
                             </c:if>

--- a/WebRoot/h/printappointments
+++ b/WebRoot/h/printappointments
@@ -163,7 +163,16 @@ action="compose" paction="view" id="${msg.id}"/>
                 <c:set var="endDateCal" value="${zm:getCalendar(endDate.time, tz)}"/>
             </c:otherwise>
         </c:choose>
-        ${fn:escapeXml(zm:getApptDateBlurb(pageContext, tz, startDate.time, endDate.time, appt.allDay))}
+        <fmt:message key="ZM_formatPrintApptDate" var="formatPrintApptDate"/>
+        <fmt:message key="ZM_formatPrintApptTime" var="formatPrintApptTime"/>
+        <c:choose>
+            <c:when test="${formatPrintApptDate eq '???ZM_formatPrintApptDate???' or formatPrintApptTime eq '???ZM_formatPrintApptTime???'}">
+                ${fn:escapeXml(zm:getApptDateBlurb(pageContext, tz, startDate.time, endDate.time, appt.allDay))}
+            </c:when>
+            <c:otherwise>
+                ${fn:escapeXml(zm:getApptDateBlurbWithTemplate(pageContext, tz, startDate.time, endDate.time, appt.allDay, "ZM_formatPrintApptDate", "ZM_formatPrintApptTime"))}
+            </c:otherwise>
+        </c:choose>
         &nbsp;
         <span class='ZhCalTimeZone'>
         <fmt:message var="displayName" bundle='${TzMsg}' key="${tz.ID}"/>
@@ -220,7 +229,15 @@ action="compose" paction="view" id="${msg.id}"/>
             :
         </td>
         <td class='MsgHdrValue'>
-                ${fn:escapeXml(zm:getRepeatBlurb(repeat,pageContext,tz, appt.start.date))}
+            <fmt:message key="ZM_formatPrintApptRecurDate" var="formatPrintApptRecurDate"/>
+            <c:choose>
+                <c:when test="${formatPrintApptRecurDate eq '???ZM_formatPrintApptRecurDate???'}">
+                    ${fn:escapeXml(zm:getRepeatBlurb(repeat, pageContext, tz, appt.start.date))}
+                </c:when>
+                <c:otherwise>
+                    ${fn:escapeXml(zm:getRepeatBlurbWithTemplate(repeat, pageContext, tz, appt.start.date, "ZM_formatPrintApptRecurDate"))}
+                </c:otherwise>
+            </c:choose>
         </td>
     </tr>
 </c:if>

--- a/WebRoot/messages/ZhMsg.properties
+++ b/WebRoot/messages/ZhMsg.properties
@@ -1798,6 +1798,16 @@ ZM_replyPrefix = ----- {0} wrote:
 ZM_originalMessage = ----- Original Message -----
 ZM_forwardedMessage = ----- Forwarded Message -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = A network service error has occurred.

--- a/WebRoot/messages/ZhMsg_ar.properties
+++ b/WebRoot/messages/ZhMsg_ar.properties
@@ -1805,6 +1805,16 @@ ZM_replyPrefix = ----- {0} \u0643\u062a\u0628:\u200f
 ZM_originalMessage = ----- \u0627\u0644\u0631\u0633\u0627\u0644\u0629 \u0627\u0644\u0623\u0635\u0644\u064a\u0629 -----
 ZM_forwardedMessage = ----- \u0627\u0644\u0631\u0633\u0627\u0644\u0629 \u0627\u0644\u062a\u064a \u0623\u0639\u064a\u062f \u062a\u0648\u062c\u064a\u0647\u0647\u0627 -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u062d\u062f\u062b \u062e\u0637\u0623 \u0641\u064a \u062e\u062f\u0645\u0629 \u0627\u0644\u0634\u0628\u0643\u0629.\u200f

--- a/WebRoot/messages/ZhMsg_ca.properties
+++ b/WebRoot/messages/ZhMsg_ca.properties
@@ -1798,6 +1798,16 @@ ZM_replyPrefix = ----- {0} ha escrit:
 ZM_originalMessage = ----- Missatge original -----
 ZM_forwardedMessage = ----- Missatge reenviat -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = S\u2019ha produ\u00eft un error al servei de xarxa.

--- a/WebRoot/messages/ZhMsg_da.properties
+++ b/WebRoot/messages/ZhMsg_da.properties
@@ -1799,6 +1799,16 @@ ZM_replyPrefix = ----- {0} skrev:
 ZM_originalMessage = ----- Original meddelelse -----
 ZM_forwardedMessage = ----- Videresendt meddelelse -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Der er opst\u00e5et en netv\u00e6rksservicefejl.

--- a/WebRoot/messages/ZhMsg_de.properties
+++ b/WebRoot/messages/ZhMsg_de.properties
@@ -1802,6 +1802,16 @@ ZM_replyPrefix = ----- {0} schrieb:
 ZM_originalMessage = ----- Urspr\u00fcngliche Mail -----
 ZM_forwardedMessage = ----- Weitergeleitete Mail -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Fehler im Netzwerkdienst

--- a/WebRoot/messages/ZhMsg_en_AU.properties
+++ b/WebRoot/messages/ZhMsg_en_AU.properties
@@ -1804,6 +1804,16 @@ ZM_replyPrefix = ----- {0} wrote:
 ZM_originalMessage = ----- Original Message -----
 ZM_forwardedMessage = ----- Forwarded Message -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = A network service error has occurred.

--- a/WebRoot/messages/ZhMsg_en_GB.properties
+++ b/WebRoot/messages/ZhMsg_en_GB.properties
@@ -1799,6 +1799,16 @@ ZM_replyPrefix = ----- {0} wrote:
 ZM_originalMessage = ----- Original Message -----
 ZM_forwardedMessage = ----- Forwarded Message -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = A network service error has occurred.

--- a/WebRoot/messages/ZhMsg_es.properties
+++ b/WebRoot/messages/ZhMsg_es.properties
@@ -1801,6 +1801,16 @@ ZM_replyPrefix = ----- {0} escribi\u00f3:
 ZM_originalMessage = ----- Mensaje original -----
 ZM_forwardedMessage = ----- Mensaje reenviado -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Ha ocurrido un error en el servicio de red.

--- a/WebRoot/messages/ZhMsg_eu.properties
+++ b/WebRoot/messages/ZhMsg_eu.properties
@@ -1793,6 +1793,16 @@ ZM_replyPrefix = ----- {0} erabiltzaileak idatzi du:
 ZM_originalMessage = ----- Jatorrizko mezua -----
 ZM_forwardedMessage = ----- Mezua birbidalia -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Errore bat gertatu da sare-zerbitzuan.

--- a/WebRoot/messages/ZhMsg_fr.properties
+++ b/WebRoot/messages/ZhMsg_fr.properties
@@ -1802,6 +1802,16 @@ ZM_replyPrefix = ----- {0} a \u00e9crit\u00a0:
 ZM_originalMessage = ----- Mail d\u2019origine -----
 ZM_forwardedMessage = ----- Mail transf\u00e9r\u00e9 -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Une erreur r\u00e9seau s\u2019est produite.

--- a/WebRoot/messages/ZhMsg_fr_CA.properties
+++ b/WebRoot/messages/ZhMsg_fr_CA.properties
@@ -1795,6 +1795,16 @@ ZM_replyPrefix = ----- {0} a \u00e9crit :
 ZM_originalMessage = ----- Courriel d\u2019origine -----
 ZM_forwardedMessage = ----- Courriel transf\u00e9r\u00e9 -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Une erreur r\u00e9seau s\u2019est produite.

--- a/WebRoot/messages/ZhMsg_hi.properties
+++ b/WebRoot/messages/ZhMsg_hi.properties
@@ -1799,6 +1799,16 @@ ZM_replyPrefix = ----- {0} \u0928\u0947 \u0932\u093f\u0916\u093e:
 ZM_originalMessage = ----- \u092e\u0942\u0932 \u092e\u0948\u0938\u0947\u091c -----
 ZM_forwardedMessage = ----- \u092b\u093c\u0949\u0930\u0935\u0930\u094d\u0921 \u0915\u093f\u092f\u093e \u0917\u092f\u093e \u092e\u0948\u0938\u0947\u091c -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u0915\u094b\u0908 \u0928\u0947\u091f\u0935\u0930\u094d\u0915 \u0938\u0947\u0935\u093e \u0924\u094d\u0930\u0941\u091f\u093f \u0906\u0908.

--- a/WebRoot/messages/ZhMsg_hu.properties
+++ b/WebRoot/messages/ZhMsg_hu.properties
@@ -1804,6 +1804,16 @@ ZM_replyPrefix = ----- {0} ezt \u00edrta:
 ZM_originalMessage = ----- Eredeti \u00fczenet -----
 ZM_forwardedMessage = ----- Tov\u00e1bb\u00edtott \u00fczenet -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Hiba t\u00f6rt\u00e9nt a h\u00e1l\u00f3zati szolg\u00e1ltat\u00e1sban.

--- a/WebRoot/messages/ZhMsg_in.properties
+++ b/WebRoot/messages/ZhMsg_in.properties
@@ -1795,6 +1795,16 @@ ZM_replyPrefix = ----- {0} menulis:
 ZM_originalMessage = ----- Pesan Asli -----
 ZM_forwardedMessage = ----- Pesan yang Diteruskan -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Terjadi kesalahan layanan jaringan.

--- a/WebRoot/messages/ZhMsg_it.properties
+++ b/WebRoot/messages/ZhMsg_it.properties
@@ -1799,6 +1799,16 @@ ZM_replyPrefix = ----- {0} ha scritto:
 ZM_originalMessage = ----- Messaggio originale -----
 ZM_forwardedMessage = ----- Messaggio inoltrato -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Si \u00e8 verificato un errore del servizio di rete.

--- a/WebRoot/messages/ZhMsg_iw.properties
+++ b/WebRoot/messages/ZhMsg_iw.properties
@@ -1794,6 +1794,16 @@ ZM_replyPrefix = ----- {0} \u05db\u05ea\u05d1:
 ZM_originalMessage = ----- \u05d4\u05d5\u05d3\u05e2\u05d4 \u05de\u05e7\u05d5\u05e8\u05d9\u05ea -----
 ZM_forwardedMessage = ----- \u05d4\u05d5\u05d3\u05e2\u05d4 \u05de\u05d5\u05e2\u05d1\u05e8\u05ea -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u05d0\u05d9\u05e8\u05e2\u05d4 \u05e9\u05d2\u05d9\u05d0\u05ea \u05e9\u05d9\u05e8\u05d5\u05ea\u05d9 \u05e8\u05e9\u05ea.

--- a/WebRoot/messages/ZhMsg_ja.properties
+++ b/WebRoot/messages/ZhMsg_ja.properties
@@ -1790,6 +1790,16 @@ ZM_replyPrefix = ----- {0}\u3055\u3093\u304c\u66f8\u3044\u305f\u30e1\u30c3\u30bb
 ZM_originalMessage = ----- \u5143\u306e\u30e1\u30c3\u30bb\u30fc\u30b8 -----
 ZM_forwardedMessage = ----- \u8ee2\u9001\u30e1\u30c3\u30bb\u30fc\u30b8 -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u30cd\u30c3\u30c8\u30ef\u30fc\u30af\u30b5\u30fc\u30d3\u30b9\u30a8\u30e9\u30fc\u304c\u767a\u751f\u3057\u307e\u3057\u305f\u3002

--- a/WebRoot/messages/ZhMsg_ko.properties
+++ b/WebRoot/messages/ZhMsg_ko.properties
@@ -1801,6 +1801,16 @@ ZM_replyPrefix = ----- {0} \uc791\uc131:
 ZM_originalMessage = ----- \uc6d0\ubcf8 \uba54\uc2dc\uc9c0 -----
 ZM_forwardedMessage = ----- \uc804\ub2ec \uba54\uc2dc\uc9c0 -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \ub124\ud2b8\uc6cc\ud06c \uc11c\ube44\uc2a4 \uc624\ub958\uac00 \ubc1c\uc0dd\ud588\uc2b5\ub2c8\ub2e4.

--- a/WebRoot/messages/ZhMsg_lo.properties
+++ b/WebRoot/messages/ZhMsg_lo.properties
@@ -1794,6 +1794,16 @@ ZM_replyPrefix = ----- {0} \u0e82\u0ebd\u0e99\u0ea7\u0ec8\u0eb2:
 ZM_originalMessage = ----- \u0e82\u0ecd\u0ec9\u200b\u0e84\u0ea7\u0eb2\u0ea1\u200b\u200b\u0ec0\u0e94\u0eb5\u0ea1 -----
 ZM_forwardedMessage = ----- \u0e82\u0ecd\u0ec9\u200b\u0e84\u0ea7\u0eb2\u0ea1\u200b\u0eaa\u0ebb\u0ec8\u0e87\u200b\u200b\u0e95\u0ecd\u0ec8\u200b\u0ec1\u0ea5\u0ec9\u0ea7 -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u0ec0\u0e81\u0eb5\u0e94\u200b\u0e84\u0ea7\u0eb2\u0ea1\u0e9c\u0eb4\u0e94\u0e9e\u0eb2\u0e94\u0e81\u0eb2\u0e99\u0e9a\u0ecd\u0ea5\u0eb4\u0e81\u0eb2\u0e99\u0ec0\u0e84\u0eb7\u0ead\u0e82\u0ec8\u0eb2\u0e8d\u0e82\u0eb6\u0ec9\u0e99.

--- a/WebRoot/messages/ZhMsg_ms.properties
+++ b/WebRoot/messages/ZhMsg_ms.properties
@@ -1804,6 +1804,16 @@ ZM_replyPrefix = ----- {0} menulis:
 ZM_originalMessage = -------- Mesej Asal --------
 ZM_forwardedMessage = ----- Mesej Dimajukan -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Ralat perkhidmatan rangkaian telah berlaku.

--- a/WebRoot/messages/ZhMsg_nl.properties
+++ b/WebRoot/messages/ZhMsg_nl.properties
@@ -1799,6 +1799,16 @@ ZM_replyPrefix = ----- {0} schreef:
 ZM_originalMessage = ----- Oorspronkelijk bericht -----
 ZM_forwardedMessage = ----- Doorgestuurd bericht -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Er is een netwerkservicefout opgetreden.

--- a/WebRoot/messages/ZhMsg_no.properties
+++ b/WebRoot/messages/ZhMsg_no.properties
@@ -1799,6 +1799,16 @@ ZM_replyPrefix = ----- {0} skrev:
 ZM_originalMessage = ----- Opprinnelig melding -----
 ZM_forwardedMessage = ----- Videresendt melding -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Det har oppst\u00e5tt en nettverkstjenestefeil.

--- a/WebRoot/messages/ZhMsg_pl.properties
+++ b/WebRoot/messages/ZhMsg_pl.properties
@@ -1804,6 +1804,16 @@ ZM_replyPrefix = ----- {0} napisa\u0142/a:
 ZM_originalMessage = ----- Wiadomo\u015b\u0107 oryginalna -----
 ZM_forwardedMessage = ----- Wiadomo\u015b\u0107 przekazana -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Wyst\u0105pi\u0142 b\u0142\u0105d us\u0142ugi sieciowej.

--- a/WebRoot/messages/ZhMsg_pt.properties
+++ b/WebRoot/messages/ZhMsg_pt.properties
@@ -1799,6 +1799,16 @@ ZM_replyPrefix = ----- {0} escreveu:
 ZM_originalMessage = ----- Mensagem original -----
 ZM_forwardedMessage = ----- Mensagem reencaminhada -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Ocorreu um erro no servi\u00e7o de rede.

--- a/WebRoot/messages/ZhMsg_pt_BR.properties
+++ b/WebRoot/messages/ZhMsg_pt_BR.properties
@@ -1799,6 +1799,16 @@ ZM_replyPrefix = ----- {0} escreveu:
 ZM_originalMessage = ----- Mensagem original -----
 ZM_forwardedMessage = ----- Mensagem encaminhada -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Ocorreu um erro no servi\u00e7o de rede.

--- a/WebRoot/messages/ZhMsg_ro.properties
+++ b/WebRoot/messages/ZhMsg_ro.properties
@@ -1804,6 +1804,16 @@ ZM_replyPrefix = ----- {0} a scris:
 ZM_originalMessage = ----- Mesaj original -----
 ZM_forwardedMessage = ----- Mesaj redirec\u0163ionat -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = S-a produs o eroare \u00een serviciul de re\u0163ea.

--- a/WebRoot/messages/ZhMsg_ru.properties
+++ b/WebRoot/messages/ZhMsg_ru.properties
@@ -1799,6 +1799,16 @@ ZM_replyPrefix = ----- {0} \u043f\u0438\u0448\u0435\u0442:
 ZM_originalMessage = ----- \u0418\u0441\u0445\u043e\u0434\u043d\u043e\u0435 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0435 -----
 ZM_forwardedMessage = ----- \u041f\u0435\u0440\u0435\u0441\u043b\u0430\u043d\u043d\u043e\u0435 \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0435 -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u041e\u0448\u0438\u0431\u043a\u0430 \u0441\u0435\u0442\u0438.

--- a/WebRoot/messages/ZhMsg_sl.properties
+++ b/WebRoot/messages/ZhMsg_sl.properties
@@ -1795,6 +1795,16 @@ ZM_replyPrefix = ----- {0} je napisal/a:
 ZM_originalMessage = ----- Izvirno sporo\u010dilo -----
 ZM_forwardedMessage = ----- Posredovano sporo\u010dilo -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Pri\u0161lo je do napake v omre\u017eni storitvi.

--- a/WebRoot/messages/ZhMsg_sv.properties
+++ b/WebRoot/messages/ZhMsg_sv.properties
@@ -1799,6 +1799,16 @@ ZM_replyPrefix = ----- {0} skrev:
 ZM_originalMessage = ----- Ursprungligt meddelande -----
 ZM_forwardedMessage = ----- Vidarebefordrat meddelande -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Ett n\u00e4tverksfel har intr\u00e4ffat.

--- a/WebRoot/messages/ZhMsg_ta.properties
+++ b/WebRoot/messages/ZhMsg_ta.properties
@@ -1804,6 +1804,16 @@ ZM_replyPrefix = ----- {0} \u0b8e\u0bb4\u0bc1\u0ba4\u0bbf\u0baf\u0ba4\u0bc1:
 ZM_originalMessage = ----- \u0b85\u0b9a\u0bb2\u0bcd \u0b9a\u0bc6\u0baf\u0bcd\u0ba4\u0bbf -----
 ZM_forwardedMessage = ----- \u0bae\u0bc1\u0ba9\u0bcd\u0ba9\u0ba9\u0bc1\u0baa\u0bcd\u0baa\u0baa\u0bcd\u0baa\u0b9f\u0bcd\u0b9f \u0b9a\u0bc6\u0baf\u0bcd\u0ba4\u0bbf -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u0ba8\u0bc6\u0b9f\u0bcd\u0bb5\u0bca\u0bb0\u0bcd\u0b95\u0bcd \u0b9a\u0bc7\u0bb5\u0bc8\u0baa\u0bcd \u0baa\u0bbf\u0bb4\u0bc8 \u0b8f\u0bb1\u0bcd\u0baa\u0b9f\u0bcd\u0b9f\u0ba4\u0bc1.

--- a/WebRoot/messages/ZhMsg_th.properties
+++ b/WebRoot/messages/ZhMsg_th.properties
@@ -1804,6 +1804,16 @@ ZM_replyPrefix = ----- {0} \u0e40\u0e02\u0e35\u0e22\u0e19:
 ZM_originalMessage = ----- \u0e02\u0e49\u0e2d\u0e04\u0e27\u0e32\u0e21\u0e15\u0e49\u0e19\u0e09\u0e1a\u0e31\u0e1a -----
 ZM_forwardedMessage = ----- \u0e02\u0e49\u0e2d\u0e04\u0e27\u0e32\u0e21\u0e2a\u0e48\u0e07\u0e15\u0e48\u0e2d -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u0e40\u0e01\u0e34\u0e14\u0e02\u0e49\u0e2d\u0e1c\u0e34\u0e14\u0e1e\u0e25\u0e32\u0e14\u0e01\u0e31\u0e1a\u0e1a\u0e23\u0e34\u0e01\u0e32\u0e23\u0e40\u0e04\u0e23\u0e37\u0e2d\u0e02\u0e48\u0e32\u0e22

--- a/WebRoot/messages/ZhMsg_tr.properties
+++ b/WebRoot/messages/ZhMsg_tr.properties
@@ -1804,6 +1804,16 @@ ZM_replyPrefix = ----- {0} \u015f\u00f6yle yaz\u0131yor:
 ZM_originalMessage = ----- Orijinal Mesaj -----
 ZM_forwardedMessage = ----- \u0130letilen Mesaj -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = Bir a\u011f hizmeti hatas\u0131 olu\u015ftu.

--- a/WebRoot/messages/ZhMsg_uk.properties
+++ b/WebRoot/messages/ZhMsg_uk.properties
@@ -1804,6 +1804,16 @@ ZM_replyPrefix = ----- {0} \u043f\u0438\u0448\u0435:
 ZM_originalMessage = ----- \u0412\u0438\u0445\u0456\u0434\u043d\u0435 \u043f\u043e\u0432\u0456\u0434\u043e\u043c\u043b\u0435\u043d\u043d\u044f -----
 ZM_forwardedMessage = ----- \u041f\u0435\u0440\u0435\u0441\u043b\u0430\u043d\u0435 \u043f\u043e\u0432\u0456\u0434\u043e\u043c\u043b\u0435\u043d\u043d\u044f -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u0412\u0438\u043d\u0438\u043a\u043b\u0430 \u043f\u043e\u043c\u0438\u043b\u043a\u0430 \u043c\u0435\u0440\u0435\u0436\u043d\u043e\u0457 \u0441\u043b\u0443\u0436\u0431\u0438.

--- a/WebRoot/messages/ZhMsg_vi.properties
+++ b/WebRoot/messages/ZhMsg_vi.properties
@@ -1797,6 +1797,16 @@ ZM_replyPrefix = ----- {0} \u0111\u00e3 vi\u1ebft:
 ZM_originalMessage = ----- Th\u01b0 g\u1ed1c -----
 ZM_forwardedMessage = -----Th\u01b0 \u0111\u00e3 chuy\u1ec3n ti\u1ebfp -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = M\u1ed9t l\u1ed7i d\u1ecbch v\u1ee5 m\u1ea1ng \u0111\u00e3 x\u1ea3y ra.

--- a/WebRoot/messages/ZhMsg_zh_CN.properties
+++ b/WebRoot/messages/ZhMsg_zh_CN.properties
@@ -1803,6 +1803,16 @@ ZM_replyPrefix = ----- {0} \u5199\u9053\uff1a
 ZM_originalMessage = ----- \u539f\u59cb\u90ae\u4ef6 -----
 ZM_forwardedMessage = ----- \u8f6c\u53d1\u90ae\u4ef6 -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u51fa\u73b0\u7f51\u7edc\u670d\u52a1\u9519\u8bef\u3002

--- a/WebRoot/messages/ZhMsg_zh_HK.properties
+++ b/WebRoot/messages/ZhMsg_zh_HK.properties
@@ -1798,6 +1798,16 @@ ZM_replyPrefix = ----- {0} \u5beb\u9053\ufe55
 ZM_originalMessage = ----- \u539f\u59cb\u90f5\u4ef6 -----
 ZM_forwardedMessage = ----- \u8f49\u5bc4\u90f5\u4ef6 -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u51fa\u73fe\u7db2\u7d61\u670d\u52d9\u932f\u8aa4\u3002

--- a/WebRoot/messages/ZhMsg_zh_TW.properties
+++ b/WebRoot/messages/ZhMsg_zh_TW.properties
@@ -1804,6 +1804,16 @@ ZM_replyPrefix = ----- {0}\u5beb\u9053:
 ZM_originalMessage = ----- \u539f\u59cb\u90f5\u4ef6 -----
 ZM_forwardedMessage = ----- \u8f49\u5bc4\u90f5\u4ef6 -----
 
+# format for an appointment shown in a separate window
+#ZM_formatRestApptDate
+#ZM_formatRestApptTime
+#ZM_formatRestApptRecurDate
+
+# format for print appointment page
+#ZM_formatPrintApptDate
+#ZM_formatPrintApptTime
+#ZM_formatPrintApptRecurDate
+
 ####### service.*
 
 service.FAILURE = \u767c\u751f\u7db2\u8def\u670d\u52d9\u932f\u8aa4\u3002


### PR DESCRIPTION
**Enhancement:**
Add ability to change date time format in Print Appointment page and Rest Calendar (right-click Calendar and click shown in a separate window).

**Scope:**
* Appointment in Rest Calendar
    * Date header (date and time)
    * Repeats header (date)
* Print appointment page
    * Date header (date and time)
    * Repeats header (date)

**New Keys in ZhMsg.properties:**
For Rest Calendar
* ZM_formatRestApptDate   (date format in Date header)
* ZM_formatRestApptTime   (time format in Date header)
* ZM_formatRestApptRecurDate   (date format in Repeats header)

For Print Appointment
* ZM_formatPrintApptDate   (date format in Date header)
* ZM_formatPrintApptTime   (time format in Date header)
* ZM_formatPrintApptRecurDate   (date format in Repeats header)

Note that the keys are disabled (commented out) by default.

**Behavior:**
Rest Calendar:
* For Date header, custom date time format is applied when both ZM_formatRestApptDate and ZM_formatRestApptTime are defined in ZhMsg. Otherwise, default format is used.
* For Repeats header, custom date format is applied when ZM_formatRestApptRecurDate is specified in ZhMsg. Otherwise, default format is used.

Print Appointment:
* For Date header, custom date time format is applied when both ZM_formatPrintApptDate and ZM_formatPrintApptTime are defined in ZhMsg. Otherwise, default format is used.
* For Repeats header, custom date format is applied when ZM_formatPrintApptRecurDate is specified in ZhMsg. Otherwise, default format is used.

**Server side change**
* https://github.com/Zimbra/zm-taglib/pull/45

**Example:**
Default date format in Repeats header on Rest Calendar
![screenshot (default)](https://user-images.githubusercontent.com/32184593/207881155-5360912f-63df-4e70-95de-925e32276d31.png)

When `ZM_formatRestApptRecurDate = yyyy/MM/dd(EEE)` is specified in ZhMsg.properties
![screenshot (custom date format)](https://user-images.githubusercontent.com/32184593/207881288-18d3020f-19ab-43b8-9032-2e0f03c8f1aa.png)