### PR TITLE
ZCS-14933: Prevent access of classic ui when zimbraClassicWebClientDisabled is TRUE

### DIFF
--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -89,6 +89,7 @@
 %>
 
 <c:set var="modernSupported" value="${domainInfo.attrs.zimbraModernWebClientDisabled ne true}" />
+<c:set var="isClassicWebClientSupported" value="${domainInfo.attrs.zimbraClassicWebClientDisabled ne true}" />
 
 <c:if test="${ua.isModernIE}">
 	<c:set var="modernSupported" value="false" />
@@ -247,6 +248,7 @@
                         
                         <c:set var="isUpgradedMailbox" value="${isUpgradedMailbox}" />
                         <c:set var="prefClientType" value="${requestScope.authResult.prefs.zimbraPrefClientType[0]}" />
+                        <c:set var="advancedSupported" value="${!isUpgradedMailbox || isClassicWebClientSupported || !modernSupported}" />
 
                         <c:if test="${param.screenSize eq 'small' && empty client}">
                             <c:choose>
@@ -261,9 +263,14 @@
                             </c:choose>
                         </c:if>
 
-                        <c:if test="${empty client or client eq 'preferred'}">
+                        <c:if test="${client eq 'modern' or client eq 'advanced'}">
                             <c:set var="client"
-                                value="${isUpgradedMailbox ? mobileSupported && modernSupported ? 'modern' : prefClientType eq 'advanced' ? 'advanced' : 'modern' : prefClientType}" />
+                                value="${isUpgradedMailbox ? (modernSupported && client eq 'modern' ? 'modern' : (advancedSupported ? 'advanced' : 'modern')) : (client eq 'advanced' ? 'advanced': prefClientType)}" />
+                        </c:if>
+
+                        <c:if test="${client ne 'advanced' && client ne 'modern' && client ne 'notfound'}">
+                            <c:set var="client"
+                                value="${isUpgradedMailbox ? modernSupported && advancedSupported ? prefClientType : modernSupported ? 'modern' : 'classic' : prefClientType}" />
                         </c:if>
                         <c:choose>
                             <c:when test="${client eq 'advanced'}">
@@ -288,7 +295,7 @@
                                     </c:otherwise>
                                 </c:choose>
                             </c:when>
-                            <c:when test="${client eq 'modern' and modernSupported and isUpgradedMailbox}">
+                            <c:when test="${client eq 'modern'}">
                                     <jsp:forward page="/public/modern.jsp"/>
                             </c:when>
                             <c:when test="${client eq 'notfound'}">
@@ -856,7 +863,9 @@ if (application.getInitParameter("offlineMode") != null) {
                                     <div style="position: relative;">
                                         <select id="client" name="client" onchange="clientChange(this.options[this.selectedIndex].value)">
                                             <option value="preferred" <c:if test="${client eq 'preferred'}">selected</c:if> > <fmt:message key="clientPreferred"/></option>
-                                            <option value="advanced" <c:if test="${client eq 'advanced'}">selected</c:if>> <fmt:message key="clientAdvanced"/></option>
+                                            <c:if test="${isClassicWebClientSupported}">
+                                                <option value="advanced" <c:if test="${client eq 'advanced'}">selected</c:if>> <fmt:message key="clientAdvanced"/></option>
+                                            </c:if>
                                             <c:if test="${modernSupported}">
                                                 <option value="modern" <c:if test="${client eq 'modern'}">selected</c:if>> <fmt:message key="clientModern"/></option>
                                             </c:if>


### PR DESCRIPTION
- 'Classic' and 'Modern' options are displayed in the client dropdown menu of the login page, depending on the values of `zimbraClassicWebClientDisabled` and `zimbraModernWebClientDisabled` respectively.

- After successful login: 
1.  Redirecting user to the Classic or Modern client based on `zimbraClassicWebClientDisabled` and `zimbraModernWebClientDisabled` value. 
2. Preventing user to access Classic UI if `zimbraClassicWebClientDisabled` is TRUE by selecting 'Classic' client option on the login screen and accessing the classic UI client via a URL like `?client=advanced`.
3. The user will be redirected to the Classic UI if they have selected the '**Classic**' option on the login page or if they are accessing the Classic UI client via a URL such as `?client=advanced` when `zimbraClassicWebClientDisabled` is **TRUE** and user is in a non-upgraded mailbox.
4. The user will be redirected to the Preferred client if they have selected other than 'Classic' option on the login page or if the are accessing the client via a URL other than `?client=advanced` when user is in a non-upgraded mailbox.
5. Users with upgraded mailboxes will be redirected to the Classic UI client if both `zimbraClassicWebClientDisabled` and `zimbraModernWebClientDisabled` are **TRUE**.
6. Users with non-upgraded mailboxes will be redirected to the Preferred client if both `zimbraClassicWebClientDisabled` and `zimbraModernWebClientDisabled` are **TRUE**.