### PR TITLE
ZCS-13852: Classic UI | Display mail recall option in context menu of mail

### DIFF
--- a/WebRoot/js/zimbraMail/share/model/ZmSearch.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSearch.js
@@ -421,7 +421,7 @@ function(params) {
 					if (this.types.contains(ZmItem.MSG) || this.types.contains(ZmItem.CONV)) {
 						// special handling for showing participants ("To" instead of "From")
 						var folder = this.folderId && appCtxt.getById(this.folderId);
-						request.recip = (folder && folder.isOutbound()) ? "2" : "0";
+						request.recip = (folder && folder.isOutbound()) ? (this.types.contains(ZmItem.MSG) ? "3" : "2") : "0";
 					}
 
 					if (this.types.contains(ZmItem.CONV)) {


### PR DESCRIPTION
- In Search API sent parameter recip:3, in order to get CC and BCC data in response from BE to display the correct count above when the type is the message.