### PR TITLE
ZCS-13590 remove retention policy setting if zimbraFeatureRetentionPolicyEnabled is disabled

### DIFF
--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -937,7 +937,7 @@ function() {
 	this.registerSetting("EXPORT_MAX_DAYS",					{name:"zimbraExportMaxDays", type:ZmSetting.T_COS, dataType:ZmSetting.D_INT, defaultValue:0});
 	this.registerSetting("FILTER_BATCH_SIZE",               {name:"zimbraFilterBatchSize", type:ZmSetting.T_COS, dataType:ZmSetting.D_INT, defaultValue: 10000});
     this.registerSetting("FLAGGING_ENABLED",				{name:"zimbraFeatureFlaggingEnabled", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:true});
-	this.registerSetting("ENABLE_RETENTION_POLICY",			{name:"zimbraFeatureRetentionPolicyEnabled", type:ZmSetting.T_PREF, dataType:ZmSetting.D_BOOLEAN, defaultValue:false});
+	this.registerSetting("ENABLE_RETENTION_POLICY",			{name:"zimbraFeatureRetentionPolicyEnabled", type:ZmSetting.T_PREF, dataType:ZmSetting.D_BOOLEAN, defaultValue:true});
 	this.registerSetting("FOLDERS_EXPANDED",				{name:"zimbraPrefFoldersExpanded", type:ZmSetting.T_METADATA, dataType: ZmSetting.D_HASH, isImplicit:true, section:ZmSetting.M_IMPLICIT});
 	this.registerSetting("FOLDER_TREE_OPEN",				{name:"zimbraPrefFolderTreeOpen", type:ZmSetting.T_PREF, dataType:ZmSetting.D_BOOLEAN, defaultValue:true, isImplicit:true});
 	this.registerSetting("FOLDER_TREE_SASH_WIDTH",          {name:"zimbraPrefFolderTreeSash", type:ZmSetting.T_METADATA, dataType:ZmSetting.D_INT, isImplicit:true, section:ZmSetting.M_IMPLICIT});

--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -937,6 +937,7 @@ function() {
 	this.registerSetting("EXPORT_MAX_DAYS",					{name:"zimbraExportMaxDays", type:ZmSetting.T_COS, dataType:ZmSetting.D_INT, defaultValue:0});
 	this.registerSetting("FILTER_BATCH_SIZE",               {name:"zimbraFilterBatchSize", type:ZmSetting.T_COS, dataType:ZmSetting.D_INT, defaultValue: 10000});
     this.registerSetting("FLAGGING_ENABLED",				{name:"zimbraFeatureFlaggingEnabled", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:true});
+	this.registerSetting("ENABLE_RETENTION_POLICY",			{name:"zimbraFeatureRetentionPolicyEnabled", type:ZmSetting.T_PREF, dataType:ZmSetting.D_BOOLEAN, defaultValue:false});
 	this.registerSetting("FOLDERS_EXPANDED",				{name:"zimbraPrefFoldersExpanded", type:ZmSetting.T_METADATA, dataType: ZmSetting.D_HASH, isImplicit:true, section:ZmSetting.M_IMPLICIT});
 	this.registerSetting("FOLDER_TREE_OPEN",				{name:"zimbraPrefFolderTreeOpen", type:ZmSetting.T_PREF, dataType:ZmSetting.D_BOOLEAN, defaultValue:true, isImplicit:true});
 	this.registerSetting("FOLDER_TREE_SASH_WIDTH",          {name:"zimbraPrefFolderTreeSash", type:ZmSetting.T_METADATA, dataType:ZmSetting.D_INT, isImplicit:true, section:ZmSetting.M_IMPLICIT});

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
@@ -273,7 +273,7 @@ function(event) {
         if (this._tabViews.length > 2) {
             // More than two tabs, hide the retention tab, leave the toolbar intact
             tabBar.setVisible(true);
-			if(retentionTabButton) {
+            if (retentionTabButton) {
 				retentionTabButton.setVisible(false);
 			}
         } else {
@@ -452,9 +452,9 @@ function(view) {
 
 	//ZmFolderPropertyView handle things such as color and type. (in case you're searching for "color" and can't find in this file. I know I did)
     this.addTab(0, ZmFolderPropsDialog.TABKEY_PROPERTIES, new ZmFolderPropertyView(this, this._tabContainer));
-	if(appCtxt.get(ZmSetting.ENABLE_RETENTION_POLICY)) {
+    if (appCtxt.get(ZmSetting.ENABLE_RETENTION_POLICY)) {
 		this.addTab(1, ZmFolderPropsDialog.TABKEY_RETENTION,  new ZmFolderRetentionView(this, this._tabContainer));
-	}
+    }
 
 	// setup shares group
 	if (appCtxt.get(ZmSetting.SHARING_ENABLED))	{

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
@@ -274,8 +274,8 @@ function(event) {
             // More than two tabs, hide the retention tab, leave the toolbar intact
             tabBar.setVisible(true);
             if (retentionTabButton) {
-				retentionTabButton.setVisible(false);
-			}
+                retentionTabButton.setVisible(false);
+            }
         } else {
             // Two or fewer tabs.  Hide the toolbar, just let the properties view display standalone
             // (On popup, the display defaults to the property view)
@@ -453,7 +453,7 @@ function(view) {
 	//ZmFolderPropertyView handle things such as color and type. (in case you're searching for "color" and can't find in this file. I know I did)
     this.addTab(0, ZmFolderPropsDialog.TABKEY_PROPERTIES, new ZmFolderPropertyView(this, this._tabContainer));
     if (appCtxt.get(ZmSetting.ENABLE_RETENTION_POLICY)) {
-		this.addTab(1, ZmFolderPropsDialog.TABKEY_RETENTION,  new ZmFolderRetentionView(this, this._tabContainer));
+        this.addTab(1, ZmFolderPropsDialog.TABKEY_RETENTION,  new ZmFolderRetentionView(this, this._tabContainer));
     }
 
 	// setup shares group

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmFolderPropsDialog.js
@@ -267,13 +267,15 @@ function(event) {
     var retentionTabButton = this._tabContainer.getTabButton(tabKey);
     var retentionIndex = this._tabKeyMap[ZmFolderPropsDialog.TABKEY_RETENTION];
 
-    if ((organizer.type != ZmOrganizer.FOLDER) || organizer.link) {
+    if ((organizer.type != ZmOrganizer.FOLDER) || organizer.link || typeof retentionIndex === "undefined") {
         // Not a folder, or shared - hide the retention view (and possibly the toolbar)
         this._tabInUse[retentionIndex] = false;
         if (this._tabViews.length > 2) {
             // More than two tabs, hide the retention tab, leave the toolbar intact
             tabBar.setVisible(true);
-            retentionTabButton.setVisible(false);
+			if(retentionTabButton) {
+				retentionTabButton.setVisible(false);
+			}
         } else {
             // Two or fewer tabs.  Hide the toolbar, just let the properties view display standalone
             // (On popup, the display defaults to the property view)
@@ -450,7 +452,9 @@ function(view) {
 
 	//ZmFolderPropertyView handle things such as color and type. (in case you're searching for "color" and can't find in this file. I know I did)
     this.addTab(0, ZmFolderPropsDialog.TABKEY_PROPERTIES, new ZmFolderPropertyView(this, this._tabContainer));
-    this.addTab(1, ZmFolderPropsDialog.TABKEY_RETENTION,  new ZmFolderRetentionView(this, this._tabContainer));
+	if(appCtxt.get(ZmSetting.ENABLE_RETENTION_POLICY)) {
+		this.addTab(1, ZmFolderPropsDialog.TABKEY_RETENTION,  new ZmFolderRetentionView(this, this._tabContainer));
+	}
 
 	// setup shares group
 	if (appCtxt.get(ZmSetting.SHARING_ENABLED))	{


### PR DESCRIPTION
When `zimbraFeatureRetentionPolicyEnabled` is disabled, the Retention tab present in the folder's edit properties option should be hidden.

Automation changes - https://github.com/ZimbraOS/zm-frontend-automation/pull/86