### PR TITLE
ZCS-14405: added a function not to show server version change notification dialog

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmRequestMgr.js
+++ b/WebRoot/js/zimbraMail/core/ZmRequestMgr.js
@@ -589,7 +589,7 @@ function(refresh) {
 			var curVersion = appCtxt.get(ZmSetting.SERVER_VERSION);
 			if (curVersion != refresh.version) {
 				appCtxt.set(ZmSetting.SERVER_VERSION, refresh.version);
-				if (curVersion) {
+				if (curVersion && !appCtxt.get(ZmSetting.DISABLE_VERSION_CHANGE_DIALOG)) {
 					var dlg = appCtxt.getYesNoMsgDialog();
 					dlg.reset();
 					dlg.registerCallback(DwtDialog.YES_BUTTON, this._reloadYesCallback, this, [dlg, curVersion, refresh.version]);

--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -983,6 +983,7 @@ function() {
 	this.registerSetting("TWO_FACTOR_AUTH_REQUIRED",	    {name:"zimbraFeatureTwoFactorAuthRequired", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:false});
 	this.registerSetting("TRUSTED_DEVICES_ENABLED",         {name:"zimbraFeatureTrustedDevicesEnabled", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:false});
 	this.registerSetting("APP_PASSWORDS_ENABLED",	        {name:"zimbraFeatureAppSpecificPasswordsEnabled", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:false});
+	this.registerSetting("DISABLE_VERSION_CHANGE_DIALOG",   {name:"zimbraServerVersionChangeNotificationDisabled", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:false});
 
 	this.registerSetting("RESET_PASSWORD_STATUS",				{name:"zimbraFeatureResetPasswordStatus", type:ZmSetting.T_COS, dataType:ZmSetting.D_STRING});
 	this.registerSetting("PASSWORD_RECOVERY_EMAIL",				{name:"zimbraPrefPasswordRecoveryAddress", type:ZmSetting.T_COS, dataType:ZmSetting.D_STRING});


### PR DESCRIPTION
Adding a function not to show a dialog of server version change when `zimbraServerVersionChangeNotificationDisabled` is TRUE.
Default value is FALSE - a dialog will be shown.

Related PR:
* https://github.com/Zimbra/zm-mailbox/pull/1549