### PR TITLE
ZBUG-4772: Fix Verify button not highlighting on right-click paste of 2FA code

### DIFF
--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -635,7 +635,7 @@ if (application.getInitParameter("offlineMode") != null) {
                                             </div>
                                         </c:when>
                                     </c:choose>
-                                    <input tabindex="0" class="zLoginFieldInput" id="totpcode" class="zLoginField" name="totpcode" type="text" value="" size="40" maxlength="${domainInfo.webClientMaxInputBufferLength}" autocomplete="off" onkeyup="updateTFAVerifyButtonStatus(this)"></td>
+                                    <input tabindex="0" class="zLoginFieldInput" id="totpcode" class="zLoginField" name="totpcode" type="text" value="" size="40" maxlength="${domainInfo.webClientMaxInputBufferLength}" autocomplete="off" oninput="updateTFAVerifyButtonStatus(this)"></td>
                                 </div>
                                 <c:if test="${authResult.trustedDevicesEnabled eq true || trustedDevicesEnabled}">
                                     <div class="trustedDeviceDiv">


### PR DESCRIPTION
**Issue**  -
The 2FA "Verify" button does not get activated when a user pastes the authentication code using the right-click context menu in browsers like Chrome, Firefox, or Edge.

**Root Cause**  -
The `onkeyup` event handler was used to trigger the button state update, but this event only fires when a keyboard key is released. Right-click → Paste does not trigger any keyboard event, so `onkeyup` is bypassed and the button state remains unchanged.

**Fix**  -
- Replaced `onkeyup` with the `oninput` event handler on the 2FA input field (`totpcode`).
- The `oninput` event is triggered on any user input, including:
  - Typing
  - Keyboard pasting (`Ctrl+V` / `Cmd+V`)
  - Right-click paste
