### PR TITLE
ZBUG-3629: fixed handling of image in signature

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
@@ -1205,7 +1205,13 @@ function(msg, idoc, account) {
 	var images = idoc.getElementsByTagName("img");
 	var num = 0;
 	for (var i = 0; i < images.length; i++) {
-		var dfsrc = images[i].getAttribute("dfsrc") || images[i].getAttribute("data-mce-src") || images[i].src;
+		var dfsrc;
+		// cid is primary as the image is embeded in the message
+		if (images[i].src && images[i].src.substring(0,4) === "cid:") {
+			dfsrc = images[i].src;
+		} else {
+			dfsrc = images[i].getAttribute("dfsrc") || images[i].getAttribute("data-mce-src") || images[i].src;
+		}
 		if (dfsrc) {
 			if (dfsrc.substring(0,4) === "cid:") {
 				num++;
@@ -1674,6 +1680,8 @@ function(signatureId, mode) {
 	mode = mode || this._composeMode;
     var htmlMode = (mode === Dwt.HTML);
     var sig = signature ? signature.getValue(htmlMode ? ZmMimeTable.TEXT_HTML : ZmMimeTable.TEXT_PLAIN) : "";
+    var regex = /data-mce-src=".*?"/gi
+    sig = sig.replaceAll(regex, "");
     sig = AjxStringUtil.trim(sig + extraSignature) + (htmlMode ? "" : this._crlf);
 
 	return sig;


### PR DESCRIPTION
**Issue:**
An inline image is not included in a reply/forward message when the sender of the original message is added to trusted address.

**Root cause:**
Source of an image was fetched in the following priority:
dfsrc => data-mce-src => src

Before the fix, `data-mce-src` is set for an image in a signature.
`<img pnsrc="cid:edf162835aead51e0a185735d5add806ee0b8710@zimbra" data-mce-src="https://HOST/home/ACCOUNT/Briefcase/imageg.png" src="https://HOST/service/home/~/?auth=co&amp;loc=en_US&amp;id=400&amp;part=2.2">`

At reply/forward, the url in `data-mce-src` is set in `src` of `img` tag when a trusted address is configured.
```
ZmComposeView.js, line 1239:
else if (showImages) {
	var src = dfsrc;//x + "&t=" + (new Date()).getTime();
	num++;
	images[i].src = src;
	images[i].setAttribute("dfsrc", dfsrc);
}
```
Then the image in the forwarded message points the briefcase path. If it is not shared, the image cannot be fetched.
The full access path to a briefcase file is unnecessary for a recipient. The image file is embedded in a message source and referred as cid. The image should always be fetched from the embedded data.

**Fix:**
* When a signature is set in Compose page, `data-mce-src` is removed from the image.
* When a signature image is reused at reply/forward, `cid` in `src` is used if it exists.
