### PR TITLE
ZCS-14601: fixed styles in 2FA code verification page

### DIFF
--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -6033,7 +6033,11 @@ h2.ZmTwoFactorCustomTitleLoginPage {
 .ZmTwoFactorSetupContainer.ZmTwoFactorSetupCodeContainer {
 	height: 100%;
 	margin: 0 20px;
+	display: flex;
+	align-items: center;
 	align-content: center;
+	justify-content: center;
+	flex-direction: row;
 }
 
 .ZmTwoFactorSetupContainer.ZmTwoFactorSetupCodeContainer label {
@@ -6043,6 +6047,10 @@ h2.ZmTwoFactorCustomTitleLoginPage {
 
 .ZmTwoFactorSetupContainer.ZmTwoFactorSetupCodeContainer INPUT[type="text"] {
 	margin: 3px 0;
+}
+
+.ZmTwoFactorSetupCodeSubContainer {
+	width: 100%;
 }
 
 .ZmTwoFactorCustomSetupContainerLoginPage {

--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -6020,6 +6020,22 @@ h2.ZmTwoFactorCustomTitleLoginPage {
 	text-align:center;
 }
 
+.ZmTwoFactorSetupCode {
+	display: flex;
+	height: 100%;
+	flex-direction: column;
+}
+
+.ZmTwoFactorSetupCodeDescriptionGuide {
+	margin-bottom: 0;
+}
+
+.ZmTwoFactorSetupContainer.ZmTwoFactorSetupCodeContainer {
+	height: 100%;
+	margin: 0 20px;
+	align-content: center;
+}
+
 .ZmTwoFactorSetupContainer.ZmTwoFactorSetupCodeContainer label {
 	display: inline-block;
 	margin: 0 10px;

--- a/WebRoot/css/zm.css
+++ b/WebRoot/css/zm.css
@@ -6020,6 +6020,15 @@ h2.ZmTwoFactorCustomTitleLoginPage {
 	text-align:center;
 }
 
+.ZmTwoFactorSetupContainer.ZmTwoFactorSetupCodeContainer label {
+	display: inline-block;
+	margin: 0 10px;
+}
+
+.ZmTwoFactorSetupContainer.ZmTwoFactorSetupCodeContainer INPUT[type="text"] {
+	margin: 3px 0;
+}
+
 .ZmTwoFactorCustomSetupContainerLoginPage {
 	text-align: center;
 }

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmTwoFactorSetupDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmTwoFactorSetupDialog.js
@@ -377,15 +377,20 @@ function() {
 		var spanElem = Dwt.getElement(this._htmlElId + "_resend_code_status");
 		spanElem.style.display = "none";
 		var pElem = Dwt.getElement(this._htmlElId + "_code_description_guide");
+		var divCodeContainer = Dwt.getElement(this._htmlElId + "_code_input_container");
 		if (this.tfaMethod === ZmTwoFactorAuth.APP) {
 			codeTitleElem.textContent = ZmMsg.twoStepAuthCode;
 			pElem.textContent = ZmMsg.twoStepAuthCodeDescription;
 			this._resendCodeLink.style.display = "none";
+			pElem.style.marginBottom = "";
+			divCodeContainer.style.marginTop = "";
 		} else if (this.tfaMethod === ZmTwoFactorAuth.EMAIL) {
 			codeTitleElem.textContent = ZmMsg.twoStepAuthCodeEmail;
 			Dwt.setInnerHtml(pElem, AjxMessageFormat.format(ZmMsg.twoStepAuthCodeDescriptionEmail, AjxStringUtil.htmlEncode(this._emailAddressInput.value)));
 			this._resendCodeLink.style.display = "";
 			this._resendCodeLink.textContent = ZmMsg.twoStepAuthResendCode;
+			pElem.style.marginBottom = "5px";
+			divCodeContainer.style.marginTop = "0";
 		}
 		this.setButtonEnabled(ZmTwoFactorSetupDialog.NEXT_BUTTON, this._codeInput.value !== "");
 		this.setButtonEnabled(ZmTwoFactorSetupDialog.PREVIOUS_BUTTON, true);

--- a/WebRoot/js/zimbraMail/share/view/dialog/ZmTwoFactorSetupDialog.js
+++ b/WebRoot/js/zimbraMail/share/view/dialog/ZmTwoFactorSetupDialog.js
@@ -377,20 +377,15 @@ function() {
 		var spanElem = Dwt.getElement(this._htmlElId + "_resend_code_status");
 		spanElem.style.display = "none";
 		var pElem = Dwt.getElement(this._htmlElId + "_code_description_guide");
-		var divCodeContainer = Dwt.getElement(this._htmlElId + "_code_input_container");
 		if (this.tfaMethod === ZmTwoFactorAuth.APP) {
 			codeTitleElem.textContent = ZmMsg.twoStepAuthCode;
 			pElem.textContent = ZmMsg.twoStepAuthCodeDescription;
 			this._resendCodeLink.style.display = "none";
-			pElem.style.marginBottom = "";
-			divCodeContainer.style.marginTop = "";
 		} else if (this.tfaMethod === ZmTwoFactorAuth.EMAIL) {
 			codeTitleElem.textContent = ZmMsg.twoStepAuthCodeEmail;
 			Dwt.setInnerHtml(pElem, AjxMessageFormat.format(ZmMsg.twoStepAuthCodeDescriptionEmail, AjxStringUtil.htmlEncode(this._emailAddressInput.value)));
 			this._resendCodeLink.style.display = "";
 			this._resendCodeLink.textContent = ZmMsg.twoStepAuthResendCode;
-			pElem.style.marginBottom = "5px";
-			divCodeContainer.style.marginTop = "0";
 		}
 		this.setButtonEnabled(ZmTwoFactorSetupDialog.NEXT_BUTTON, this._codeInput.value !== "");
 		this.setButtonEnabled(ZmTwoFactorSetupDialog.PREVIOUS_BUTTON, true);

--- a/WebRoot/templates/share/Dialogs.template
+++ b/WebRoot/templates/share/Dialogs.template
@@ -712,12 +712,12 @@
 				<p id="${id}_email_note_text"></p>
 			</div>
 		</div>
-		<div id='${id}_code'>
+		<div id='${id}_code' class="ZmTwoFactorSetupCode">
 			<div id='${id}_code_description'>
 				<h4 id='${id}_code_title'><$=ZmMsg.twoStepAuthCode$></h4>
-				<p id='${id}_code_description_guide'><$=ZmMsg.twoStepAuthCodeDescription$></p>
+				<p id='${id}_code_description_guide' class="ZmTwoFactorSetupCodeDescriptionGuide"><$=ZmMsg.twoStepAuthCodeDescription$></p>
 			</div>
-			<div id='${id}_code_input_container' class="ZmTwoFactorSetupContainer ZmTwoFactorSetupCodeContainer">
+			<div class="ZmTwoFactorSetupContainer ZmTwoFactorSetupCodeContainer">
 				<div id='${id}_code_error' style="display:none;margin-left:115px;" class="ZmTwoFactorSetupError"><$=ZmMsg.twoStepAuthCodeError$></div>
 				<label for="${id}_code_input"><$=ZmMsg.code$> : </label>
 				<input type="text" id="${id}_code_input" autocomplete="off"/>

--- a/WebRoot/templates/share/Dialogs.template
+++ b/WebRoot/templates/share/Dialogs.template
@@ -712,18 +712,21 @@
 				<p id="${id}_email_note_text"></p>
 			</div>
 		</div>
-		<div id='${id}_code' class="ZmTwoFactorSetupCode">
-			<div id='${id}_code_description'>
-				<h4 id='${id}_code_title'><$=ZmMsg.twoStepAuthCode$></h4>
-				<p id='${id}_code_description_guide' class="ZmTwoFactorSetupCodeDescriptionGuide"><$=ZmMsg.twoStepAuthCodeDescription$></p>
-			</div>
-			<div class="ZmTwoFactorSetupContainer ZmTwoFactorSetupCodeContainer">
-				<div id='${id}_code_error' style="display:none;margin-left:115px;" class="ZmTwoFactorSetupError"><$=ZmMsg.twoStepAuthCodeError$></div>
-				<label for="${id}_code_input"><$=ZmMsg.code$> : </label>
-				<input type="text" id="${id}_code_input" autocomplete="off"/>
-				<div id='${id}_resend_code' style="text-align:right">
-					<a id='${id}_resend_code_link' href="#" style="display:none"><$=ZmMsg.twoStepAuthResendCode$></a>
-					<span id='${id}_resend_code_status' href="#" style="display:none"></span>
+		<div id='${id}_code' style="height:100%">
+			<h4 id='${id}_code_title_spacer' style="margin-bottom:0"></h4>
+			<div class="ZmTwoFactorSetupCode">
+				<div id='${id}_code_description'>
+					<h4 id='${id}_code_title' style="margin-top:0"><$=ZmMsg.twoStepAuthCode$></h4>
+					<p id='${id}_code_description_guide' class="ZmTwoFactorSetupCodeDescriptionGuide"><$=ZmMsg.twoStepAuthCodeDescription$></p>
+				</div>
+				<div class="ZmTwoFactorSetupContainer ZmTwoFactorSetupCodeContainer">
+					<div id='${id}_code_error' style="display:none;margin-left:115px;" class="ZmTwoFactorSetupError"><$=ZmMsg.twoStepAuthCodeError$></div>
+					<label for="${id}_code_input"><$=ZmMsg.code$> : </label>
+					<input type="text" id="${id}_code_input" autocomplete="off"/>
+					<div id='${id}_resend_code' style="text-align:right">
+						<a id='${id}_resend_code_link' href="#" style="display:none"><$=ZmMsg.twoStepAuthResendCode$></a>
+						<span id='${id}_resend_code_status' href="#" style="display:none"></span>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/WebRoot/templates/share/Dialogs.template
+++ b/WebRoot/templates/share/Dialogs.template
@@ -717,7 +717,7 @@
 				<h4 id='${id}_code_title'><$=ZmMsg.twoStepAuthCode$></h4>
 				<p id='${id}_code_description_guide'><$=ZmMsg.twoStepAuthCodeDescription$></p>
 			</div>
-			<div class="ZmTwoFactorSetupContainer">
+			<div id='${id}_code_input_container' class="ZmTwoFactorSetupContainer ZmTwoFactorSetupCodeContainer">
 				<div id='${id}_code_error' style="display:none;margin-left:115px;" class="ZmTwoFactorSetupError"><$=ZmMsg.twoStepAuthCodeError$></div>
 				<label for="${id}_code_input"><$=ZmMsg.code$> : </label>
 				<input type="text" id="${id}_code_input" autocomplete="off"/>

--- a/WebRoot/templates/share/Dialogs.template
+++ b/WebRoot/templates/share/Dialogs.template
@@ -720,12 +720,14 @@
 					<p id='${id}_code_description_guide' class="ZmTwoFactorSetupCodeDescriptionGuide"><$=ZmMsg.twoStepAuthCodeDescription$></p>
 				</div>
 				<div class="ZmTwoFactorSetupContainer ZmTwoFactorSetupCodeContainer">
-					<div id='${id}_code_error' style="display:none;margin-left:115px;" class="ZmTwoFactorSetupError"><$=ZmMsg.twoStepAuthCodeError$></div>
-					<label for="${id}_code_input"><$=ZmMsg.code$> : </label>
-					<input type="text" id="${id}_code_input" autocomplete="off"/>
-					<div id='${id}_resend_code' style="text-align:right">
-						<a id='${id}_resend_code_link' href="#" style="display:none"><$=ZmMsg.twoStepAuthResendCode$></a>
-						<span id='${id}_resend_code_status' href="#" style="display:none"></span>
+					<div class="ZmTwoFactorSetupCodeSubContainer">
+						<div id='${id}_code_error' style="display:none" class="ZmTwoFactorSetupError"><$=ZmMsg.twoStepAuthCodeError$></div>
+						<label for="${id}_code_input"><$=ZmMsg.code$> : </label>
+						<input type="text" id="${id}_code_input" autocomplete="off"/>
+						<div id='${id}_resend_code' style="text-align:right" class="ZmTwoFactorResendCode">
+							<a id='${id}_resend_code_link' href="#" style="display:none"><$=ZmMsg.twoStepAuthResendCode$></a>
+							<span id='${id}_resend_code_status' href="#" style="display:none"></span>
+						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
**Issue:**
Contents of the following page overlaps in a specific language and font:
2FA email setup > Enter a verification code

**Fix:**
Update the template and styles.