### PR TITLE
ZCS-13306: added derefGroupMember for print contacts

### DIFF
--- a/WebRoot/h/printcontacts
+++ b/WebRoot/h/printcontacts
@@ -34,7 +34,7 @@
         <c:otherwise>
             <%--If both contactIds and folderId is null(won't happen in real scenario), contacts of system contact
             folder will be returned--%>
-            <zm:getAllContacts contactIds="${contactIds}" folderId="${param.sfi}" var="contacts"/>
+            <zm:getAllContacts contactIds="${contactIds}" folderId="${param.sfi}" derefGroupMember="true" var="contacts"/>
         </c:otherwise>
     </c:choose>
 </app:handleError>


### PR DESCRIPTION
Add `derefGroupMember="true"` to `zm:getAllContacts` so that members of a contact group is shown in Print Contact page.

**Related PRs:**
* https://github.com/Zimbra/zm-mailbox/pull/1510
* https://github.com/Zimbra/zm-taglib/pull/49