### PR TITLE
ZCS-13393 Support localHost config option for ZJspSession.

### DIFF
--- a/WebRoot/WEB-INF/web.xml
+++ b/WebRoot/WEB-INF/web.xml
@@ -542,6 +542,17 @@
     <env-entry-value>%%list VAR:zimbraServiceEnabled ,%%</env-entry-value>
   </env-entry>
 
+  <!-- LOCALHOSTBEGIN %%comment LOCAL:webclient_localhost_override,-->%%
+  <env-entry>
+    <description>
+      Override of the localHost key used by ZJspSession.
+    </description>
+    <env-entry-name>localHost</env-entry-name>
+    <env-entry-type>java.lang.String</env-entry-type>
+    <env-entry-value>@@webclient_localhost_override@@</env-entry-value>
+  </env-entry>
+  %%comment LOCAL:webclient_localhost_override,<!--%% LOCALHOSTEND -->
+
   <env-entry>
     <description>
       The http and httpsPort need to be in sync with the webserver


### PR DESCRIPTION
**Problem**
* localHost used by ZJspSession (for soap url) needs to be overridden by adding an override in web.xml.
* zok needs a method of overriding with a persisted config.

**Solution**
* Allow a non-empty value in localconfig to set the override, leaving this block commented out if localconfig key is empty.

Alternatively we can set it directly if a specific value is present in one of the fields used by zok (e.g. mls_service_endpoint).