### PR TITLE
ZCS-12881: add ability to show explanation in change password page

### DIFF
--- a/WebRoot/h/changepass
+++ b/WebRoot/h/changepass
@@ -102,6 +102,12 @@
                 </div>
                 <form method='post' name="changePassForm" id="zLoginForm" action="" autocomplete="off" accept-charset="utf-8" onsubmit="return compareConfirmPass();">
                     <c:if test="${successfullLogin ne 'true'}">
+                        <fmt:message key="passwordExplanation" var="passwordExplanation"/>
+                        <c:if test="${passwordExplanation ne '???passwordExplanation???'}">
+                            <div id='passwordExplanation'>
+                                <fmt:message key="passwordExplanation"/>
+                            </div>
+                        </c:if>
                         <div class="form">
                             <div class="loginSection">
                                 <input type="hidden" name="loginOp" value="login"/>


### PR DESCRIPTION
Adding an ability to show additional explanation in change password page when `passwordExplanation` is defined in `ZhMsg.properties`.