### PR TITLE
ZCS-12884: changed to use appContextPath on url of change password page

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
+++ b/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
@@ -1962,7 +1962,6 @@ function(ev) {
     		var publicUrl = appCtxt.get(ZmSetting.PUBLIC_URL);
     		if (publicUrl) {
     			var parts = AjxStringUtil.parseURL(publicUrl);
-    			path = parts.path + "/h/changepass";
     			var switchMode = (parts.protocol == "http" && proto == ZmSetting.PROTO_HTTPS);
     			proto = switchMode ? proto : parts.protocol;
     			port = switchMode ? port : parts.port;


### PR DESCRIPTION
**Problem:**
When zimbraMailURL is changed from `/` to `/test/path`, for example, user can access `https://host/test/path/` to log in to Classic UI. However, URL of change password page is always `https://host/h/changepass`. It needs to be `https://host/test/path/h/changepass`.

**Change:**
* always use `appContextPath` for the path as defined at line 1960
* If you don't want to add it to change password page, `zimbraChangePasswordURL` can be used.

**Note:**
User can access `https://host/` and login to Classic UI even when zimbraMailURL is set to `/test/path`. In this situation, when user accesses print message or compose in new window, the url becomes `https://host/test/path/`. After the fix, the path of change password page will be changed as same as others. (i.e. `https://host/test/path/h/changepass` will open)
```
ZmAppCtxt.prototype.getChangePasswordWindow =
function(ev) {
    var url = appCtxt.get(ZmSetting.CHANGE_PASSWORD_URL);
        if (!url) {
            // ...
            var path   = appContextPath+"/h/changepass";
            var publicUrl = appCtxt.get(ZmSetting.PUBLIC_URL);
            if (publicUrl) {
                var parts = AjxStringUtil.parseURL(publicUrl);
                path = parts.path + "/h/changepass";
```