### PR TITLE
ZCS-12677: add ability to load css in a skin on print page

### DIFF
--- a/WebRoot/WEB-INF/tags/head.tag
+++ b/WebRoot/WEB-INF/tags/head.tag
@@ -41,13 +41,15 @@
     <c:choose>
         <c:when test="${not print}">
             <c:set var='css' value='/css/common,login,images,skin.css'/>
+            <c:set var="clientType" value="standard"/>
         </c:when>
         <c:otherwise>
-            <c:set var='css' value='/css/zhtml.css'/>
+            <c:set var='css' value='/css/zhtml,skin.css'/>
+            <c:set var="clientType" value="print"/>
         </c:otherwise>
     </c:choose>
     <c:url var='cssurl' value="${css}">
-        <c:param name="client"	value="standard" />
+        <c:param name="client"	value="${clientType}" />
         <c:param name="skin"	value="${skin}" />
         <c:param name="v"		value="${version}" />
         <c:param name="debug"   value="${param.dev}" />

--- a/WebRoot/skins/_base/base3/print.css
+++ b/WebRoot/skins/_base/base3/print.css
@@ -1,8 +1,7 @@
-<skin>
-<!--
+/*
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Web Client
- * Copyright (C) 2006, 2007, 2012, 2013, 2014, 2016 Synacor, Inc.
+ * Copyright (C) 2023 Synacor, Inc.
  *
  * The contents of this file are subject to the Common Public Attribution License Version 1.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,40 +17,7 @@
  * The Initial Developer of the Original Code is Zimbra, Inc.  All rights to the Original Code were
  * transferred by Zimbra, Inc. to Synacor, Inc. on September 14, 2015.
  *
- * All portions of the code are Copyright (C) 2006, 2007, 2012, 2013, 2014, 2016 Synacor, Inc. All Rights Reserved.
+ * All portions of the code are Copyright (C) 2012, 2013, 2014, 2016 Synacor, Inc. All Rights Reserved.
  * ***** END LICENSE BLOCK *****
--->
-	<common>
-		<substitutions>
-			<file>../_base/base3/skin.properties</file>
-			<file>skin.properties</file>
-		</substitutions>
-		<css>
-			<file>../_base/base3/skin.css</file>
-		</css>
-	</common>
-	<advanced>
-		<script>
-			<file>../_base/base3/ZmSkin.js</file>
-		</script>
-		<html>
-			<file>../_base/base3/skin.html</file>
-			<file>../_base/base3/splash.html</file>
-		</html>
-	</advanced>
-	<standard>
-		<css>
-			<file>../../css/zhtml.css</file>
-			<file>../_base/base3/zhtml.css</file>
-		</css>
-	</standard>		
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
-</skin>
+ */
+/* styles for print page */

--- a/WebRoot/skins/bare/manifest.xml
+++ b/WebRoot/skins/bare/manifest.xml
@@ -44,14 +44,14 @@
 			<file>../../css/zhtml.css</file>
 			<file>../_base/base3/zhtml.css</file>
 		</css>
-	</standard>		
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/beach/manifest.xml
+++ b/WebRoot/skins/beach/manifest.xml
@@ -29,29 +29,29 @@
 		<css>
 			<file>../_base/base3/skin.css</file>
 		</css>
-    </common>
-    <advanced>
-	    <script>
-    	    <file>../_base/base3/ZmSkin.js</file>
-    	</script>
+	</common>
+	<advanced>
+		<script>
+			<file>../_base/base3/ZmSkin.js</file>
+		</script>
 		<html>
 			<file>../_base/base3/skin.html</file>
 			<file>../_base/base3/splash.html</file>
 		</html>
 	</advanced>
 	<standard>
-        <css>
-            <file>../../css/zhtml.css</file>
-            <file>../_base/base3/zhtml.css</file>
-        </css>
-	</standard>		
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+		<css>
+			<file>../../css/zhtml.css</file>
+			<file>../_base/base3/zhtml.css</file>
+		</css>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/beach/manifest.xml
+++ b/WebRoot/skins/beach/manifest.xml
@@ -45,4 +45,13 @@
             <file>../_base/base3/zhtml.css</file>
         </css>
 	</standard>		
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/bones/manifest.xml
+++ b/WebRoot/skins/bones/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>		
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/bones/manifest.xml
+++ b/WebRoot/skins/bones/manifest.xml
@@ -44,14 +44,14 @@
 			<file>../../css/zhtml.css</file>
 			<file>../_base/base3/zhtml.css</file>
 		</css>
