### PR TITLE
Fixed ContactGroup resolution issue by exclusively retrieving from appContext cache, ensuring consistent behavior regardless of window docking status

### DIFF
--- a/WebRoot/js/zimbraMail/share/model/ZmAutocomplete.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmAutocomplete.js
@@ -549,7 +549,7 @@ ZmAutocompleteMatch = function(match, options, isContact, str) {
  */
 ZmAutocompleteMatch.prototype.setContactGroupMembers =
 		function(groupId, callback) {
-			var ac = window.parentAppCtxt || window.appCtxt;
+			var ac = window.appCtxt;
 			var contactGroup = ac.cacheGet(groupId);
 			if (contactGroup) {
 				var groups = contactGroup.getGroupMembers();


### PR DESCRIPTION
In the constructor of `ZmItem`, the `appContext` is used to cache the object. Contact groups or distribution lists are also such `ZmItem` objects. Even when the email window is undocked, such contact groups are created in the `appContext`, never in the `parentAppContext`.

A problem arises in the `setContactGroupMembers` function when trying to resolve the email addresses in the contact group. After the network call of `GetContactsRequest` successfully retrieves the addresses, they are processed in `ZmContact.prototype._handleLoadResponse`. There, in `ZmContact.prototype._loadFromDom`, the addresses are stored in the attribute `"attr.groups"` of the `ZmItem` object. However, the `ZmItem` object of the contact group remains in the `appContext` the entire time and not in the `parentAppContext`.

Now, when `setContactGroupMembers` tries to retrieve the contact group from the cache, it checks whether a `parentAppContext` exists or if it needs to fallback to the default `appContext`. However, since the `ZmItem` of the contact group is not in the `parentAppContext`, resolving the contact group in the undocked window does not work. It only works while the window is docked.

The solution is to exclusively retrieve the `ZmItem` of the contact group from the cache of the `appContext` and never from the `parentAppContext`, regardless of whether the window is docked or undocked. This is because the contact group, or rather the constructor of `ZmItem`, does not make any distinction and always adds itself to the cache of the `appContext` and never the `parentAppContext`.