### PR TITLE
fix(i18n): correct Norwegian mistranslation of "Default" in login page selector (ZBUG-5385)

### DIFF
--- a/WebRoot/messages/ZmMsg_no.properties
+++ b/WebRoot/messages/ZmMsg_no.properties
@@ -617,7 +617,7 @@ clientLoginNotice = <a target="_new" href="https://www.zimbra.com">Zimbra</a> ::
     <a target="_new" href="https://wiki.zimbra.com">Wiki</a> \u2013 \
     <a target="_new" href="https://www.zimbra.com/forums">Fora</a>
 clientMobile = Mobil
-clientPreferred = Misligholde
+clientPreferred = Standard
 clientStandard = Standard (HTML)
 clientTouch = Touch
 clientType = Klienttype:
@@ -631,7 +631,7 @@ clientWhatsThisMessage = <p><strong>Modern</strong><br> Den Modern Web-appen gir
 	samarbeids- og kalenderfunksjoner som er popul\u00E6re blant \
 	str\u00F8mbrukere p\u00E5 Desktop-nettlesere.\
 	</p>\
-	<p><strong>Misligholde</strong><br> Dette vil logge deg p\u00E5 i henhold til \
+	<p><strong>Standard</strong><br> Dette vil logge deg p\u00E5 i henhold til \
 	den lagrede preferansen. I nettappen \u0027Modern\u0027 angir \
 	du denne innstillingen i Innstillinger\u003e Generelt\u003e DRMra-versjon. \
 	I \u0027Classic\u0027 angir du det under Innstillinger\u003e Generelt\u003e Logg p\u00E5.</p>
@@ -644,7 +644,7 @@ clientWhatsThisMessageWithoutTablet = <p><strong>Modern</strong><br> Den Modern 
 	samarbeids- og kalenderfunksjoner som er popul\u00E6re blant \
 	str\u00F8mbrukere p\u00E5 Desktop-nettlesere.\
 	</p>\
-	<p><strong>Misligholde</strong><br> Dette vil logge deg p\u00E5 i henhold til \
+	<p><strong>Standard</strong><br> Dette vil logge deg p\u00E5 i henhold til \
 	den lagrede preferansen. I nettappen \u0027Modern\u0027 angir \
 	du denne innstillingen i Innstillinger\u003e Generelt\u003e DRMra-versjon. \
 	I \u0027Classic\u0027 angir du det under Innstillinger\u003e Generelt\u003e Logg p\u00E5.</p>


### PR DESCRIPTION
## What changed

Replaced the incorrect Norwegian word **Misligholde** with **Standard** in three locations in `WebRoot/messages/ZmMsg_no.properties`:

| Line | Key | Before | After |
|------|-----|--------|-------|
| L620 | `clientPreferred` | `Misligholde` | `Standard` |
| L634 | `clientWhatsThisMessage` (tooltip heading, tablet) | `<strong>Misligholde</strong>` | `<strong>Standard</strong>` |
| L647 | `clientWhatsThisMessageWithoutTablet` (tooltip heading, non-tablet) | `<strong>Misligholde</strong>` | `<strong>Standard</strong>` |

## Why

The word *misligholde* is the Norwegian legal/financial term meaning "to default on an obligation" (e.g., breach a contract). A machine-translation pipeline resolved the English UI word "Default" using a broad dictionary without context filtering, selecting the wrong sense.

The correct Norwegian software UI term is **Standard** (pre-set/baseline option), which is:
- Used consistently across KDE KMail, Mozilla Thunderbird (52 hits), and Microsoft Terminology (13 TM hits) for this concept
- Already used in 14 other keys within `ZmMsg_no.properties` (e.g., `defaultAccountName`, `defaultIdentityName`, `clientStandard`)

## Scope

Only `ZmMsg_no.properties` (Classic Ajax web client bundle) is affected. The Modern UI uses a separate JS bundle and does not reference these keys. No other Norwegian locale files (`ZbMsg_no`, `AjxMsg_no`, `ZhMsg_no`, `ZmSMS_no`) contain these strings.

## Reviewer notes

- L621 (`clientStandard = Standard (HTML)`) is adjacent to L620. After the fix, the two options correctly read "Standard" and "Standard (HTML)" — matching the English canonical "Default" and "Standard (HTML)".
- No collateral changes needed. All three occurrences of "Misligholde" in the file have been fixed.

Refs: ZBUG-5385