### PR TITLE
ZCS-13569: modify the LC config value zimbraPasswordAllowUsername to LDAP value zimbraFeatureAllowUsernameInPassword and modify the password rules accordingly

### DIFF
--- a/WebRoot/h/changepass
+++ b/WebRoot/h/changepass
@@ -63,7 +63,7 @@
     <c:set var="zimbraPasswordMinNumericChars" value="${mailbox.accountInfo.attrs.zimbraPasswordMinNumericChars[0]}"/>
     <c:set var="zimbraPasswordMinDigitsOrPuncs" value="${mailbox.accountInfo.attrs.zimbraPasswordMinDigitsOrPuncs[0]}"/>
     <c:set var="zimbraPasswordAllowedChars" value="${mailbox.accountInfo.attrs.zimbraPasswordAllowedChars[0]}"/>
-    <c:set var="zimbraFeatureAllowUsernameInPassword" value="${not empty mailbox.accountInfo.attrs.zimbraFeatureAllowUsernameInPassword[0] ? zm:boolean(mailbox.accountInfo.attrs.zimbraFeatureAllowUsernameInPassword[0]) : false}"/>
+    <c:set var="zimbraFeatureAllowUsernameInPassword" value="${not empty mailbox.accountInfo.attrs.zimbraFeatureAllowUsernameInPassword[0] ? zm:boolean(mailbox.accountInfo.attrs.zimbraFeatureAllowUsernameInPassword[0]) : TRUE}"/>
     <c:set var="zimbraPasswordAllowedPunctuationChars" value="${mailbox.accountInfo.attrs.zimbraPasswordAllowedPunctuationChars[0]}"/>
     <c:set var="zimbraPasswordEnforceHistory" value="${mailbox.accountInfo.attrs.zimbraPasswordEnforceHistory[0]}"/>
     <c:set var="zimbraPasswordBlockCommonEnabled" value="${not empty mailbox.accountInfo.attrs.zimbraPasswordBlockCommonEnabled[0] ? mailbox.accountInfo.attrs.zimbraPasswordBlockCommonEnabled[0] : FALSE}"/>
@@ -188,7 +188,7 @@
                                     </c:if>
                                     <c:if test="${!zm:boolean(zimbraFeatureAllowUsernameInPassword)}">
                                         <li>
-                                            <fmt:message key="zimbraFeatureAllowUsernameInPassword" var="allowUsernameMsg"></fmt:message>
+                                            <fmt:message key="zimbraPasswordAllowUsername" var="allowUsernameMsg"></fmt:message>
                                             <img src="/img/zimbra/ImgCloseGrayModern.png" id="allowUsernameCloseImg" style="display: inline;"/>
                                             <img src="/img/zimbra/ImgCheckModern.png" id="allowUsernameCheckImg" style="display: none;"/>
                                             ${allowUsernameMsg}

--- a/WebRoot/h/changepass
+++ b/WebRoot/h/changepass
@@ -63,7 +63,7 @@
     <c:set var="zimbraPasswordMinNumericChars" value="${mailbox.accountInfo.attrs.zimbraPasswordMinNumericChars[0]}"/>
     <c:set var="zimbraPasswordMinDigitsOrPuncs" value="${mailbox.accountInfo.attrs.zimbraPasswordMinDigitsOrPuncs[0]}"/>
     <c:set var="zimbraPasswordAllowedChars" value="${mailbox.accountInfo.attrs.zimbraPasswordAllowedChars[0]}"/>
