### PR TITLE
ZBUG-4269: Add missing splashScreenCopyright key for pt_BR locale

### DIFF
--- a/WebRoot/messages/ZhMsg_pt_BR.properties
+++ b/WebRoot/messages/ZhMsg_pt_BR.properties
@@ -1133,6 +1133,7 @@ spellcheckSuggestionsLabel = Sugest\u00f5es:
 
 splashScreenAppName = Cliente web
 splashScreenMobileAppName = Cliente web de celular
+splashScreenCopyright = Copyright \u00a9 2005-2026 Synacor, Inc. Todos os direitos reservados. "Zimbra" \u00e9 uma marca comercial registrada da Synacor, Inc.
 start = Inicial
 startLabel = Inicial:
 startDate = Data inicial

--- a/WebRoot/messages/ZmMsg_pt_BR.properties
+++ b/WebRoot/messages/ZmMsg_pt_BR.properties
@@ -3895,6 +3895,8 @@ splashScreenMobileAppName = Cliente web de celular
 splashScreenCompanyURL = https://www.zimbra.com
 splashScreenVersion = Vers\u00e3o
 splashScreenZimbraUrl = <a href='https://www.zimbra.com' target=_blank>https://www.zimbra.com</a>
+splashScreenCopyright = Copyright \u00a9 2005-2026 Synacor, Inc. Todos os direitos reservados. "Zimbra" \u00e9 uma marca comercial registrada da Synacor, Inc.
+splashScreenCopyrightZD = Copyright \u00a9 2008-2026 Synacor, Inc. Todos os direitos reservados. "Zimbra" \u00e9 uma marca comercial registrada da Synacor, Inc.
 
 recurDailyEveryDay = Diariamente
 recurDailyEveryWeekday = Todo dia \u00fatil


### PR DESCRIPTION
pt_BR was falling back to the European Portuguese (pt) locale which uses 'registada' instead of the Brazilian Portuguese 'registrada'. Added the key explicitly to ZmMsg_pt_BR.properties and ZhMsg_pt_BR.properties with proper \uXXXX escaping for non-ASCII characters.