### PR TITLE
ZCS-12725: added error handling for skin name

### DIFF
--- a/WebRoot/public/launchZCS.jsp
+++ b/WebRoot/public/launchZCS.jsp
@@ -1,6 +1,8 @@
 <%@ page buffer="8kb" session="true" autoFlush="true" pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
 <%@ page import="java.util.*,javax.naming.*,com.zimbra.client.ZAuthResult" %>
+<%@ page import="java.util.regex.Pattern" %>
 <%@ page import="com.zimbra.cs.taglib.bean.BeanUtils" %>
+<%@ page import="com.zimbra.common.util.ZimbraLog" %>
 <%@ taglib prefix="zm" uri="com.zimbra.zm" %>
 <%@ taglib prefix="app" uri="com.zimbra.htmlclient" %>
 <%@ taglib prefix="fmt" uri="com.zimbra.i18n" %>
@@ -41,11 +43,27 @@
     ZAuthResult authResult = (ZAuthResult) request.getAttribute("authResult");
     String skin = authResult.getSkin();
     if (skin == null) {
-        skin = authResult.getPrefs().get("zimbraPrefSkin").get(0);
+        try {
+            skin = authResult.getPrefs().get("zimbraPrefSkin").get(0);
+        } catch (Exception e) {
+            // do nothing
+        }
     }
+
+    if (skin == null || !Pattern.matches("^[A-Za-z0-9]+$", skin)) {
+        skin = "";
+        ZimbraLog.webclient.warn("a valid skin name could not be fetched. Default skin is used.");
+    }
+    pageContext.setAttribute("skin", skin, PageContext.REQUEST_SCOPE);
 %>
 <app:skinAndRedirect defaultSkin="${skin}" />
 <%
+    try {
+        skin = (String) pageContext.getAttribute("skin", PageContext.REQUEST_SCOPE);
+    } catch (Exception e) {
+        // do nothing
+    }
+
 	// Set to expire far in the past.
 	response.setHeader("Expires", "Tue, 24 Jan 2000 17:46:50 GMT");
 

--- a/WebRoot/public/launchZCS.jsp
+++ b/WebRoot/public/launchZCS.jsp
@@ -40,29 +40,29 @@
 		contextPath = "";
 	}
 
-    ZAuthResult authResult = (ZAuthResult) request.getAttribute("authResult");
-    String skin = authResult.getSkin();
-    if (skin == null) {
-        try {
-            skin = authResult.getPrefs().get("zimbraPrefSkin").get(0);
-        } catch (Exception e) {
-            // do nothing
-        }
-    }
+	ZAuthResult authResult = (ZAuthResult) request.getAttribute("authResult");
+	String skin = authResult.getSkin();
+	if (skin == null) {
+		try {
+			skin = authResult.getPrefs().get("zimbraPrefSkin").get(0);
+		} catch (Exception e) {
+			// do nothing
+		}
+	}
 
-    if (skin == null || !Pattern.matches("^[A-Za-z0-9]+$", skin)) {
-        skin = "";
-        ZimbraLog.webclient.warn("a valid skin name could not be fetched. Default skin is used.");
-    }
-    pageContext.setAttribute("skin", skin, PageContext.REQUEST_SCOPE);
+	if (skin == null || !Pattern.matches("^[A-Za-z0-9]+$", skin)) {
+		skin = "";
+		ZimbraLog.webclient.warn("a valid skin name could not be fetched. Default skin is used.");
+	}
+	pageContext.setAttribute("skin", skin, PageContext.REQUEST_SCOPE);
 %>
 <app:skinAndRedirect defaultSkin="${skin}" />
 <%
-    try {
-        skin = (String) pageContext.getAttribute("skin", PageContext.REQUEST_SCOPE);
-    } catch (Exception e) {
-        // do nothing
-    }
+	try {
+		skin = (String) pageContext.getAttribute("skin", PageContext.REQUEST_SCOPE);
+	} catch (Exception e) {
+		// do nothing
+	}
 
 	// Set to expire far in the past.
 	response.setHeader("Expires", "Tue, 24 Jan 2000 17:46:50 GMT");


### PR DESCRIPTION
**Issue:**
There is an edge case that zimbraPrefSkin cannot be fetched from auth result in launchZCS.jsp due to an error/exception on backend. In such a case, (part of) error message is unexpectedly set in `skin` variable at the following code.
```
String skin = authResult.getSkin();
```
The value of `skin` is not a valid skin name. When it happens, Classic UI is not shown at all - blank page is shown.

**Fix:**
Added error handling to launchZCS.jsp.
* If skin name cannot be fetched (null) or it is invalid name, set `skin` to an empty string.
* a valid or an empty skin name is passed to `<app:skinAndRedirect defaultSkin="${skin}" />`.  If `${skin}` is empty, a default skin is identified in the tag.
* get a skin identified in the tag using `getAttribute`, and set `skin` to the value.