-    <c:set var="zimbraFeatureAllowUsernameInPassword" value="${not empty mailbox.accountInfo.attrs.zimbraFeatureAllowUsernameInPassword[0] ? zm:boolean(mailbox.accountInfo.attrs.zimbraFeatureAllowUsernameInPassword[0]) : TRUE}"/>
+    <c:set var="zimbraFeatureAllowUsernameInPassword" value="${not empty mailbox.accountInfo.attrs.zimbraFeatureAllowUsernameInPassword[0] ? mailbox.accountInfo.attrs.zimbraFeatureAllowUsernameInPassword[0] : TRUE}"/>
     <c:set var="zimbraPasswordAllowedPunctuationChars" value="${mailbox.accountInfo.attrs.zimbraPasswordAllowedPunctuationChars[0]}"/>
     <c:set var="zimbraPasswordEnforceHistory" value="${mailbox.accountInfo.attrs.zimbraPasswordEnforceHistory[0]}"/>
     <c:set var="zimbraPasswordBlockCommonEnabled" value="${not empty mailbox.accountInfo.attrs.zimbraPasswordBlockCommonEnabled[0] ? mailbox.accountInfo.attrs.zimbraPasswordBlockCommonEnabled[0] : FALSE}"/>
@@ -562,7 +562,7 @@
                 }
             }
 
