### PR TITLE
ZCS-12836: Add ability to suppress sending a message from external email addresses

### DIFF
--- a/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
+++ b/WebRoot/js/zimbraMail/calendar/view/ZmApptEditView.js
@@ -1657,6 +1657,9 @@ function() {
     var defaultIdentity = identityCollection.defaultIdentity;
 	for (var i = 0, count = identities.length; i < count; i++) {
 		var identity = identities[i];
+		if (appCtxt.get("BLOCK_SEND_FROM_IMAP_POP") && identity.isFromDataSource) {
+			continue;
+		}
 		options.push(new DwtSelectOptionData(identity.id, this._getIdentityText(identity), (identity.id == defaultIdentity.id)));
 	}
 	return options;

--- a/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
@@ -3590,6 +3590,9 @@ function() {
 
 	for (var i = 0, count = identities.length; i < count; i++) {
 		var identity = identities[i];
+		if (appCtxt.get("BLOCK_SEND_FROM_IMAP_POP") && identity.isFromDataSource) {
+			continue;
+		}
 		options.push(new DwtSelectOptionData(identity.id, this._getIdentityText(identity)));
 	}
 	return options;

--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmSignaturesPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmSignaturesPage.js
@@ -489,6 +489,9 @@ function(addSigs) {
 
 	if (identities && identities.length) {
 		for (var i = 0, len = identities.length; i < len; i++) {
+			if (appCtxt.get("BLOCK_SEND_FROM_IMAP_POP") && identities[i].isFromDataSource) {
+				continue;
+			}
 			this._addUsageSelects(identities[i], table, signatures);
 		}
 	}

--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -927,6 +927,7 @@ function() {
     this.registerSetting("ATTACHMENTS_VIEW_IN_HTML_ONLY",	{name:"zimbraAttachmentsViewInHtmlOnly", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:false});
 	this.registerSetting("AVAILABLE_SKINS",					{type:ZmSetting.T_COS, dataType:ZmSetting.D_LIST, isGlobal:true});
 	this.registerSetting("AVAILABLE_CSVFORMATS",			{type:ZmSetting.T_COS, dataType:ZmSetting.D_LIST, isGlobal:true});
+	this.registerSetting("BLOCK_SEND_FROM_IMAP_POP",		{name:"zimbraBlockEmailSendFromImapPop", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:false});
 	this.registerSetting("CHANGE_PASSWORD_ENABLED",			{name:"zimbraFeatureChangePasswordEnabled", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:false});
 	this.registerSetting("DISPLAY_NAME",					{name:"displayName", type:ZmSetting.T_COS});
 	this.registerSetting("DUMPSTER_ENABLED",				{name:"zimbraDumpsterEnabled", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:true});

--- a/WebRoot/templates/prefs/Pages.template
+++ b/WebRoot/templates/prefs/Pages.template
@@ -1306,52 +1306,54 @@ and the container element is replaced with that control.
 						<td class='ZOptionsLabel'>&nbsp;</td>
 						<td class='ZOptionsField'><input id='${id}_EXTERNAL_DELETE_AFTER_DOWNLOAD' tabindex=0 type=checkbox></td>
 					</tr>
-					<tr><td colspan=2><hr /></td></tr>
-					<tr>
-						<td class='ZOptionsLabel' style='text-align:left' colspan=2><$=ZmMsg.accountFromPrompt$></td>
-					</tr>
-					<tr>
-						<td class='ZOptionsLabel'><$=ZmMsg.fromLabel$></td>
-						<td class='ZOptionsField'><$=ZmMsg.fromDetail$></td>
-					</tr>
-					<tr>
-						<td class='ZOptionsLabel'>&nbsp;</td>
-						<td class='ZOptionsField ZOptionsSubField'>
-							<table role="presentation">
-								<tr>
-									<td style='padding-right:.5em;'>
-										<input id='${id}_EXTERNAL_FROM_NAME' tabindex=0 size=30>
-									</td>
-								</tr>
-							</table>
-						</td>
-					</tr>
-					<tr>
-						<td class='ZOptionsLabel'><$=ZmMsg.setReplyTo$></td>
-						<td class='ZOptionsField'><input id='${id}_EXTERNAL_REPLY_TO' tabindex=0 type=checkbox></td>
-					</tr>
-					<tr>
-						<td class='ZOptionsLabel'>&nbsp;</td>
-						<td class='ZOptionsField ZOptionsSubField'>
-							<table role="presentation">
-								<tr>
-									<td style='padding-right:.5em;'>
-										<input id='${id}_EXTERNAL_REPLY_TO_NAME' tabindex=0 size=30>
-									</td>
-									<td class='ZmSelector'>
-										<select id='${id}_EXTERNAL_REPLY_TO_EMAIL' tabindex=0></select>
-									</td>
-								</tr>
-							</table>
-						</td>
-					</tr>
-					<tr>
-						<td class='ZOptionsLabel'><$=ZmMsg.signatureLabel$></td>
-						<td class='ZOptionsField' valign='middle'>
-						    <a id ='${id}_External_Signatures_Link' href='#Prefs.Signatures'><$=ZmMsg.manageSignaturesForExternalAccount$></a>
-						    <span id ='${id}_External_Signatures_Text'><$=ZmMsg.manageSignaturesForExternalAccount$></span>
-                        </td>
-					</tr>
+					<$ if (!appCtxt.get("BLOCK_SEND_FROM_IMAP_POP")) { $>
+						<tr><td colspan=2><hr /></td></tr>
+						<tr>
+							<td class='ZOptionsLabel' style='text-align:left' colspan=2><$=ZmMsg.accountFromPrompt$></td>
+						</tr>
+						<tr>
+							<td class='ZOptionsLabel'><$=ZmMsg.fromLabel$></td>
+							<td class='ZOptionsField'><$=ZmMsg.fromDetail$></td>
+						</tr>
+						<tr>
+							<td class='ZOptionsLabel'>&nbsp;</td>
+							<td class='ZOptionsField ZOptionsSubField'>
+								<table role="presentation">
+									<tr>
+										<td style='padding-right:.5em;'>
+											<input id='${id}_EXTERNAL_FROM_NAME' tabindex=0 size=30>
+										</td>
+									</tr>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<td class='ZOptionsLabel'><$=ZmMsg.setReplyTo$></td>
+							<td class='ZOptionsField'><input id='${id}_EXTERNAL_REPLY_TO' tabindex=0 type=checkbox></td>
+						</tr>
+						<tr>
+							<td class='ZOptionsLabel'>&nbsp;</td>
+							<td class='ZOptionsField ZOptionsSubField'>
+								<table role="presentation">
+									<tr>
+										<td style='padding-right:.5em;'>
+											<input id='${id}_EXTERNAL_REPLY_TO_NAME' tabindex=0 size=30>
+										</td>
+										<td class='ZmSelector'>
+											<select id='${id}_EXTERNAL_REPLY_TO_EMAIL' tabindex=0></select>
+										</td>
+									</tr>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<td class='ZOptionsLabel'><$=ZmMsg.signatureLabel$></td>
+							<td class='ZOptionsField' valign='middle'>
+								<a id ='${id}_External_Signatures_Link' href='#Prefs.Signatures'><$=ZmMsg.manageSignaturesForExternalAccount$></a>
+								<span id ='${id}_External_Signatures_Text'><$=ZmMsg.manageSignaturesForExternalAccount$></span>
+							</td>
+						</tr>
+					<$ } $>
 				</table>
 			</td>
 		</tr>


### PR DESCRIPTION
Hide the following items when zimbraBlockEmailSendFromImapPop is TRUE.
* Compose -> From options -> external imap / pop accounts
* Calendar ->  From options -> external imap / pop accounts
* Preferences -> Signatures -> external imap / pop accounts
* Preferences -> Accounts -> external imap / pop account setting -> Settings for Sent Messages (From display name, Reply-to and Signature)