### PR TITLE
ZCS-17622:Apache mina version update

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -212,7 +212,7 @@
         <ivy:install organisation="com.sun.xml.ws" module="policy" revision="2.3.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="org.jvnet.staxex" module="stax-ex" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="com.sun.xml.stream.buffer" module="streambuffer" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-        <ivy:install organisation="org.apache.mina" module="mina-core" revision="2.0.4" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+        <ivy:install organisation="org.apache.mina" module="mina-core" revision="2.0.27" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 
         <war warfile="${build.war.file}" webxml='${build.dir}/web.xml'
              compress='${war.compress}' duplicate="preserve">
@@ -281,7 +281,7 @@
         <ivy:install organisation="com.sun.xml.ws" module="policy" revision="2.3.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="org.jvnet.staxex" module="stax-ex" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="com.sun.xml.stream.buffer" module="streambuffer" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-        <ivy:install organisation="org.apache.mina" module="mina-core" revision="2.0.4" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+        <ivy:install organisation="org.apache.mina" module="mina-core" revision="2.0.27" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 
         <copy todir="${webapp.dir}/WEB-INF/lib">
             <fileset dir="${build.tmp.dir}">

--- a/build.xml
+++ b/build.xml
@@ -212,7 +212,7 @@
         <ivy:install organisation="com.sun.xml.ws" module="policy" revision="2.3.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="org.jvnet.staxex" module="stax-ex" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="com.sun.xml.stream.buffer" module="streambuffer" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-        <ivy:install organisation="org.apache.mina" module="mina-core" revision="2.0.27" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+        <ivy:install organisation="org.apache.mina" module="mina-core" revision="2.1.10" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 
         <war warfile="${build.war.file}" webxml='${build.dir}/web.xml'
              compress='${war.compress}' duplicate="preserve">
@@ -281,7 +281,7 @@
         <ivy:install organisation="com.sun.xml.ws" module="policy" revision="2.3.1" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="org.jvnet.staxex" module="stax-ex" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="com.sun.xml.stream.buffer" module="streambuffer" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-        <ivy:install organisation="org.apache.mina" module="mina-core" revision="2.0.27" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+        <ivy:install organisation="org.apache.mina" module="mina-core" revision="2.1.10" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
 
         <copy todir="${webapp.dir}/WEB-INF/lib">
             <fileset dir="${build.tmp.dir}">

--- a/ivy.xml
+++ b/ivy.xml
@@ -18,7 +18,7 @@
         <dependency org="gifencoder" name="gifencoder" rev="0.9"/>
         <dependency org="com.yahoo.platform.yui" name="yuicompressor" rev="2.4.8"/>
         <dependency org="rhino" name="js" rev="1.6R7"/>
-        <dependency org="org.apache.mina" name="mina-core" rev="2.0.27"/>
+        <dependency org="org.apache.mina" name="mina-core" rev="2.1.10"/>
         <dependency org="zimbra" name="zm-soap" rev="latest.integration"/>
         <dependency org="zimbra" name="zm-ajax" rev="latest.integration"/>
         <dependency org="zimbra" name="zm-common" rev="latest.integration"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -18,7 +18,7 @@
         <dependency org="gifencoder" name="gifencoder" rev="0.9"/>
         <dependency org="com.yahoo.platform.yui" name="yuicompressor" rev="2.4.8"/>
         <dependency org="rhino" name="js" rev="1.6R7"/>
-        <dependency org="org.apache.mina" name="mina-core" rev="2.0.4"/>
+        <dependency org="org.apache.mina" name="mina-core" rev="2.0.27"/>
         <dependency org="zimbra" name="zm-soap" rev="latest.integration"/>
         <dependency org="zimbra" name="zm-ajax" rev="latest.integration"/>
         <dependency org="zimbra" name="zm-common" rev="latest.integration"/>


### PR DESCRIPTION
As part of ZBUG-4636 fix & as a precautionary measures, although Zimbra is not directly impacted by any vulnerabilities, we will update Apache MINA to latest version to mitigate any future risks. 
