### PR TITLE
ZCS-2733 remove product help page link if help pages are not available in the build

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -2412,7 +2412,7 @@ function(parent, parentElement, adminUrl) {
 
 		menu.createSeparator();
 
-		if (supportedHelps.indexOf("productHelp") !== -1) {
+		if (window.productHelpSupported && supportedHelps.indexOf("productHelp") !== -1) {
 			mi = menu.createMenuItem("documentation", {text: ZmMsg.productHelp});
 			mi.addSelectionListener(helpListener);
 		}

--- a/WebRoot/public/launchZCS.jsp
+++ b/WebRoot/public/launchZCS.jsp
@@ -64,7 +64,7 @@
 	try {
 		productHelpSupported = new java.io.File(application.getRealPath("/help")).exists();
 	} catch (Exception ignored) {
-		// Just in case there's anException, catch it.
+		// Just in case there's an exception, catch it.
 	}
 	application.setAttribute("productHelpSupported", productHelpSupported);
 %>

--- a/WebRoot/public/launchZCS.jsp
+++ b/WebRoot/public/launchZCS.jsp
@@ -58,6 +58,17 @@
 	// Prevent IE from ever going into compatibility/quirks mode.
 	response.setHeader("X-UA-Compatible", "IE=edge");
 %>
+<%
+    // check if help directory exists
+    boolean productHelpSupported = true;
+	try {
+		productHelpSupported = new java.io.File(application.getRealPath("/help")).exists();
+	} catch (Exception ignored) {
+		// Just in case there's anException, catch it.
+	}
+	application.setAttribute("productHelpSupported", productHelpSupported);
+%>
+<c:set var="productHelpSupported" value="<%=productHelpSupported%>" />
 
 <!DOCTYPE html>
 <zm:getUserAgent var="ua" session="false"/>
@@ -233,6 +244,7 @@
 	window.csrfToken            = "${csrfToken}";
 	window.appLang              = "${lang}";
 	localStorage.setItem("csrfToken" , "${csrfToken}");
+	window.productHelpSupported = ${productHelpSupported};
 </script>
 <noscript><p><b>Javascript must be enabled to use this.</b></p></noscript>
 </head>


### PR DESCRIPTION
Product help pages will be excluded from next build and patch releases. Those can be include back by installing "zimbra-help" package. This code removes the "Product Help" link from the UI when the help pages are unavailable.