### PR TITLE
ZCS-12661 Fix classic client WCAG related issues

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
@@ -746,7 +746,7 @@ function(tabGroup) {
 
                         this._schButton,
                         this._scheduleView._tabGroup,
-                        this.getHtmlEditor(),
+                        this.getHtmlEditor().getTabGroupMember(),
                         this._scheduleAssistant._tabGroup
                     ]);
 };

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalItemEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalItemEditView.js
@@ -749,7 +749,9 @@ function(width) {
 	var dateCalSelectionListener = new AjxListener(this, this._dateCalSelectionListener);
 
 	// start/end date DwtCalendar's
+	this._startDateField = document.getElementById(this._htmlElId + "_startDateField");
 	this._startDateButton = ZmCalendarApp.createMiniCalButton(this, this._htmlElId + "_startMiniCalBtn", dateButtonListener, dateCalSelectionListener, ZmMsg.startDate);
+	this._endDateField = document.getElementById(this._htmlElId + "_endDateField");
 	this._endDateButton = ZmCalendarApp.createMiniCalButton(this, this._htmlElId + "_endMiniCalBtn", dateButtonListener, dateCalSelectionListener, ZmMsg.endDate);
 	this._startDateButton.setSize("20");
 	this._startDateButton.setAttribute('aria-label', ZmMsg.startDate);

--- a/WebRoot/js/zimbraMail/calendar/view/ZmCalMonthView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmCalMonthView.js
@@ -738,7 +738,7 @@ function() {
 
     if (!this._tabMember) {
         var today = new Date();
-        var day = this._dateToDayIndex[this._dayKey(today)];
+        var day = this._dateToDayIndex[this._dayKey(today)] || this._dateToDayIndex[Object.keys(this._dateToDayIndex)[0]];
         if (day) {
             var todayEl = document.getElementById(day.tdId);
             if (todayEl) {

--- a/WebRoot/js/zimbraMail/mail/controller/ZmConvController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmConvController.js
@@ -186,6 +186,12 @@ function(value) {
 	}
 };
 
+ZmConvController.prototype._initializeTabGroup =
+function(view) {
+	if (this._tabGroups[view]) { return; }
+	ZmBaseController.prototype._initializeTabGroup.apply(this, arguments);
+};
+
 ZmConvController.prototype._initializeView =
 function(view) {
 	if (!this._view[view]) {

--- a/WebRoot/js/zimbraMail/mail/controller/ZmMsgController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmMsgController.js
@@ -272,8 +272,7 @@ ZmMsgController.prototype._initializeTabGroup =
 function(view) {
 	if (this._tabGroups[view]) { return; }
 
-	ZmMailListController.prototype._initializeTabGroup.apply(this, arguments);
-
+	ZmBaseController.prototype._initializeTabGroup.apply(this, arguments);
 	this._tabGroups[view].removeMember(this._view[view]);
 };
 

--- a/WebRoot/js/zimbraMail/share/controller/ZmListController.js
+++ b/WebRoot/js/zimbraMail/share/controller/ZmListController.js
@@ -980,6 +980,10 @@ function(view) {
 		prevButton = this._toolbar[view].getButton(ZmOperation.VIEW_MENU);
 	}
 
+	if (view.includes('MSG')) {
+		prevButton = this._toolbar[view].getButton(ZmOperation.DETACH);
+	}
+
 	var tb = new ZmNavToolBar({parent:this._toolbar[view], context:view, prevButton: prevButton, nextButton: nextButton});
 	this._setNavToolBar(tb, view);
 };

--- a/WebRoot/js/zimbraMail/share/view/ZmListView.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmListView.js
@@ -1105,19 +1105,22 @@ function (ev) {
 			this._compositeTabGroup.setFocusMember(nextElement);
 			this._headerFocusElement = nextElement;
 		}
+		ev.stopPropagation();
 	}
 
 	if (keyCode === DwtKeyEvent.KEY_SPACE) {
 		var currentHeaderItem = this._headerList[this._headerFocusElementIndex];
 		clickEl = document.getElementById(currentHeaderItem._id);
 		this._columnClicked(clickEl,ev);
+		ev.stopPropagation();
 	}
 
-	if (keyCode === DwtKeyEvent.KEY_ENTER && ev.metaKey) {
-		var actionMenu = this._colHeaderActionMenu = this._getActionMenuForColHeader();
+	if (keyCode === DwtKeyEvent.KEY_ENTER && ev.ctrlKey) {
+		var actionMenu = this._getActionMenuForColHeader(true);
 		if (actionMenu && actionMenu instanceof DwtMenu) {
 			var rect = ev.target.getBoundingClientRect();
 			actionMenu.popup(0, rect.x, rect.y);
+			ev.stopPropagation();
 		}
 	}
 };

--- a/WebRoot/js/zimbraMail/share/view/ZmNavToolBar.js
+++ b/WebRoot/js/zimbraMail/share/view/ZmNavToolBar.js
@@ -128,7 +128,12 @@ function(next) {
 	for (var i = 0; i < childCount; i++) {
 		var childIndex = next ? i : childCount - 1 - i;
 		var child = this.getChild(childIndex);
-		if (child._enabled) {
+		if (child.isDwtText) {
+			if (child._enabled && child.getText()) {
+				sibling = child;
+				break;
+			}
+		} else if (child._enabled) {
 			sibling = child;
 			break;
 		}

--- a/WebRoot/js/zimbraMail/tasks/view/ZmTaskEditView.js
+++ b/WebRoot/js/zimbraMail/tasks/view/ZmTaskEditView.js
@@ -629,9 +629,25 @@ ZmTaskEditView.prototype._addTabGroupMembers =
 function(tabGroup) {
 	tabGroup.addMember(this._subjectField);
 	tabGroup.addMember(this._location);
+	tabGroup.addMember(this._prioritySelect);
+	tabGroup.addMember(this._folderSelect);
+	tabGroup.addMember(this._statusSelect);
+	tabGroup.addMember(this._pCompleteSelectInput);
+	tabGroup.addMember(this._pCompleteButton);
 
-	var bodyFieldId = this._notesHtmlEditor.getBodyFieldId();
-	tabGroup.addMember(document.getElementById(bodyFieldId));
+	tabGroup.addMember(this._startDateField);
+	tabGroup.addMember(this._startDateButton);
+	tabGroup.addMember(this._endDateField);
+	tabGroup.addMember(this._endDateButton);
+
+	tabGroup.addMember(this._reminderCheckbox);
+	tabGroup.addMember(this._remindDateField);
+	tabGroup.addMember(this._remindDateButton);
+	tabGroup.addMember(this._remindTimeSelect._timeSelectInput);
+	tabGroup.addMember(this._remindTimeSelect._timeSelectBtn);
+	tabGroup.addMember(this._reminderConfigure);
+
+	tabGroup.addMember(this._notesHtmlEditor.getTabGroupMember())
 };
 
 // Consistent spot to locate various dialogs
@@ -758,7 +774,16 @@ function(isEnabled) {
 
 ZmTaskEditView.prototype._setRemindersConfigureEnabled = function(enabled) {
 	this._reminderConfigure.setEnabled(enabled);
-    this._reminderConfigure.getHtmlElement().onclick = enabled ? AjxCallback.simpleClosure(skin.gotoPrefs, skin, "NOTIFICATIONS") : null;
+	var callBack = AjxCallback.simpleClosure(skin.gotoPrefs, skin, "NOTIFICATIONS");
+	this._reminderConfigure.getHtmlElement().onclick = enabled ? callBack : null;
+	Dwt.setHandler(this._reminderConfigure.getHtmlElement(), DwtEvent.ONKEYUP, ZmTaskEditView._keyUpHandler.bind(this, callBack));
+};
+
+ZmTaskEditView._keyUpHandler =
+function(callBack, ev) {
+	if (ev.keyCode === DwtKeyEvent.KEY_ENTER) {
+		callBack();
+	}
 };
 
 //

--- a/WebRoot/js/zimbraMail/tasks/view/ZmTaskEditView.js
+++ b/WebRoot/js/zimbraMail/tasks/view/ZmTaskEditView.js
@@ -775,10 +775,16 @@ function(isEnabled) {
 ZmTaskEditView.prototype._setRemindersConfigureEnabled = function(enabled) {
 	this._reminderConfigure.setEnabled(enabled);
 	var callBack = AjxCallback.simpleClosure(skin.gotoPrefs, skin, "NOTIFICATIONS");
-	this._reminderConfigure.getHtmlElement().onclick = enabled ? callBack : null;
+	Dwt.setHandler(this._reminderConfigure.getHtmlElement(), DwtEvent.ONCLICK, ZmTaskEditView._clickHandler.bind(this, callBack, enabled));
 	Dwt.setHandler(this._reminderConfigure.getHtmlElement(), DwtEvent.ONKEYUP, ZmTaskEditView._keyUpHandler.bind(this, callBack));
 };
 
+ZmTaskEditView._clickHandler =
+function(callback, enabled) {
+	if (enabled) {
+		callback();
+	}
+}
 ZmTaskEditView._keyUpHandler =
 function(callBack, ev) {
 	if (ev.keyCode === DwtKeyEvent.KEY_ENTER) {


### PR DESCRIPTION
Fixed element contrast and tab navigation related issues.
- On Add/Edit appointment dialog, included tinymce toolbar as part of keyboard tab navigation.
- On Add/Edit task dialog, Added all interactive elements as part of keyboard tab navigation.
- Calendar month view, Fixed tab navigation by including first's day block in the tab navigation when today's day block is not present in the current view.
- Message/Conversation view in the new tab, Fixed tab navigation. Previously, tab navigation get stuck on msg header block.
- Message/Conversation list view, Updated keyboard shortcut for opening context menu on header element.