### PR TITLE
ZCS-13121: reverted part of ZCS-12886

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,3 @@ RUN cd /opt/zimbra/jetty_base/webapps/zimbra/public && cat login.jsp | sed -e '/
 RUN cd /opt/zimbra/jetty_base/webapps/zimbra/public && mv login.jsp.tmp login.jsp
 RUN cd /opt/zimbra/jetty_base/webapps/zimbra/public && cat launchZCS.jsp | sed -e '/\/\/ check if modern package exists/,/%>/c\%>' | sed -e 's/value="<%=modernSupported%>"/value="true"/' > launchZCS.jsp.tmp
 RUN cd /opt/zimbra/jetty_base/webapps/zimbra/public && mv launchZCS.jsp.tmp launchZCS.jsp
-RUN cd /opt/zimbra/jetty_base/webapps/zimbra/public && cat modern.jsp | sed -e 's,window.location.origin + "/modern/",window.location.origin;,' > modern.jsp.tmp
-RUN cd /opt/zimbra/jetty_base/webapps/zimbra/public && mv modern.jsp.tmp modern.jsp


### PR DESCRIPTION
Removed some code from Dockerfile to keep Modern UI path as `/modern`.