### PR TITLE
ZCS-12944: changed to get skin from pageContext on error.jsp

### DIFF
--- a/WebRoot/public/error.jsp
+++ b/WebRoot/public/error.jsp
@@ -29,7 +29,11 @@
 
 <%
 	String skin = request.getParameter("skin");
-	if (skin == null || !Pattern.matches("^[0-9A-Za-z]+$", skin)) {
+	if (skin == null) {
+		Object o = pageContext.getAttribute("skin", PageContext.REQUEST_SCOPE);
+		skin = String.valueOf(o);
+	}
+	if (skin == null || "null".equals(skin) || !Pattern.matches("^[0-9A-Za-z]+$", skin)) {
 		skin = application.getInitParameter("zimbraDefaultSkin");
 	}
 %>


### PR DESCRIPTION
**Issue:**
When error.jsp is shown, default skin harmony is always used.
When user accesses ZWC with virtual hostname and zimbraPrefSkin is set on the domain, css files defined in the skin should be used.

**Fix:**
`<app:skinAndRedirect />` at line 26 gets a skin of a domain based on access URL. The skin is set in "skin" attribute of pageContext.
After the fix, skin is identified as follows:
1. If request url for error.jsp has "skin" parameter, it is used.
2. If not, a skin set in pageContext is used.
3. If both empty or null, zimbraDefaultSkin in init parameter is used.

The PR is adding the 2nd logic.