### PR TITLE
PREAPPS-7606: Date Filter in Advance setting displays incorrect date if selected date is appended with current time.

### DIFF
--- a/WebRoot/js/zimbraMail/prefs/view/ZmFilterRuleDialog.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmFilterRuleDialog.js
@@ -1389,11 +1389,7 @@ function(ev) {
 		if (msg = this._checkCondition(c)) {
 			break;
 		} else {
-			if (c.testType === ZmFilterRule.C_TEST_MAP[ZmFilterRule.C_DATE]) {
-				rule.addCondition(c.testType, c.comparator, Number(c.value), c.subjectMod, c.caseSensitive);
-			} else {
-				rule.addCondition(c.testType, c.comparator, c.value, c.subjectMod, c.caseSensitive);
-			}
+			rule.addCondition(c.testType, c.comparator, c.value, c.subjectMod, c.caseSensitive);
 		}
 	}
 	if (!msg) {

--- a/WebRoot/js/zimbraMail/prefs/view/ZmFilterRuleDialog.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmFilterRuleDialog.js
@@ -1389,7 +1389,11 @@ function(ev) {
 		if (msg = this._checkCondition(c)) {
 			break;
 		} else {
-			rule.addCondition(c.testType, c.comparator, c.value, c.subjectMod, c.caseSensitive);
+			if (c.testType === ZmFilterRule.C_TEST_MAP[ZmFilterRule.C_DATE]) {
+				rule.addCondition(c.testType, c.comparator, Number(c.value), c.subjectMod, c.caseSensitive);
+			} else {
+				rule.addCondition(c.testType, c.comparator, c.value, c.subjectMod, c.caseSensitive);
+			}
 		}
 	}
 	if (!msg) {
@@ -1550,7 +1554,7 @@ function(inputs, conf, field) {
 		if (!date) {
 			return null;
 		}
-		return String(date.getTime() / 1000);
+		return String(new Date(date.getFullYear(),date.getMonth(), date.getDate()).getTime()/1000);
 	}
 	if (type == ZmFilterRule.TYPE_FOLDER_PICKER) {
 		return inputs[field].dwtObj.getData(ZmFilterRuleDialog.DATA);


### PR DESCRIPTION
**Issue in current implementation:** 
Date Filter in Advance setting displays incorrect date if selected date is appended with current time.

**what is observed:**
Current date gets appended to the selected date and its equivalent timeStamp is calculated and sent to API. Since current time is appended it displays incorrect date when server timezone and client timezone varies and it dose not handle DST time. 

**What should it be changed to:**
Removing the time part and sending only date part in long format to the API.

**Example:**
If the selected date is 1/1/2024 then its equivalent timestamp value 1704090386 is sent to ModifyFilterRulesRequest.
Whose equivalent date value is Monday, 1 January 2024 01:26:26 [GMT-05:00]
But in response we get 1704067200. i.e, Sunday, 31 December 2023 19:00:00 [GMT-05:00]
Which is one day before the selected date.

**Solution / Approach:**
Removing the time part and sending only date in long format displays proper date. The timezone calculation is done in backend side considering LDAP attribute for timezone.
For Ex: If selected date is 1/1/2024 then its equivalent timestamp value 1704047400 is sent to ModifyFilterRulesRequest.
Whose equivalent date value is 2024-01-01 00:00:00
and in response we get the same value i.e, 1704047400