### PR TITLE
ZBUG-2856, ZBUG-4052: fixed tab and window control at compose

### DIFF
--- a/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
+++ b/WebRoot/js/zimbraMail/core/ZmAppCtxt.js
@@ -1571,10 +1571,11 @@ function() {
  * @param	{Boolean}	fullView		<code>true</code> to include the full version
  * @param	{int}		width			the width
  * @param	{int}		height			the height
- * @param   {String}    name            window name
+ * @param	{String}	name			window name
+ * @param	{Boolean}	isCompoe		compose window or not
  */
 ZmAppCtxt.prototype.getNewWindow = 
-function(fullVersion, width, height, name) {
+function(fullVersion, width, height, name, isCompose) {
 	// build url
 	var url = [];
 	var i = 0;
@@ -1610,7 +1611,7 @@ function(fullVersion, width, height, name) {
 	this.handlePopupBlocker(newWin);
 	if(newWin) {
 		// add this new window to global list so parent can keep track of child windows!
-		return this.getAppController().addChildWindow(newWin, this.__childWindowId);
+		return this.getAppController().addChildWindow(newWin, this.__childWindowId, isCompose);
 	}
 };
 

--- a/WebRoot/js/zimbraMail/core/ZmAppViewMgr.js
+++ b/WebRoot/js/zimbraMail/core/ZmAppViewMgr.js
@@ -836,6 +836,16 @@ function(force, viewId, skipHistory) {
 		return false;
 	}
 
+	if (this._isNewWindow) {
+		try {
+			if (window.hasOwnProperty("previousName")) {
+				window.name = window.previousName;
+			}
+		} catch (e) {
+			// do nothing
+		}
+	}
+
 	DBG.println(AjxDebug.DBG2, "app view mgr: current view is now " + this._currentViewId);
 	if (!this._showView(this._currentViewId, this._popCallback, null, force, true)) {
 		DBG.println(AjxDebug.DBG1, "ERROR: pop with no view to show");

--- a/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
+++ b/WebRoot/js/zimbraMail/core/ZmZimbraMail.js
@@ -2951,17 +2951,42 @@ function(bStartTimer) {
  * @private
  */
 ZmZimbraMail.prototype.addChildWindow =
-function(childWin, childId) {
+function(childWin, childId, isCompose) {
 	if (this._childWinList == null) {
 		this._childWinList = new AjxVector();
 	}
 
-	// NOTE: we now save childWin w/in Object so other params can be added to it.
-	// Otherwise, Safari breaks (see http://bugs.webkit.org/show_bug.cgi?id=7162)
-	var newWinObj = {win:childWin,childId:childId};
-	this._childWinList.add(newWinObj);
+	var newWinObj;
+	if (isCompose) {
+		newWinObj = this.getChildWindowForCompose(childWin, childId);
+	}
 
+	if (!newWinObj) {
+		// NOTE: we now save childWin w/in Object so other params can be added to it.
+		// Otherwise, Safari breaks (see http://bugs.webkit.org/show_bug.cgi?id=7162)
+		newWinObj = {win:childWin,childId:childId};
+		this._childWinList.add(newWinObj);
+	}
 	return newWinObj;
+};
+
+/**
+ * Gets a child window for Compose
+ * 
+ * @private
+ */
+ZmZimbraMail.prototype.getChildWindowForCompose =
+function(childWin, childId) {
+	var list = this._childWinList;
+	if (list && childWin) {
+		for (var i = 0; i < list.size(); i++) {
+			var winObj = list.get(i);
+			if (childWin === winObj.win) {
+				return winObj;
+			}
+		}
+	}
+	return null;
 };
 
 /**
@@ -3000,6 +3025,24 @@ function(childWin) {
 				// and leave the other parameters in winObj intact
 				winObj.win = null;
 				break;
+			}
+		}
+	}
+};
+
+/**
+ * Removes non-existing windows.
+ * 
+ * @private
+ */
+ZmZimbraMail.prototype.removeNonExistingChildWindow =
+function() {
+	var list = this._childWinList;
+	if (list) {
+		for (var i = list.size() - 1; i > -1; i--) {
+			var winObj = list.get(i);
+			if (!winObj.win || winObj.win.closed) {
+				list.removeAt(i);
 			}
 		}
 	}

--- a/WebRoot/js/zimbraMail/mail/controller/ZmConvListController.js
+++ b/WebRoot/js/zimbraMail/mail/controller/ZmConvListController.js
@@ -657,7 +657,11 @@ function(params, callback) {
 	var lv = this._listView[this._currentViewId];
 	var msg = lv && lv._selectedMsg;
 	if (msg && DwtMenu.menuShowing()) {
-		return msg;
+		if (callback) {
+			callback.run(msg);
+		} else {
+			return msg;
+		}
 	}
 	
 	var sel = lv.getSelection();


### PR DESCRIPTION
**Issue:**
* The same draft message could be shown in different tabs or separate windows. It caused an issue around SaveDraftRequest when the draft was sent on one of the tabs/windows but another was still opened.
* When Reply button was clicked, the replying message was shown in a tab. Then Reply, or Edit as New button was clicked on the same message, the existing tab was overwritten.

**Fix:**
Adding the following processes:
* Add a saved draft item to a compose controller so that the id of the draft message shown in a compose tab can be identified.
* Set a window name based on a message id when a window is shown or a draft is saved on the window.
* Check if the draft has already be shown in a tab or window when Edit action is executed on a draft.
* Call SaveDraftRequest before detaching a compose tab so that attachments can be shown correctly on the new window.

**Behavior after the fix:**
If a draft is shown in a tab or window and Edit action is executed on the draft, the focus moves to the tab or window.
If a draft is not shown in a tab or window, it is shown in a new tab or window.
When Reply, Reply All, Forward or Edit as New is executed, a draft is always shown in a new tab or window.

**Related PR:**
* https://github.com/Zimbra/zm-ajax/pull/134