### PR TITLE
ZCS-12712: added ability to load domain-specific login page without redirection

### DIFF
--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -17,6 +17,26 @@
 <%-- this checks and redirects to admin if need be --%>
 <zm:adminRedirect/>
 <app:skinAndRedirect />
+<c:if test="${zm:isDomainLoginPageEnabled()}">
+    <zm:getDomainInfo var="domainInfo" by="virtualHostname" value="${zm:getServerName(pageContext)}"/>
+    <c:choose>
+        <c:when test="${not empty domainInfo}">
+            <c:set var="zimbraDomainLoginPagePath" value="${domainInfo.attrs.zimbraDomainLoginPagePath}" />
+            <c:choose>
+              <c:when test="${not empty zimbraDomainLoginPagePath}" >
+                <jsp:forward page="${zimbraDomainLoginPagePath}" />
+              </c:when>
+              <c:otherwise>
+                <jsp:forward page="${domainInfo.attrs.zimbraDomainLoginPageFallbackPath}" />
+              </c:otherwise>
+            </c:choose>
+        </c:when>
+        <c:otherwise>
+            <jsp:forward page="${zm:getDomainLoginPageErrorPath()}" />
+        </c:otherwise>
+    </c:choose>
+</c:if>
+
 <fmt:setLocale value='${pageContext.request.locale}' scope='request' />
 <fmt:setBundle basename="/messages/ZmMsg" scope="request"/>
 <fmt:setBundle basename="/messages/ZhMsg" var="zhmsg" scope="request"/>


### PR DESCRIPTION
**Enhancement:**
Add an ability to load a domain-specific login page without redirection for multi-tenant system.
`zimbraWebClientLoginURL` and `zimbraWebClientLogoutURL` cause redirection to the specified login/logout URL. There is a customer who doesn't want the redirection.

**Use case:**
For example, assuming
* `zimbraDomainLoginPageEnabled` is `TRUE`
* `zimbraDomainLoginPagePath` is `/custom/domain2-login.jsp`
* `zimbraDomainLoginPageFallbackPath` is `/custom/fallback.jsp`
* `zimbraDomainLoginPageErrorPath` is `/custom/error.jsp`
* the custom jsp files are deployed on `/opt/zimbra/jetty/webapps/zimbra/custom/` directory.
* a domain `domain2.dev.zimbra.com` exists. Its `zimbraVirtualHostname` is `vdomain2.dev.zimbra.com`.

In this case, when a user accesses a login page `https://vdomain2.dev.zimbra.com/` , `domain2-login.jsp` is loaded without redirection.
If `zimbraDomainLoginPagePath` is empty, `fallback.jsp` is loaded.
If DomainInfo cannot be fetched for some reason, `error.jsp` is loaded.

**Comparison:**
Redirect:
* an external server can be specified.
* at least two requests/responses are necessary. URL is changed by the redirection.

Forward:
* a path only on the server can be specified.
* it can be processed with a single request/response. URL is not changed.

**Related PRs:**
* https://github.com/Zimbra/zm-mailbox/pull/1432
* https://github.com/Zimbra/zm-taglib/pull/46