### PR TITLE
PREAPPS-7930: Shared folder synchronization to mobile options are always enabled

### DIFF
--- a/WebRoot/js/zimbraMail/prefs/view/ZmSharingPage.js
+++ b/WebRoot/js/zimbraMail/prefs/view/ZmSharingPage.js
@@ -194,7 +194,7 @@ function() {
 	var folders = folderTree && folderTree.asList({remoteOnly:true});
 	this._mountedShareListView.set(AjxVector.fromArray([]));
 	var mountedShareComment = document.getElementById(this._pageId + "_mountedSharesComment");
-	var shareFolderMobileSyncEnabled = appCtxt.get(ZmSetting.SHARED_FOLDER_MOBILE_SYNC_ENABLED);
+	var shareFolderMobileSyncEnabled = appCtxt.get(ZmSetting.MOBILE_SYNC_ENABLED) && appCtxt.get(ZmSetting.SHARED_FOLDER_MOBILE_SYNC_ENABLED);
 
 	if (mountedShareComment) {
 		mountedShareComment.style.display = shareFolderMobileSyncEnabled ? 'block' : 'none';
@@ -824,7 +824,7 @@ function() {
 			headerList.push(new DwtListHeaderItem({field:ZmSharingView.F_FOLDER, text:ZmMsg.sharingFolder, width:ZmMsg.COLUMN_WIDTH_FOLDER_SH}));
 		}
 		headerList.push(new DwtListHeaderItem({field:ZmSharingView.F_WITH, text:ZmMsg.sharingWith, width:ZmMsg.COLUMN_WIDTH_WITH_SH}));
-		if (this.status === ZmSharingView.MOUNTED && appCtxt.get(ZmSetting.SHARED_FOLDER_MOBILE_SYNC_ENABLED)) {
+		if (this.status === ZmSharingView.MOUNTED && appCtxt.get(ZmSetting.MOBILE_SYNC_ENABLED) && appCtxt.get(ZmSetting.SHARED_FOLDER_MOBILE_SYNC_ENABLED)) {
 			headerList.push(new DwtListHeaderItem({field:ZmSharingView.F_SYNC, text:ZmMsg.syncToMobile, width:ZmMsg.COLUMN_WIDTH_SYNC_SH, align:"center" }));
 		}
 	} else {
@@ -908,6 +908,7 @@ function(params) {
 	if (
 		this.status === ZmSharingView.MOUNTED &&
 		params.ctrlKey &&
+		appCtxt.get(ZmSetting.MOBILE_SYNC_ENABLED) &&
 		appCtxt.get(ZmSetting.SHARED_FOLDER_MOBILE_SYNC_ENABLED)
 	) {
 		// handle selection of mobile sync checkbox using keyboard shortcut Ctrl + `.
@@ -954,7 +955,7 @@ function(ev) {
 					cell.innerHTML = this._getCellContents([], 0, share, ZmSharingView.F_ROLE, null, {returnText:true});
 				}
 
-				if (appCtxt.get(ZmSetting.SHARED_FOLDER_MOBILE_SYNC_ENABLED)) {
+				if (appCtxt.get(ZmSetting.MOBILE_SYNC_ENABLED) && appCtxt.get(ZmSetting.SHARED_FOLDER_MOBILE_SYNC_ENABLED)) {
 					var syncToMobileCell = document.getElementById(this._getCellId(share, ZmSharingView.F_SYNC));
 					if (syncToMobileCell) {
 						syncToMobileCell.innerHTML = this._getCellContents([], 0, share, ZmSharingView.F_SYNC, null, {returnText:true});

--- a/WebRoot/js/zimbraMail/share/model/ZmSettings.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmSettings.js
@@ -991,7 +991,7 @@ function() {
 	this.registerSetting("RESET_PASSWORD_RECOVERY_CODE_EXPIRY",				{name:"zimbraResetPasswordRecoveryCodeExpiry", type:ZmSetting.T_COS, dataType:ZmSetting.D_STRING});
 	this.registerSetting("PASSWORD_RECOVERY_CODE_VALIDITY",				{name:"zimbraRecoveryAccountCodeValidity", type:ZmSetting.T_COS, dataType:ZmSetting.D_STRING});
 	this.registerSetting("PASSWORD_RECOVERY_SUSPENSION_TIME",				{name:"zimbraFeatureResetPasswordSuspensionTime", type:ZmSetting.T_COS, dataType:ZmSetting.D_STRING});
-	this.registerSetting("SHARED_FOLDER_MOBILE_SYNC_ENABLED",				{name:"zimbraFeatureSharedFolderMobileSyncEnabled", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN, defaultValue:true});
+	this.registerSetting("SHARED_FOLDER_MOBILE_SYNC_ENABLED",				{name:"zimbraFeatureSharedFolderMobileSyncEnabled", type:ZmSetting.T_COS, dataType:ZmSetting.D_BOOLEAN});
 
 	// user metadata (included with COS since the user can't change them)
 	this.registerSetting("LICENSE_STATUS",					{type:ZmSetting.T_COS, defaultValue:ZmSetting.LICENSE_GOOD});


### PR DESCRIPTION
- Considering the zimbraFeatureMobileSyncEnabled LDAP attribute for showing mobile sync option on share folder.