### PR TITLE
ZBUG-4874: Contact Group doesn't autofill in the "To:" field, when zimbraPrefComposeInNewWindow TRUE

### DIFF
--- a/WebRoot/js/zimbraMail/package/NewWindow_2.js
+++ b/WebRoot/js/zimbraMail/package/NewWindow_2.js
@@ -145,6 +145,7 @@ AjxPackage.require("zimbraMail.calendar.ZmCalendarApp");
 AjxPackage.require("zimbraMail.tasks.ZmTasksApp");
 AjxPackage.require("zimbraMail.abook.ZmContactsApp");
 AjxPackage.require("zimbraMail.share.ZmSearchApp");
+AjxPackage.require("zimbraMail.abook.view.ZmContactsHelper");
 AjxPackage.require("zimbraMail.abook.model.ZmContact");
 AjxPackage.require("zimbraMail.abook.model.ZmContactList");
 AjxPackage.require("zimbraMail.briefcase.ZmBriefcaseApp");

--- a/WebRoot/js/zimbraMail/share/model/ZmAutocomplete.js
+++ b/WebRoot/js/zimbraMail/share/model/ZmAutocomplete.js
@@ -549,8 +549,7 @@ ZmAutocompleteMatch = function(match, options, isContact, str) {
  */
 ZmAutocompleteMatch.prototype.setContactGroupMembers =
 		function(groupId, callback) {
-			var ac = window.appCtxt;
-			var contactGroup = ac.cacheGet(groupId);
+			var contactGroup = appCtxt.getById(groupId);
 			if (contactGroup) {
 				var groups = contactGroup.getGroupMembers();
 				var addresses = (groups && groups.good && groups.good.getArray()) || [];


### PR DESCRIPTION
Passed the `appCtxt.getById(groupId)` method to retrieve the cache data of the contact group, which resolved the issue of the contact group not autofilling in the new window