### PR TITLE
ZBUG-3617: User with & in username is unable to login to webmail

### DIFF
--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -52,12 +52,13 @@
                                                         || (ua.isOsAndroid)
                                                         || (ua.isIos))}"/>
 <c:set var="totpAuthRequired" value="false"/>
-<c:set var="trimmedUserName" value="${fn:trim(fn:escapeXml(param.username))}"/>
+<c:set var="trimmedUserName" value="${fn:trim(param.username)}"/>
 <%--'virtualacctdomain' param is set only for external virtual accounts--%>
 <c:if test="${not empty param.username and not empty param.virtualacctdomain}">
 	<%--External login email address are mapped to internal virtual account--%>
-	<c:set var="trimmedUserName" value="${fn:replace(fn:escapeXml(param.username),'@' ,'.')}@${param.virtualacctdomain}"/>
+	<c:set var="trimmedUserName" value="${fn:replace(param.username,'@' ,'.')}@${param.virtualacctdomain}"/>
 </c:if>
+<c:set var="encodedUserName" value="${fn:escapeXml(trimmedUserName)}"/>
 
 <c:if test="${not empty trimmedUserName}">
     <c:choose>

--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -1114,6 +1114,19 @@ function clientChange(selectValue) {
         }
     }
 
+    // Function to encode XML characters
+    function escapeXml(xmlString) {
+    return xmlString.replace(/[<>&'"]/g, function (char) {
+        switch (char) {
+        case '<': return '&lt;';
+        case '>': return '&gt;';
+        case '&': return '&amp;';
+        case "'": return '&apos;';
+        case '"': return '&quot;';
+        }
+    });
+    }
+
     // Function to check special character
     function isAsciiPunc(ch) {
         return (ch >= 33 && ch <= 47) || // ! " # $ % & ' ( ) * + , - . /
@@ -1180,6 +1193,7 @@ function clientChange(selectValue) {
 
     function handleNewPasswordChange() {
         var currentValue = newPasswordInput.value;
+        var encodedPwd = escapeXml(currentValue);
         var parsedChars = parseCharsFromPassword(currentValue);
         var matchedRule = [];
 
@@ -1220,7 +1234,7 @@ function clientChange(selectValue) {
         }
 
         if (${!zimbraFeatureAllowUsernameInPassword}) {
-            if (!currentValue.includes("${trimmedUserName.split('@')[0]}")) {
+            if (!encodedPwd.includes("${encodedUserName.split('@')[0]}")) {
                 matchedRule.push({type : "zimbraPasswordAllowUsername"});
             }
         }


### PR DESCRIPTION
**RCA**: Somewhere username is getting encoded when sending auth request, most probably the username which is being provided by the username is getting encoded using escapeXml and the trimmedUsername is used to validate the password rules which is also in an encoded form.
**Solution**: encoded form of trimmedUsername is stored in encodedUserName and the password is stored in encodedPwd 
 which is being used to validate the zimbraFeatureAllowUsernameInPassword rule. Removed the escapeXml of JSTL from the trimmedUsername. It will send the unencoded data to hit the API.