### PR TITLE
ZBUG-4505: [Classic UI] Fix incorrect French translation for mailOnly Specific distribution list mail policy

### DIFF
--- a/WebRoot/messages/ZmMsg_fr.properties
+++ b/WebRoot/messages/ZmMsg_fr.properties
@@ -1969,7 +1969,7 @@ mailLabel = Mail\u00a0:
 mailAnyone = Tout le monde peut envoyer \u00e0 cette liste
 mailOnlyMembers = Seuls les membres peuvent envoyer \u00e0 cette liste
 mailOnlyInternal = Seuls les utilisateurs internes peuvent envoyer \u00e0 cette liste
-mailOnlySpecific = Seuls ces utilisateurs peuvent ajouter des valeurs dans cette liste
+mailOnlySpecific = Seuls ces utilisateurs peuvent envoyer \u00e0 cette liste\u00a0:
 makeLabel = {0}:
 manageSignatures = <a href='#Prefs.Signatures' onclick='skin.gotoPrefs("SIGNATURES");return false'>G\u00e9rer vos signatures ...</a>
 manageSignaturesForExternalAccount = G\u00e9rer vos signatures...


### PR DESCRIPTION
The radio button label for "Only these users can send to this list:" was incorrectly translated as "peuvent ajouter des valeurs dans cette liste" (can add values to this list) instead of "peuvent envoyer à cette liste" (can send to this list).