-	</standard>		
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/carbon/manifest.xml
+++ b/WebRoot/skins/carbon/manifest.xml
@@ -46,4 +46,13 @@
             <file>../_base/base3/zhtml.css</file>
         </css>
 	</standard>		
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/carbon/manifest.xml
+++ b/WebRoot/skins/carbon/manifest.xml
@@ -30,29 +30,29 @@
 			<file>../_base/base3/skin.css</file>
 			<file>skin.css</file>
 		</css>
-    </common>
-    <advanced>
-	    <script>
-    	    <file>../_base/base3/ZmSkin.js</file>
-    	</script>
+	</common>
+	<advanced>
+		<script>
+			<file>../_base/base3/ZmSkin.js</file>
+		</script>
 		<html>
 			<file>../_base/base3/skin.html</file>
 			<file>../_base/base3/splash.html</file>
 		</html>
 	</advanced>
 	<standard>
-        <css>
-            <file>../../css/zhtml.css</file>
-            <file>../_base/base3/zhtml.css</file>
-        </css>
-	</standard>		
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+		<css>
+			<file>../../css/zhtml.css</file>
+			<file>../_base/base3/zhtml.css</file>
+		</css>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/harmony/manifest.xml
+++ b/WebRoot/skins/harmony/manifest.xml
@@ -46,4 +46,13 @@
             <file>../_base/base3/zhtml.css</file>
         </css>
 	</standard>		
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/harmony/manifest.xml
+++ b/WebRoot/skins/harmony/manifest.xml
@@ -30,29 +30,29 @@
 			<file>../_base/base3/skin.css</file>
 			<file>skin.css</file>
 		</css>
-    </common>
-    <advanced>
-	    <script>
-    	    <file>../_base/base3/ZmSkin.js</file>
-    	</script>
+	</common>
+	<advanced>
+		<script>
+			<file>../_base/base3/ZmSkin.js</file>
+		</script>
 		<html>
 			<file>../_base/base3/skin.html</file>
 			<file>../_base/base3/splash.html</file>
 		</html>
 	</advanced>
 	<standard>
-        <css>
-            <file>../../css/zhtml.css</file>
-            <file>../_base/base3/zhtml.css</file>
-        </css>
-	</standard>		
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+		<css>
+			<file>../../css/zhtml.css</file>
+			<file>../_base/base3/zhtml.css</file>
+		</css>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/hotrod/manifest.xml
+++ b/WebRoot/skins/hotrod/manifest.xml
@@ -30,7 +30,7 @@
 			<file>../_base/base3/skin.css</file>
 		</css>
 	</common>
-	<advanced>	
+	<advanced>
 		<script>
 			<file>../_base/base3/ZmSkin.js</file>
 		</script>
@@ -38,20 +38,20 @@
 			<file>../_base/base3/skin.html</file>
 			<file>../_base/base3/splash.html</file>
 		</html>
-	</advanced>	
+	</advanced>
 	<standard>
 		<css>
 			<file>../../css/zhtml.css</file>
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/hotrod/manifest.xml
+++ b/WebRoot/skins/hotrod/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/lake/manifest.xml
+++ b/WebRoot/skins/lake/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>	
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/lake/manifest.xml
+++ b/WebRoot/skins/lake/manifest.xml
@@ -23,7 +23,7 @@
 -->
 	<common>
 		<substitutions>
-			<file>../_base/base3/skin.properties</file>		
+			<file>../_base/base3/skin.properties</file>
 			<file>skin.properties</file>
 		</substitutions>
 		<css>
@@ -44,14 +44,14 @@
 			<file>../../css/zhtml.css</file>
 			<file>../_base/base3/zhtml.css</file>
 		</css>
-	</standard>	
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/lavender/manifest.xml
+++ b/WebRoot/skins/lavender/manifest.xml
@@ -38,20 +38,20 @@
 			<file>../_base/base3/skin.html</file>
 			<file>../_base/base3/splash.html</file>
 		</html>
-	</advanced>	
+	</advanced>
 	<standard>
 		<css>
 			<file>../../css/zhtml.css</file>
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/lavender/manifest.xml
+++ b/WebRoot/skins/lavender/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/lemongrass/manifest.xml
+++ b/WebRoot/skins/lemongrass/manifest.xml
@@ -23,14 +23,14 @@
 -->
 	<common>
 		<substitutions>
