### PR TITLE
ZCS-14872: changed to pass params to get a message in Conv view

### DIFF
--- a/WebRoot/js/zimbraMail/mail/controller/ZmConvController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmConvController.js
@@ -387,13 +387,13 @@ function() {
  * @return	{ZmMailMsg}		the selected message
  */
 ZmConvController.prototype.getMsg =
-function(params) {
-	return ZmConvListController.prototype.getMsg.call(this, params); //we need to get the first hot message from the conv.
+function(params, callback) {
+	return ZmConvListController.prototype.getMsg.call(this, params, callback); //we need to get the first hot message from the conv.
 };
 
 ZmConvController.prototype._getLoadedMsg =
 function(params, callback) {
-	callback.run(this.getMsg());
+	this.getMsg(params, callback);
 };
 
 // overloaded...

--- a/WebRoot/js/zimbraMail/mail/controller/ZmConvListController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmConvListController.js
@@ -651,7 +651,7 @@ function(items) {
  * be made to the server if the conv has not been loaded.
  */
 ZmConvListController.prototype.getMsg =
-function(params) {
+function(params, callback) {
 	
 	// First see if action is being performed on a msg in the conv view in the reading pane
 	var lv = this._listView[this._currentViewId];
@@ -664,7 +664,7 @@ function(params) {
 	var item = (sel && sel.length) ? sel[0] : null;
 	if (item) {
 		if (item.type == ZmItem.CONV) {
-			return item.getFirstHotMsg(params);
+			return item.getFirstHotMsg(params, callback);
 		} else if (item.type == ZmItem.MSG) {
 			return ZmDoublePaneController.prototype.getMsg.apply(this, arguments);
 		}


### PR DESCRIPTION
**Issue:**
An error message is shown in the following case:
1. set Conversation view
2. receive an email with attachment
3. show the message and click Reply
4. edit message body, click "Add attachments from original message" and click "Save Draft"
5. close the tab to go back to conversation list
6. check that the conversation has the received message and the draft
7. double-click the conversation. It is shown in another tab.
8. click Reply
9. edit message body and click Save Draft
10. click "Add attachments from original message" and click "Save Draft"
11. SaveDraftRequest fails and then an error message is shown

**Analysis:**
In step 9, the reply message is created based on the draft. 
On the other hand, not double-click but just click the conversation in step 7 (i.e. stay in Mail tab) and click Reply, and then the reply message is created based on the received message.
Reply, Reply-All and Forward message should be created based on a message in a conversation **except** message(s) in Drafts, Junk or Trash folders.
```
ZmMailApp.getReplyFoldersToOmit = function(search) {
	var omit = ZmMailApp.getFoldersToOmit(search);
	omit[ZmFolder.ID_DRAFTS] = true;
	return omit;
};
```

A conversation shown in another tab is processed by ZmConvController.
`ZmConvController._getLoadedMsg` is called with `params.foldersToOmit`, but the `params` is not passed to `ZmConvController.getMsg`.
```
ZmMailListController.prototype._doAction =
function(params) {
		this._getLoadedMsg(params, respCallback);

ZmConvController.prototype._getLoadedMsg =
function(params, callback) {
	callback.run(this.getMsg());

ZmConvController.prototype.getMsg =
function(params) {
	return ZmConvListController.prototype.getMsg.call(this, params); //we need to get the first hot message from the conv.
```
Then the reply message is created based on the draft message.
The 1st SaveDraft at step 9 overwrites the existing draft message. At this point, attachments in the original draft is removed. Then the 2nd SaveDraft at step 10 fails because the attachment no longer exists.

Anyway, again, a reply message should not be created based on a draft.

In addition, the timing of callback execution needs to be changed.
If `ZmConv.getFirstHotMsg` is called without `callback` param, GetMsgRequest is not called. The soap request needs to be called to load an entire target message (i.e. message body and attachments).
```
ZmConv.prototype.getFirstHotMsg =
function(params, callback) {
	//...
	if (callback) {
		if (msg && msg._loaded && !params.forceLoad) {
			callback.run(msg);
		}
		else {
			var respCallback = this._handleResponseGetFirstHotMsg.bind(this, params, callback);
			params.fetch = ZmSetting.CONV_FETCH_FIRST;
			this.load(params, respCallback);   // HERE
		}
	}
```


**Fix:**
* Call ZmConvController.getMsg with `params` so that `foldersToOmit` can be considered.
* Change the timing of callback execution from `callback.run(this.getMsg(params))` to `this.getMsg(params, callback)`.
   * Before the fix, `this.getMsg` is executed first, and then `callback` is executed. In this case, GetMsgRequest is not called.
   * After the fix, `callback` is executed within the process. GetMsgRequest is executed and then a target reply/forward message can be fetched.