### PR TITLE
ZBUG-4620:Fix domain name retrieval issue from server side

### DIFF
--- a/WebRoot/public/login.jsp
+++ b/WebRoot/public/login.jsp
@@ -733,8 +733,9 @@ if (application.getInitParameter("offlineMode") != null) {
                                             String zimbraPasswordAllowedPunctuationChars = null;
 
                                             if (userName != null) {
+                                                String serverName = request.getServerName();
                                                 AccountSelector as = new AccountSelector(AccountBy.name, userName);
-                                                Account acct = Provisioning.getInstance().get(as);
+                                                Account acct = Provisioning.getInstance().get(as, serverName);
 
                                                 zimbraPasswordMinLength = acct.getPasswordMinLength();
                                                 zimbraPasswordMinUpperCaseChars = acct.getPasswordMinUpperCaseChars();


### PR DESCRIPTION
Issue:
Login was failing when users entered only their username without a domain while the "password must change" policy was enforced.

Fix Implemented:
Updated the UI to call a backend method, passing the server name.
On the server side, the domain is retrieved using the provided serverName.
The backend constructs the complete username.