### PR TITLE
ZCS-13042: fixed for device with small screen resolution

### DIFF
--- a/WebRoot/public/launchZCS.jsp
+++ b/WebRoot/public/launchZCS.jsp
@@ -322,8 +322,8 @@
             splSwitch.style.visibility = 'hidden';
         }
     }
-	function switchToStandardClient() {
-		document.location = window.appContextPath + "/?client=standard";
+	function switchClient() {
+		document.location = window.appContextPath + "/?screenSize=small";
 	}
     killSplashScreenSwitch();
 	<c:set var="enforceMinDisplay" value="${requestScope.authResult.prefs.zimbraPrefAdvancedClientEnforceMinDisplay[0]}"/>
@@ -331,7 +331,7 @@
 		enforceMinDisplay = ${enforceMinDisplay ne 'FALSE'};
 		unsupported = (screen && (screen.width <= 800 && screen.height <= 600) && !${isOfflineMode}) || (AjxEnv.isSafari && !AjxEnv.isSafari4up);
 		if (enforceMinDisplay && unsupported) {
-			switchToStandardClient();
+			switchClient();
 		}
 		delete enforceMinDisplay;
 		delete unsupported;


### PR DESCRIPTION
**Issue:**
Looping access occurs when accessing Classic UI from PC with small resolution.

Steps to reproduce:
1. set account's zimbraPrefClientType to "advanced"
2. access Login page using a PC browser. The display resolution is less than 600x800 (width x height)
3. choose "Classic" client type and log in to the account. The URL has "client=advanced" parameter. (https://host/?client=advanced )
6. remove the parameter and access https://host/
7. Looping access occurs. The URL has "client=standard" parameter.

**Changes:**
* launchZCS.jsp: changed the parameter to `screenSize=small` for redirection to login.jsp
* login.jsp
    * when parameter has `screenSize=small` and Modern UI is supported, set `client` to `modern`
    * when parameter has `screenSize=small` and Modern UI is not supported, set `client` to `notfound` because both advanced and modern are unavailable for the device. In addition, an error message is set.
    * If `client` is `notfound`, force to logout. If the error message has been set for small screen device, it is shown in login page.

Related PR:
* https://github.com/Zimbra/zm-ajax/pull/121