-			<file>../_base/base3/skin.properties</file>		
+			<file>../_base/base3/skin.properties</file>
 			<file>skin.properties</file>
 		</substitutions>
 		<css>
 			<file>../_base/base3/skin.css</file>
 		</css>
 	</common>
-	<advanced>	
+	<advanced>
 		<script>
 			<file>../_base/base3/ZmSkin.js</file>
 		</script>
@@ -38,20 +38,20 @@
 			<file>../_base/base3/skin.html</file>
 			<file>../_base/base3/splash.html</file>
 		</html>
-	</advanced>	
+	</advanced>
 	<standard>
 		<css>
 			<file>../../css/zhtml.css</file>
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/lemongrass/manifest.xml
+++ b/WebRoot/skins/lemongrass/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/oasis/manifest.xml
+++ b/WebRoot/skins/oasis/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>	
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/oasis/manifest.xml
+++ b/WebRoot/skins/oasis/manifest.xml
@@ -23,7 +23,7 @@
 -->
 	<common>
 		<substitutions>
-			<file>../_base/base3/skin.properties</file>		
+			<file>../_base/base3/skin.properties</file>
 			<file>skin.properties</file>
 		</substitutions>
 		<css>
@@ -44,14 +44,14 @@
 			<file>../../css/zhtml.css</file>
 			<file>../_base/base3/zhtml.css</file>
 		</css>
-	</standard>	
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/pebble/manifest.xml
+++ b/WebRoot/skins/pebble/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>	
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/pebble/manifest.xml
+++ b/WebRoot/skins/pebble/manifest.xml
@@ -23,7 +23,7 @@
 -->
 	<common>
 		<substitutions>
-			<file>../_base/base3/skin.properties</file>		
+			<file>../_base/base3/skin.properties</file>
 			<file>skin.properties</file>
 		</substitutions>
 		<css>
@@ -44,14 +44,14 @@
 			<file>../../css/zhtml.css</file>
 			<file>../_base/base3/zhtml.css</file>
 		</css>
-	</standard>	
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/sand/manifest.xml
+++ b/WebRoot/skins/sand/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/sand/manifest.xml
+++ b/WebRoot/skins/sand/manifest.xml
@@ -45,13 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/serenity/manifest.xml
+++ b/WebRoot/skins/serenity/manifest.xml
@@ -29,29 +29,29 @@
 		<css>
 			<file>../_base/base3/skin.css</file>
 		</css>
-    </common>
-    <advanced>
-	    <script>
-    	    <file>../_base/base3/ZmSkin.js</file>
-    	</script>
+	</common>
+	<advanced>
+		<script>
+			<file>../_base/base3/ZmSkin.js</file>
+		</script>
 		<html>
 			<file>../_base/base3/skin.html</file>
 			<file>../_base/base3/splash.html</file>
 		</html>
 	</advanced>
 	<standard>
-        <css>
-            <file>../../css/zhtml.css</file>
-            <file>../_base/base3/zhtml.css</file>
-        </css>
-	</standard>		
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+		<css>
+			<file>../../css/zhtml.css</file>
+			<file>../_base/base3/zhtml.css</file>
+		</css>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/serenity/manifest.xml
+++ b/WebRoot/skins/serenity/manifest.xml
@@ -45,4 +45,13 @@
             <file>../_base/base3/zhtml.css</file>
         </css>
 	</standard>		
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/sky/manifest.xml
+++ b/WebRoot/skins/sky/manifest.xml
@@ -30,7 +30,7 @@
 			<file>../_base/base3/skin.css</file>
 		</css>
 	</common>
-	<advanced>	
+	<advanced>
 		<script>
 			<file>../_base/base3/ZmSkin.js</file>
 		</script>
@@ -45,13 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/sky/manifest.xml
+++ b/WebRoot/skins/sky/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/smoke/manifest.xml
+++ b/WebRoot/skins/smoke/manifest.xml
@@ -29,29 +29,29 @@
 		<css>
 			<file>../_base/base3/skin.css</file>
 		</css>
-    </common>
-    <advanced>
-	    <script>
-    	    <file>../_base/base3/ZmSkin.js</file>
-    	</script>
+	</common>
+	<advanced>
+		<script>
+			<file>../_base/base3/ZmSkin.js</file>
+		</script>
 		<html>
 			<file>../_base/base3/skin.html</file>
 			<file>../_base/base3/splash.html</file>
 		</html>
 	</advanced>
 	<standard>
