### PR TITLE
ZCS-12542: increase the width of address picker dialog when Sharing feature and GAL are disabled

### DIFF
--- a/WebRoot/js/zimbraMail/abook/view/ZmContactPicker.js
+++ b/WebRoot/js/zimbraMail/abook/view/ZmContactPicker.js
@@ -509,7 +509,7 @@ function(account) {
 		this._resetSelectDiv();
 		this._searchInSelect.addChangeListener(new AjxListener(this, this._searchTypeListener));
 	} else {
-		this.setSize("600");
+		this.setSize("900px");
 	}
 
 	// Somehow the width gets changed to a very very high number after tree will be added, so lets save it here then re-apply

--- a/WebRoot/templates/abook/Contacts.template
+++ b/WebRoot/templates/abook/Contacts.template
@@ -985,7 +985,7 @@
 				<td>
 					<table role="presentation" width='100%'>
 						<tr>
-							<td width='600'>
+							<td width='600px'>
 								<table role="presentation" class='ZPropertySheet' cellspacing='6' id='${id}_searchTable'>
 									<$ if (data.detailed) { $>
 									<tr id='${id}_searchNameRow'>
@@ -1017,16 +1017,18 @@
 									<$ } $>
 								</table>
 							</td>
-							<td align='right' valign='bottom'>
-								<$ if (data.showSelect) { $>
-									<table role="presentation" class='ZPropertySheet' cellspacing='6'>
-										<tr>
-											<td class='Label nobreak' id='${id}_listSelectLbl'><$= ZmMsg.showNames $></td>
-											<td id='${id}_listSelect'></td>
-										</tr>
-									</table>
-								<$ } $>
-							</td>
+							<$ if (data.showSelect) { $>
+								<td align='right' valign='bottom'>
+										<table role="presentation" class='ZPropertySheet' cellspacing='6'>
+											<tr>
+												<td class='Label nobreak' id='${id}_listSelectLbl'><$= ZmMsg.showNames $></td>
+												<td id='${id}_listSelect'></td>
+											</tr>
+										</table>
+								</td>
+							<$ } else { $>
+								<td align='right' valign='bottom' width='300px'>
+							<$ } $>
 						</tr>
 					</table>
 				</td>


### PR DESCRIPTION
**Issue:**
When zimbraFeatureSharingEnabled and zimbraFeatureGalEnabled are FALSE, the width of address picker dialog is narrow.

**Root cause:**
When they are FALSE, "Show names from: + Options" is not included in the dialog. It is not just invisible but html elements for the label and option does not exist. Then the width of the dialog decreases.

**Fix:**
* set the width of the dialog to `900px` when the "Show names from:" option does not exist
* modified a template
    * When the option exists, it works as it is.
    * When it does not exist, `td` element with `width='300px'` is used.

**Additional information:**
When the attributes are TRUE, the width of the dialog depends on the max string length of "Show name from" options.
For example, with the following options,
(English)
* Global Address List
* Personal and Shared Contacts
* Contacts

(Japanese) 
* グローバルアドレスリスト
* 個人連絡先と共有連絡先
* 連絡先

the width of the dialog is set as follows:
(English):
* both TRUE:  927px
* both FALSE: 621px  -> 900px after the fix

(Japanese)
* enabled:  880px
* disabled: 622px  -> 900px after the fix