### PR TITLE
ZCS-14513: added error handling when disabling 2FA fails

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
+++ b/WebRoot/js/zimbraMail/mail/view/prefs/ZmAccountsPage.js
@@ -307,6 +307,7 @@ ZmAccountsPage.prototype._handleTwoStepAuthLink =
 function(params, method, action) {
 	if (action === ZmAccountsPage.ACTION_DISABLE_TFA) {
 		var dialog = appCtxt.getYesNoMsgDialog();
+		dialog.reset();
 		dialog.setMessage(ZmMsg.twoStepAuthDisableConfirm, DwtMessageDialog.CRITICAL_STYLE, ZmMsg.twoStepAuthDisable);
 		dialog.registerCallback(DwtDialog.YES_BUTTON, ZmTwoFactorSetupDialog.disableTwoFactorAuth.bind(window, params, dialog, method));
 		dialog.popup();
@@ -316,7 +317,8 @@ function(params, method, action) {
 		var isRecoveryAddressConfigured = (appCtxt.get(ZmSetting.PASSWORD_RECOVERY_EMAIL) && appCtxt.get(ZmSetting.PASSWORD_RECOVERY_EMAIL_STATUS) === "verified");
 		if (isFeatureResetPasswordEnabled && !isRecoveryAddressConfigured) {
 			var dialog = appCtxt.getMsgDialog();
-			dialog.setMessage(ZmMsg.twoStepAuthEmailRecoveryAddressRequired);
+			dialog.reset();
+			dialog.setMessage(ZmMsg.twoStepAuthEmailRecoveryAddressRequired, DwtMessageDialog.INFO_STYLE, ZmMsg.twoStepAuthSetup);
 			dialog.popup();
 			return;
 		}
@@ -387,6 +389,7 @@ function() {
 	if (tfaEnabledMethod.indexOf(ZmTwoFactorAuth.EMAIL) !== -1) {
 		// TODO: when zimbraFeatureTwoFactorAuthRequired is TRUE and only email method is enabled, recovery address cannot be reset.
 		var msgDialog = appCtxt.getOkCancelMsgDialog();
+		msgDialog.reset();
 		msgDialog.setMessage(ZmMsg.recoveryEmailButtonResetWarining, DwtMessageDialog.WARNING_STYLE, ZmMsg.recoveryEmailButtonResetWariningTitle);
 		msgDialog.registerCallback(DwtDialog.OK_BUTTON, this._handleResetRecoveryEmail.bind(this, msgDialog));
 		msgDialog.popup();
@@ -453,12 +456,14 @@ function(response) {
 			};
 			ZmTwoFactorSetupDialog.disableTwoFactorAuthCallback(paramsObj, null, ZmTwoFactorAuth.EMAIL);
 			var dialog = appCtxt.getMsgDialog();
-			dialog.setMessage(ZmMsg.passwordRecoveryTFAEmailDisabledButResetFailed, DwtMessageDialog.CRITICAL_STYLE);
+			dialog.reset();
+			dialog.setMessage(ZmMsg.passwordRecoveryTFAEmailDisabledButResetFailed, DwtMessageDialog.CRITICAL_STYLE, ZmMsg.recoveryEmailButtonResetWariningTitle);
 			dialog.popup();
 		} else {
 			// DisableTwoFactorAuthReseponse failed. SetRecoveryAccountRequest was not executed.
 			var dialog = appCtxt.getMsgDialog();
-			dialog.setMessage(ZmMsg.passwordRecoveryDisableTFAEmailFailed, DwtMessageDialog.CRITICAL_STYLE);
+			dialog.reset();
+			dialog.setMessage(ZmMsg.passwordRecoveryDisableTFAEmailFailed, DwtMessageDialog.CRITICAL_STYLE, ZmMsg.recoveryEmailButtonResetWariningTitle);
 			dialog.popup();
 		}
 	} else if (!response._isException) {

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmTwoFactorSetupDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmTwoFactorSetupDialog.js
@@ -677,9 +677,17 @@ function(params, dialog, method) {
 };
 
 ZmTwoFactorSetupDialog.disableTwoFactorAuthCallback =
-function(params, dialog, method) {
+function(params, dialog, method, result) {
 	if (dialog) {
 		dialog.popdown();
+		if (!result || result.isException()) {
+			var errorDialog = appCtxt.getMsgDialog();
+			errorDialog.reset();
+			var message = result ? result.getException().getErrorMsg() : ZmCsfeException.getErrorMsg(ZmCsfeException.ACCT_CANNOT_DISABLE_TWO_FACTOR_AUTH);
+			errorDialog.setMessage(message, DwtMessageDialog.CRITICAL_STYLE, ZmMsg.twoStepAuthDisable);
+			errorDialog.popup();
+			return;
+		}
 	}
 	var callback = ZmTwoFactorSetupDialog._GetInfoCallback.bind(this, params, true, method);
 	var command = new ZmCsfeCommand();
@@ -698,9 +706,11 @@ function(params, dialog, method) {
  */
 ZmTwoFactorSetupDialog._GetInfoCallback =
 function(params, disableTFA, method, result) {
-	var dialog = appCtxt.getMsgDialog();
-	dialog.setMessage(ZmMsg.twoFactorAuthGetInfoFailed, DwtMessageDialog.WARNING_STYLE);
+	var dialog;
 	if (!result || result.isException()) {
+		dialog = appCtxt.getMsgDialog();
+		dialog.reset();
+		dialog.setMessage(ZmMsg.twoFactorAuthGetInfoFailed, DwtMessageDialog.WARNING_STYLE);
 		dialog.popup();
 		return;
 	}
@@ -734,6 +744,9 @@ function(params, disableTFA, method, result) {
 			params.accountPage._setAccountPasswordControls(recoveryAddressStatus);
 		}
 	} catch (e) {
+		dialog = appCtxt.getMsgDialog();
+		dialog.reset();
+		dialog.setMessage(ZmMsg.twoFactorAuthGetInfoFailed, DwtMessageDialog.WARNING_STYLE);
 		dialog.popup();
 	}
 };


### PR DESCRIPTION
**Issue:**
No error message is shown when disabling a 2FA method (app or email) fails.
For example, when a single 2FA method is enabled, zimbraFeatureTwoFactorAuthRequired is changed from FALSE to TRUE by administrator after the user logs in to web client and the user tries to disable the 2FA method, it fails because 2FA is mandatory. An error is returned from a server, but UI does not show any message.

**Changes:**
* updated `ZmTwoFactorSetupDialog.disableTwoFactorAuthCallback` to show an error message.
   * Note: it is called via `ZmTwoFactorSetupDialog.disableTwoFactorAuth` and `ZmAccountsPage.prototype._recoveryResetRequest`. For the latter, 2nd param `dialog` is null and 4th `result` is empty (undefined). `result` does not need to be checked.
* set a title in some dialogs. Previously `Information` or `Warning` was used.
* added `dialog.reset()` to remove a custom callback on buttons (OK/Cancel etc.).

**Related PR:**
* https://github.com/Zimbra/zm-ajax/pull/132