-        <css>
-            <file>../../css/zhtml.css</file>
-            <file>../_base/base3/zhtml.css</file>
-        </css>
-	</standard>		
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+		<css>
+			<file>../../css/zhtml.css</file>
+			<file>../_base/base3/zhtml.css</file>
+		</css>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/smoke/manifest.xml
+++ b/WebRoot/skins/smoke/manifest.xml
@@ -45,4 +45,13 @@
             <file>../_base/base3/zhtml.css</file>
         </css>
 	</standard>		
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/steel/manifest.xml
+++ b/WebRoot/skins/steel/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/steel/manifest.xml
+++ b/WebRoot/skins/steel/manifest.xml
@@ -45,13 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/tree/manifest.xml
+++ b/WebRoot/skins/tree/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>	
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/tree/manifest.xml
+++ b/WebRoot/skins/tree/manifest.xml
@@ -23,7 +23,7 @@
 -->
 	<common>
 		<substitutions>
-			<file>../_base/base3/skin.properties</file>		
+			<file>../_base/base3/skin.properties</file>
 			<file>skin.properties</file>
 		</substitutions>
 		<css>
@@ -44,14 +44,14 @@
 			<file>../../css/zhtml.css</file>
 			<file>../_base/base3/zhtml.css</file>
 		</css>
-	</standard>	
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/twilight/manifest.xml
+++ b/WebRoot/skins/twilight/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>	
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/twilight/manifest.xml
+++ b/WebRoot/skins/twilight/manifest.xml
@@ -23,7 +23,7 @@
 -->
 	<common>
 		<substitutions>
-			<file>../_base/base3/skin.properties</file>		
+			<file>../_base/base3/skin.properties</file>
 			<file>skin.properties</file>
 		</substitutions>
 		<css>
@@ -44,14 +44,14 @@
 			<file>../../css/zhtml.css</file>
 			<file>../_base/base3/zhtml.css</file>
 		</css>
-	</standard>	
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>

--- a/WebRoot/skins/waves/manifest.xml
+++ b/WebRoot/skins/waves/manifest.xml
@@ -45,4 +45,13 @@
 			<file>../_base/base3/zhtml.css</file>
 		</css>
 	</standard>	
+    <print>
+        <css>
+            <file>../_base/base3/print.css</file>
+        </css>
+        <cssIgnore>
+            <file>../_base/base3/skin.css</file>
+            <file>skin.css</file>
+        </cssIgnore>
+    </print>
 </skin>

--- a/WebRoot/skins/waves/manifest.xml
+++ b/WebRoot/skins/waves/manifest.xml
@@ -23,7 +23,7 @@
 -->
 	<common>
 		<substitutions>
-			<file>../_base/base3/skin.properties</file>		
+			<file>../_base/base3/skin.properties</file>
 			<file>skin.properties</file>
 		</substitutions>
 		<css>
@@ -44,14 +44,14 @@
 			<file>../../css/zhtml.css</file>
 			<file>../_base/base3/zhtml.css</file>
 		</css>
-	</standard>	
-    <print>
-        <css>
-            <file>../_base/base3/print.css</file>
-        </css>
-        <cssIgnore>
-            <file>../_base/base3/skin.css</file>
-            <file>skin.css</file>
-        </cssIgnore>
-    </print>
+	</standard>
+	<print>
+		<css>
+			<file>../_base/base3/print.css</file>
+		</css>
+		<cssIgnore>
+			<file>../_base/base3/skin.css</file>
+			<file>skin.css</file>
+		</cssIgnore>
+	</print>
 </skin>


### PR DESCRIPTION
**Problem:**
css file in a skin directory is not loaded on print message/contact/appointment/task page.

**Changes:**
* `head.tag`
    * specify `print` in `client` param for print page
    * add `skin.css` for print page
* `WebRoot/skins/_base/base3/print.css`: add empty file. Administrator can add style(s) as necessary.
* `manifest.xml` in each skin directory
    * add `<print>` element which contains the `print.css`
    * add `<cssIgnore>` element not to include css files defined in `common / css` section.
        * see https://github.com/Zimbra/zm-ajax/pull/116
    * indentation: use tab space
    * line break: use LF on all skins

FYI, you can ignore changes of indentation (white space / tab space) and line breaks (CRLF / LF) in code diff page.
File changed -> Gear icon -> Check "Hide whitespace" -> Click "Apply and reload"