### PR TITLE
ZBUG-4484 Zimbra 10.0.9 "No Such Message" error still appearing post patch.

### DIFF
--- a/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
+++ b/WebRoot/js/zimbraMail/mail/view/ZmComposeView.js
@@ -1298,7 +1298,7 @@ function(idoc) {
 			var src = img.src && unescape(img.src);
 			var dfsrc = img.getAttribute("dfsrc") || img.getAttribute("data-mce-src");
 			if (dfsrc && dfsrc.indexOf("cid:") === 0) {
-				return; //dfsrc already set so nothing to do
+				continue; //dfsrc already set so nothing to do
 			} else if (img.src && img.src.indexOf("cid:") === 0) {
 				cid = img.src;
 			} else if ( dfsrc && dfsrc.substring(0,4) === "doc:"){


### PR DESCRIPTION
- When forwarding/replying mail, if the previous mail block has an inline image and the sender pastes another mail's inline image at the end of the previous mail block, the processing of the copied inline image from the other mail is ignored and it is considered external mail. As a result, the recipient is unable to forward and respond to emails from others.