### PR TITLE
ZCS-14527: changed to show password recovery account settings based on account setting

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -542,7 +542,9 @@ ZmZimbraMail.prototype._initializeSettings = function(params) {
     if (params.settings) {
         for (var name in params.settings) {
             var id = settings.getSettingByName(name);
-            if (id) {
+            // skip overriding zimbraFeatureResetPasswordStatus to show Password Recovery Account Settings in Preferences
+            // based on account setting rather than domain setting.
+            if (id && id !== ZmSetting.RESET_PASSWORD_STATUS) {
                 settings.getSetting(id).setValue(params.settings[name]);
             }
         }

--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
@@ -312,7 +312,7 @@ function(params, method, action) {
 		dialog.popup();
 		return;
 	} else if (method === ZmTwoFactorAuth.EMAIL && action !== ZmAccountsPage.ACTION_DISABLE_TFA) {
-		var isFeatureResetPasswordEnabled = (appCtxt.get(ZmSetting.RESET_PASSWORD_STATUS) === "enabled");
+		var isFeatureResetPasswordEnabled = (appCtxt.get(ZmSetting.RESET_PASSWORD_STATUS) === "enabled" || appCtxt.get(ZmSetting.RESET_PASSWORD_STATUS) === "suspended" );
 		var isRecoveryAddressConfigured = (appCtxt.get(ZmSetting.PASSWORD_RECOVERY_EMAIL) && appCtxt.get(ZmSetting.PASSWORD_RECOVERY_EMAIL_STATUS) === "verified");
 		if (isFeatureResetPasswordEnabled && !isRecoveryAddressConfigured) {
 			var dialog = appCtxt.getMsgDialog();

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmTwoFactorSetupDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmTwoFactorSetupDialog.js
@@ -157,7 +157,7 @@ function(method) {
 		this.methodAllowed = ZmTwoFactorAuth.getTwoFactorAuthMethodAllowed();
 		this.methodEnabled = ZmTwoFactorAuth.getTwoFactorAuthMethodAllowedAndEnabled();
 		this.isResetPasswordEnabled = (
-			appCtxt.get(ZmSetting.RESET_PASSWORD_STATUS) === "enabled" &&
+			(appCtxt.get(ZmSetting.RESET_PASSWORD_STATUS) === "enabled" || appCtxt.get(ZmSetting.RESET_PASSWORD_STATUS) === "suspended") &&
 			appCtxt.get(ZmSetting.PASSWORD_RECOVERY_EMAIL) &&
 			appCtxt.get(ZmSetting.PASSWORD_RECOVERY_EMAIL_STATUS) === "verified"
 		);
@@ -724,7 +724,11 @@ function(params, disableTFA, method, result) {
 			Dwt.setDisplay(params.twoStepAuthCodesContainer, Dwt.DISPLAY_NONE);
 		}
 		// update Password recovery account status
-		if (!disableTFA && method === ZmTwoFactorAuth.EMAIL && appCtxt.get(ZmSetting.RESET_PASSWORD_STATUS) === "enabled" && params.accountPage) {
+		if (!disableTFA &&
+			method === ZmTwoFactorAuth.EMAIL &&
+			(appCtxt.get(ZmSetting.RESET_PASSWORD_STATUS) === "enabled" || appCtxt.get(ZmSetting.RESET_PASSWORD_STATUS) === "suspended") &&
+			params.accountPage)
+		{
 			params.accountPage._setAccountPasswordControls(recoveryAddressStatus);
 		}
 	} catch (e) {


### PR DESCRIPTION
**Issues:**
* when `zimbraFeatureResetPasswordStatus` is `enabled` or `suspended` on a domain and it is `disabled` on an account, user cannot configure recovery address in Password Recovery Account settings. The error message `Something went wrong. Please contact your administrator.` is shown.
* in the above case, when a user tries to configure 2FA email method, the user is asked to configure recovery address first. However, a recovery address cannot be configured. Then 2FA email method cannot be configured.

**Root cause:**
Settings passed via GetDomainInfo override account settings in the following code. A value of zimbraFeatureResetPasswordStatus in domain level is always used if it is not empty.
https://github.com/Zimbra/zm-web-client/blob/develop/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
```
// setting overrides
if (params.settings) {
    for (var name in params.settings) {
        var id = settings.getSettingByName(name);
        if (id) {
            settings.getSetting(id).setValue(params.settings[name]);
        }
    }
}
```

**Changes:**
* ZmZimbraMail.js: the above override process is necessary for some attributes, but not suitable for zimbraFeatureResetPasswordStatus. It is risky to remove the code. It is not easy to make a generic code to skip it for specific attribute(s) because there are lots of attributes which are defined in both account and domain and have domainInfo flag. Then, the PR changes it to skip `zimbraFeatureResetPasswordStatus` only.
* ZmAccountsPage.js and ZmTwoFactorSetupDialog.js: change to check if zimbraFeatureResetPasswordStatus is `enabled` or `suspended` because Password Recovery Account settings is shown when it is `suspended` as well.