### PR TITLE
ZBUG-3437: restore checkbox status when tag is added or removed

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmMailListView.js
@@ -1215,7 +1215,7 @@ function(ev) {
 	if ((!this.isMultiColumn() || appCtxt.get(ZmSetting.COLOR_MESSAGES))
 			&& (ev.event == ZmEvent.E_TAGS || ev.event == ZmEvent.E_REMOVE_ALL)) {
 		DBG.println(AjxDebug.DBG2, "ZmMailListView: TAG");
-		this.redrawItem(item);
+		this.redrawItem(item, true);
         ZmListView.prototype._changeListener.call(this, ev);
         ev.handled = true;
 	}


### PR DESCRIPTION
**Issue:**
Checkbox becomes unchecked when a tag is added to/removed from a message or conversation.
It occurs with the following configuration:
* zimbraPrefReadingPaneLocation right, or
* zimbraPrefColorMessagesEnabled TRUE

**Root cause:**
`DwtListView.prototype.redrawItem` is called when a tag is added/removed and the configuration has been set as the above.
```
	if ((!this.isMultiColumn() || appCtxt.get(ZmSetting.COLOR_MESSAGES))
			&& (ev.event == ZmEvent.E_TAGS || ev.event == ZmEvent.E_REMOVE_ALL)) {
		//...
		this.redrawItem(item);
```
`redrawItem` resets the status of the checkbox of the target item. Then checkbox becomes unchecked.

**Fix:**
* add `restoreState` parameter to `DwtListView.prototype.redrawItem`
    * https://github.com/Zimbra/zm-ajax/pull/126
* change to call `redrawItem` with `restoreState true`. As a result, new div is set and then the checkbox status is restored.