-            if (${!zimbraFeatureAllowUsernameInPassword}) {
+            if ("${zimbraFeatureAllowUsernameInPassword}" === "FALSE") {
                 var username = "${mailbox.name}".split("@")[0];
                 if (!currentValue.includes(username)) {
                     matchedLocalRule.push({type : "zimbraPasswordAllowUsername"});

--- a/WebRoot/h/changepass
+++ b/WebRoot/h/changepass
@@ -63,7 +63,7 @@
     <c:set var="zimbraPasswordMinNumericChars" value="${mailbox.accountInfo.attrs.zimbraPasswordMinNumericChars[0]}"/>
     <c:set var="zimbraPasswordMinDigitsOrPuncs" value="${mailbox.accountInfo.attrs.zimbraPasswordMinDigitsOrPuncs[0]}"/>
     <c:set var="zimbraPasswordAllowedChars" value="${mailbox.accountInfo.attrs.zimbraPasswordAllowedChars[0]}"/>
-    <c:set var="zimbraPasswordAllowUsername" value="${not empty mailbox.accountInfo.attrs.zimbraPasswordAllowUsername[0] ? zm:boolean(mailbox.accountInfo.attrs.zimbraPasswordAllowUsername[0]) : false}"/>
+    <c:set var="zimbraFeatureAllowUsernameInPassword" value="${not empty mailbox.accountInfo.attrs.zimbraFeatureAllowUsernameInPassword[0] ? zm:boolean(mailbox.accountInfo.attrs.zimbraFeatureAllowUsernameInPassword[0]) : false}"/>
     <c:set var="zimbraPasswordAllowedPunctuationChars" value="${mailbox.accountInfo.attrs.zimbraPasswordAllowedPunctuationChars[0]}"/>
     <c:set var="zimbraPasswordEnforceHistory" value="${mailbox.accountInfo.attrs.zimbraPasswordEnforceHistory[0]}"/>
     <c:set var="zimbraPasswordBlockCommonEnabled" value="${not empty mailbox.accountInfo.attrs.zimbraPasswordBlockCommonEnabled[0] ? mailbox.accountInfo.attrs.zimbraPasswordBlockCommonEnabled[0] : FALSE}"/>
@@ -186,9 +186,9 @@
                                             ${minDigitsOrPuncsMsg}
                                         </li>
                                     </c:if>
-                                    <c:if test="${!zm:boolean(zimbraPasswordAllowUsername)}">
+                                    <c:if test="${!zm:boolean(zimbraFeatureAllowUsernameInPassword)}">
                                         <li>
-                                            <fmt:message key="zimbraPasswordAllowUsername" var="allowUsernameMsg"></fmt:message>
+                                            <fmt:message key="zimbraFeatureAllowUsernameInPassword" var="allowUsernameMsg"></fmt:message>
                                             <img src="/img/zimbra/ImgCloseGrayModern.png" id="allowUsernameCloseImg" style="display: inline;"/>
                                             <img src="/img/zimbra/ImgCheckModern.png" id="allowUsernameCheckImg" style="display: none;"/>
                                             ${allowUsernameMsg}
@@ -344,7 +344,7 @@
             enabledLocalRules.push(findRule("zimbraPasswordMinDigitsOrPuncs"));
         }
 
-        if(${!zimbraPasswordAllowUsername}) {
+        if("${zimbraFeatureAllowUsernameInPassword}" === "FALSE") {
             enabledLocalRules.push(findRule("zimbraPasswordAllowUsername"));
         }
 
@@ -562,7 +562,7 @@
                 }
             }
 
-            if (${!zimbraPasswordAllowUsername}) {
+            if (${!zimbraFeatureAllowUsernameInPassword}) {
                 var username = "${mailbox.name}".split("@")[0];
                 if (!currentValue.includes(username)) {
                     matchedLocalRule.push({type : "zimbraPasswordAllowUsername"});

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmPasswordRecoveryDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmPasswordRecoveryDialog.js
@@ -793,7 +793,7 @@ function (result) {
 	var zimbraPasswordMinPunctuationChars = parseInt(attributes.zimbraPasswordMinPunctuationChars);
 	var zimbraPasswordMinNumericChars = parseInt(attributes.zimbraPasswordMinNumericChars);
 	var zimbraPasswordMinDigitsOrPuncs = parseInt(attributes.zimbraPasswordMinDigitsOrPuncs);
-	var zimbraPasswordAllowUsername = attributes.zimbraPasswordAllowUsername ? attributes.zimbraPasswordAllowUsername.toLowerCase() === "true" : false;
+	var zimbraFeatureAllowUsernameInPassword = attributes.zimbraFeatureAllowUsernameInPassword ? attributes.zimbraFeatureAllowUsernameInPassword.toLowerCase() === "true" : false;
 
 	var zimbraPasswordAllowedChars = attributes.zimbraPasswordAllowedChars || false;
 	var zimbraPasswordAllowedPunctuationChars = attributes.zimbraPasswordAllowedPunctuationChars || false;
@@ -917,7 +917,7 @@ function (result) {
 		Dwt.show(this._passwordMinDigitsOrPunctuationRule);
 	}
 
-	if(!zimbraPasswordAllowUsername) {
+	if(!zimbraFeatureAllowUsernameInPassword) {
 		var allowUsernameMsg = AjxMessageFormat.format(ZmMsg.zimbraPasswordAllowUsername);
 		enabledLocalRules.push(findRule("zimbraPasswordAllowUsername"));
 
@@ -982,7 +982,7 @@ function (result) {
 			}
 		}
 
-		if(!zimbraPasswordAllowUsername) {
+		if(!zimbraFeatureAllowUsernameInPassword) {
 			var username = this._accountInput.value.includes("@") ? this._accountInput.value.split("@")[0] : this._accountInput.value;
 			if (!currentValue.includes(username)) {
 				matchedLocalRules.push({type : "zimbraPasswordAllowUsername"});

--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -592,7 +592,7 @@ if (application.getInitParameter("offlineMode") != null) {
                                             int zimbraPasswordMinPunctuationChars = 0;
                                             int zimbraPasswordMinNumericChars = 0;
                                             int zimbraPasswordMinDigitsOrPuncs = 0;
-                                            boolean zimbraPasswordAllowUsername = false;
+                                            boolean zimbraFeatureAllowUsernameInPassword = true;
                                             String zimbraPasswordAllowedChars = null;
                                             String zimbraPasswordAllowedPunctuationChars = null;
 
@@ -606,7 +606,7 @@ if (application.getInitParameter("offlineMode") != null) {
                                                 zimbraPasswordMinPunctuationChars = acct.getPasswordMinPunctuationChars();
                                                 zimbraPasswordMinNumericChars = acct.getPasswordMinNumericChars();
                                                 zimbraPasswordMinDigitsOrPuncs = acct.getPasswordMinDigitsOrPuncs();
-                                                zimbraPasswordAllowUsername =  acct.getAllowUsernameWithinPassword();
+                                                zimbraFeatureAllowUsernameInPassword =  acct.isFeatureAllowUsernameInPassword();
                                                 zimbraPasswordAllowedChars = acct.getPasswordAllowedChars();
                                                 zimbraPasswordAllowedPunctuationChars = acct.getPasswordAllowedPunctuationChars();
                                             }
@@ -616,7 +616,7 @@ if (application.getInitParameter("offlineMode") != null) {
                                             application.setAttribute("zimbraPasswordMinPunctuationChars", zimbraPasswordMinPunctuationChars);
                                             application.setAttribute("zimbraPasswordMinNumericChars", zimbraPasswordMinNumericChars);
                                             application.setAttribute("zimbraPasswordMinDigitsOrPuncs", zimbraPasswordMinDigitsOrPuncs);
-                                            application.setAttribute("zimbraPasswordAllowUsername", zimbraPasswordAllowUsername);
+                                            application.setAttribute("zimbraFeatureAllowUsernameInPassword", zimbraFeatureAllowUsernameInPassword);
                                             application.setAttribute("zimbraPasswordAllowedChars", zimbraPasswordAllowedChars);
                                             application.setAttribute("zimbraPasswordAllowedPunctuationChars", zimbraPasswordAllowedPunctuationChars);
                                         %>
@@ -626,7 +626,7 @@ if (application.getInitParameter("offlineMode") != null) {
                                         <c:set var="zimbraPasswordMinPunctuationChars" value="<%=zimbraPasswordMinPunctuationChars%>"/>
                                         <c:set var="zimbraPasswordMinNumericChars" value="<%=zimbraPasswordMinNumericChars%>"/>
                                         <c:set var="zimbraPasswordMinDigitsOrPuncs" value="<%=zimbraPasswordMinDigitsOrPuncs%>"/>
-                                        <c:set var="zimbraPasswordAllowUsername" value="<%=zimbraPasswordAllowUsername%>"/>
+                                        <c:set var="zimbraFeatureAllowUsernameInPassword" value="<%=zimbraFeatureAllowUsernameInPassword%>"/>
                                         <c:set var="zimbraPasswordAllowedChars" value="<%=zimbraPasswordAllowedChars%>"/>
                                         <c:set var="zimbraPasswordAllowedPunctuationChars" value="<%=zimbraPasswordAllowedChars%>"/>
                                         <label for="newPassword" class="zLoginFieldLabel"><fmt:message key="passwordRecoveryResetNewLabel"/></label>
@@ -691,7 +691,7 @@ if (application.getInitParameter("offlineMode") != null) {
                                                     </fmt:message>
                                                 </li>
                                             </c:if>
-                                            <c:if test="${zm:boolean(!zimbraPasswordAllowUsername)}">
+                                            <c:if test="${!zm:boolean(zimbraFeatureAllowUsernameInPassword)}">
                                                 <li>
                                                     <img src="/img/zimbra/ImgCloseGrayModern.png" id="allowUsernameCloseImg" style="display: inline;"/>
                                                     <img src="/img/zimbra/ImgCheckModern.png" id="allowUsernameCheckImg" style="display: none;"/>
@@ -946,7 +946,7 @@ if (${zimbraPasswordMinDigitsOrPuncs}) {
     enabledRules.push(supportedRules.find(function(rule){ return rule.type === "zimbraPasswordMinDigitsOrPuncs"}));
 }
 
-if (${!zimbraPasswordAllowUsername}) {
+if (${!zimbraFeatureAllowUsernameInPassword}) {
     enabledRules.push(supportedRules.find(function(rule){ return rule.type === "zimbraPasswordAllowUsername"}));
 }
 
@@ -1098,7 +1098,7 @@ function handleNewPasswordChange() {
         }
     }
     
-    if (${!zimbraPasswordAllowUsername}) {
+    if (${!zimbraFeatureAllowUsernameInPassword}) {
         if (!currentValue.includes("${trimmedUserName.split('@')[0]}")) {
             matchedRule.push({type : "zimbraPasswordAllowUsername"});
         }


### PR DESCRIPTION
-The default value of zimbraFeatureAllowUsernameInPassword is true i.e. the user can use their username in the password.
-if the value is false, the user is not allowed to use their username in the password.