### PR TITLE
ZBUG-4023:Upgraded jetty to 9.4.57.v20241219

### DIFF
--- a/WebRoot/WEB-INF/jetty-env.xml
+++ b/WebRoot/WEB-INF/jetty-env.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 <!--
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Web Client


### PR DESCRIPTION
Added Header as --->
`<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">`

To Encounter Error **"Attribute Configure is not defined"** which cause Mailbox,webapp services stopped working..

zimbra-jetty-distribution Upgraded to version 9.4.57.v20241219
Related PR ;-
[Zimbra/zm-build/pull/301]
[Zimbra/zm-zcs-lib/pull/116]
[Zimbra/zm-mailbox/pull/1707]
[Zimbra/zm-jetty-conf/pull/27]
[Zimbra/zm-admin-console/pull/183]
