### PR TITLE
ZCS- 12659: WCAG | Classic UI | Medium Complexity | Headings

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalMonthView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalMonthView.js
@@ -551,7 +551,7 @@ function() {
 	}
 	html.append("</colgroup>");
 	html.append("<tr>");
-	html.append("<td colspan=7 class=calendar_month_header_month id='", this._titleId, "'></td>");
+	html.append("<td colspan=7 class=calendar_month_header_month role='heading' aria-level='3' id='", this._titleId, "'></td>");
 	html.append("</tr>");
 	html.append("<tr>");
 

--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -1847,6 +1847,10 @@ function() {
 
 	var logoAnchor = document.querySelector('#skin_container_logo a');
 	var applicationrow = document.querySelector('#skin_tr_app');
+	var headerTitle = document.querySelector('#headerTitle');
+	if (headerTitle) {
+		headerTitle.innerHTML = ZmMsg.zimbraTitle;
+	}
 	if (logoAnchor) {
 		rootTg.addMember(logoAnchor);
 	}

--- a/WebRoot/js/zimbraMail/prefs/view/ZmPreferencesPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmPreferencesPage.js
@@ -149,7 +149,7 @@ function() {
 		if (Dwt.hasClass(el, 'prefHeader')) {
 			var header = el;
 			header.setAttribute('role', 'heading');
-			header.setAttribute('aria-level', 1);
+			header.setAttribute('aria-level', 3);
 			header.id = Dwt.getNextId('prefHeader')
 		} else if (Dwt.hasClass(el, 'ZOptionsSectionTable')) {
 			var sectiontable = el;
@@ -184,9 +184,6 @@ function() {
 			DBG.println(AjxDebug.DBG1, "option field has no label " + Dwt.getId(field));
 			return;
 		}
-
-		label.setAttribute('role', 'heading');
-		label.setAttribute('aria-level', 2);
 
 		field.setAttribute('aria-labelledby',
 		                   Dwt.getId(label, 'ZOptionsLabel'));
@@ -251,9 +248,6 @@ function() {
 		if (!label.id) {
 			label.id = Dwt.getNextId();
 		}
-
-		label.setAttribute('role', 'heading');
-		label.setAttribute('aria-level', 2);
 	}
 };
 

--- a/WebRoot/js/zimbraMail/prefs/view/ZmShortcutsPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmShortcutsPage.js
@@ -411,7 +411,7 @@ ZmShortcutsPanel.prototype._createHtml = function() {
 	var html = [];
 	var i = 0;
 	html[i++] = "<div class='ShortcutsPanelHeader' id='" + headerId + "'>";
-	html[i++] = "<div class='title' role='header' aria-level='2'>" + ZmMsg.keyboardShortcuts + "</div>";
+	html[i++] = "<div class='title' role='header' aria-level='3'>" + ZmMsg.keyboardShortcuts + "</div>";
 	// set up HTML to create two columns using floats
 	html[i++] = "<div class='container' id='" + containerId + "'>";
 	html[i++] = "<div class='description'>" + ZmMsg.shortcutsCurrent + "</div>";

--- a/WebRoot/skins/_base/base2/skin.html
+++ b/WebRoot/skins/_base/base2/skin.html
@@ -34,6 +34,7 @@
 					<tr role='banner'>
 						<td id='skin_spacing_logo' width="130">
 							<div id='skin_container_logo' class='skin_container'></div>
+							<div id="headerTitle" role="heading" aria-level="1" class="ScreenReaderOnly"></div>
 						</td>
 						<td width="100%">
 							<div id='skin_container_toast' style='width:100%;height:100%'></div>

--- a/WebRoot/skins/_base/base3/skin.html
+++ b/WebRoot/skins/_base/base3/skin.html
@@ -34,6 +34,7 @@
 					<tr role='banner'>
 						<td id='skin_spacing_logo'>
 							<div id='skin_container_logo' class='skin_container'></div>
+							<div id="headerTitle" role="heading" aria-level="1" class="ScreenReaderOnly"></div>						
 						</td>
 						<td class='skin_td_flex'>
 							<div id='skin_container_toast'></div>

--- a/WebRoot/templates/abook/Contacts.template
+++ b/WebRoot/templates/abook/Contacts.template
@@ -435,7 +435,7 @@
 			fullnameHtml = '';
 		}
 	$>
-	<div id='${id}_contactName' class='contactHeader <$= data.isInTrash ? "Trash" : "" $>'><$= fullnameHtml $></div>
+	<div id='${id}_contactName' role='heading' aria-level='3' class='contactHeader <$= data.isInTrash ? "Trash" : "" $>'><$= fullnameHtml $></div>
 	<$ if (nickname && !isEdit) { $>
 		<div class='contactHeader'>&ldquo;<$= AjxStringUtil.htmlEncode(nickname) $>&rdquo;</div>
 	<$ } $>

--- a/WebRoot/templates/briefcase/Briefcase.template
+++ b/WebRoot/templates/briefcase/Briefcase.template
@@ -160,7 +160,7 @@
                                     <table role="presentation" width=100% height=100%>
                                         <tr>
                                             <td width="100%">
-                                                <div id="${id}_name" class="itemName"></div>
+                                                <div id="${id}_name" class="itemName" role="heading" aria-level="3"></div>
                                                 <div class="itemMeta"><span id="${id}_modified"></span>&nbsp;<$=ZmMsg.by$>&nbsp;<span id="${id}_modifier"></span></div>
                                             </td>
                                             <td align=middle width=30 valign="top">

--- a/WebRoot/templates/mail/Message.template
+++ b/WebRoot/templates/mail/Message.template
@@ -20,7 +20,7 @@
 										<div priority='<$=data.priority$>' id='<$=data.priorityDivId$>' style='margin-left:4px;' class='<$=data.priorityImg$>'></div>
 									</td>
 								<$ } $>
-								<td class='LabelColValue SubjectCol' valign=top width=100%>
+								<td class='LabelColValue SubjectCol' role='heading' aria-level='2' valign=top width=100%>
 									<$= data.subject $>
 								</td>
 								<td class='LabelColValue DateCol' align=right title='${dateTooltip}'>${dateString}</td>
@@ -157,7 +157,7 @@
 							<$ if (data.closeBtnCellId) { $>
 								<td id='${closeBtnCellId}'></td>
 							<$ } $>
-								<td class='LabelColValue SubjectCol ${subjChangeClass}' valign=top width=100%>
+								<td class='LabelColValue SubjectCol ${subjChangeClass}' role='heading' aria-level='2' valign=top width=100%>
 									<$= data.subject $>
 								</td>
 								<td class='LabelColValue DateCol' align=right title='${dateTooltip}'>${dateString}</td>
@@ -630,7 +630,7 @@
 
 <template id='mail.Message#Conv2Header'>
 	<span class="expandIcon" id='${convExpandId}'></span>
-	<span class="subject" role="heading" aria-level="1" id='${convSubjectId}'></span>
+	<span class="subject" role="heading" aria-level="2" id='${convSubjectId}'></span>
 	<span class="info" id='${convInfoId}'></span>
 </template>
 

--- a/WebRoot/templates/share/Widgets.template
+++ b/WebRoot/templates/share/Widgets.template
@@ -30,7 +30,7 @@
 	<table role="presentation" class='ZWidgetTable Z<$=buttonClass$>Table Z<$=buttonClass$>Border'style='table-layout:auto;'>
 		<tr role='none'>
 			<td role='none' id='${id}_left_icon'  	class='ZLeftIcon ZWidgetIcon'></td>
-			<td role='none' id='${id}_title'		class='ZWidgetTitle'></td>
+			<td role='heading' aria-level='2' id='${id}_title'		class='ZWidgetTitle'></td>
 			<td role='none' id='${id}_right_icon' 	class='ZRightIcon ZWidgetIcon'></td>
 			<td role='none' id='${id}_dropdown' 	class='ZDropDown'></td>
 		</tr>

--- a/WebRoot/templates/tasks/Tasks.template
+++ b/WebRoot/templates/tasks/Tasks.template
@@ -9,7 +9,7 @@
 
 <template id='tasks.Tasks#ReadOnlyView'>
 	<div class='MsgHeaderTable'>
-	<div class='SubjectCol LabelColValue' style="margin-left:5px;" id='zv__TKV__<$=Dwt.getNextId()$>__su'><$= data.subject $></div>
+	<div class='SubjectCol LabelColValue' role='heading' aria-level='3' style="margin-left:5px;" id='zv__TKV__<$=Dwt.getNextId()$>__su'><$= data.subject $></div>
 	<table role="presentation" id='${id}_hdrTable' class="ZPropertySheet" cellspacing="6" style="margin-left:5px;">
 
 		<$ if (data.location) { $><$= AjxTemplate.expand("tasks.Tasks#AddEntry", {lbl:ZmMsg.location, val:data.location, id:'__lo'}) $><$ } $>


### PR DESCRIPTION
**2.4.6_There are no heading throughout the Calendar Page.docx**

The sidebar of the calendar vertical has headings starting from level 2 and up to level 6 for nested folders.

The month view of Calendar Vertical has a level3 heading for the month name.

The title of the add event dialog is level3

**2.4.6_heading issue-Mail.docx**

The left sidebar all the headings have been defined by level based on their nesting level.

Considering only one level1 is required on a page, defined the top navigation of verticals as level2 headings.

the subject of the mail in the preview pane is level2 heading.

The contact name, briefcase file name, task name in the respective preview pane is assigned level3 heading.

**2.4.6_heading issue-Preferences.docx**

unnecessary headings defined for labels for preferences tab.

**2.4.6_heading issue h1-Preferences.docx**

Considering only one level1 is required on a page, defined one level1 which reads the name of the client.

See the changes of zm-ajax https://github.com/Zimbra/zm-ajax/pull/112