### PR TITLE
Revert "ZBUG-4023:Upgraded jetty to 9.4.57.v20241219 (#887)"

### DIFF
--- a/WebRoot/WEB-INF/jetty-env.xml
+++ b/WebRoot/WEB-INF/jetty-env.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0"?>
-<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
 <!--
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Web Client


### PR DESCRIPTION
Reverts https://github.com/Zimbra/zm-web-client/pull/887
Reverting Above changes for now because, **zimbra-jetty-distribution package** involves changes in another zimbra-repositories also (zm-build, zm-zcs-lib, zm-mailbox, zm-jetty-conf)
merging this changes will result into **failure/installation of dev-builds because new Jetty packages not present in package repository.**
will raise New-PR for this changes while upcoming patch release..