### PR TITLE
ZCS-12908: set context path on 2FA setup page

### DIFF
--- a/WebRoot/public/TwoFactorSetup.jsp
+++ b/WebRoot/public/TwoFactorSetup.jsp
@@ -37,6 +37,7 @@
 	if (contextPath.equals("/")) {
 		contextPath = "";
 	}
+	pageContext.setAttribute("contextPath", contextPath);
 %>
 <!DOCTYPE html>
 <html class="user_font_size_normal" data-istwofactorsetuppage="true">


### PR DESCRIPTION
**Issue:**
In TwoFactorSetup.jsp, a value of `contextPath` was set at lines 36-39, but it was not set in pageContext attribute. Then `${contextPath}` was always empty at line 75.
```
<script src="${contextPath}/js/TwoFactor_all.js<%=ext%>?v=${version}"></script>
```

**Fix:**
* Add `pageContext.setAttribute("contextPath", contextPath);`
